### PR TITLE
Return only real data instead of full buffer when outline read

### DIFF
--- a/go_client/outline/client_mobile.go
+++ b/go_client/outline/client_mobile.go
@@ -67,7 +67,7 @@ func (c *OutlineClient) Read() ([]byte, error) {
 		log.Printf("failed to read data: %v\n", err)
 		return nil, fmt.Errorf("failed to read data: %w", err)
 	}
-	return buf, nil
+	return buf[:n], nil
 }
 
 func (c *OutlineClient) Write(buf []byte) (int, error) {

--- a/go_client/outline/client_mobile.go
+++ b/go_client/outline/client_mobile.go
@@ -8,7 +8,7 @@ import (
 	"go_client/outline/internal"
 	"log"
 	"net"
-	//_ "go_client/logger"
+	// _ "go_client/logger"
 )
 
 const Name = "outline"
@@ -67,6 +67,12 @@ func (c *OutlineClient) Read() ([]byte, error) {
 		log.Printf("failed to read data: %v\n", err)
 		return nil, fmt.Errorf("failed to read data: %w", err)
 	}
+
+	// Return a slice containing only the actually read bytes.
+	// The TUN driver validates the capacity of the underlying buffer during write operations.
+	// Returning the full 64KB buffer would cause "no buffer space available" errors
+	// even if only a small portion contains actual data, because the TUN interface
+	// has limited buffer capacity (typically 32KB on Android devices).
 	return buf[:n], nil
 }
 


### PR DESCRIPTION
Return only actually read bytes from device.Read()

Previously returned the entire pre-allocated buffer (64KB) instead
of slicing to the actual read count (n). This caused issues when
writing to Android VPN interface, which has limited buffer capacity
and cannot handle large 64KB packets.

Now correctly returns buf[:n] containing only the packet data,
ensuring proper write operations to the TUN interface.