### PR TITLE
android: add geo-routing

### DIFF
--- a/kmp_client/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnInterfaceFactory.kt
+++ b/kmp_client/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnInterfaceFactory.kt
@@ -2,18 +2,23 @@ package com.dobby.feature.vpn_service
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.IpPrefix
 import android.net.Network
 import android.net.VpnService.Builder
 import android.os.Build
 import android.util.Log
 import com.dobby.feature.logging.Logger
 import com.dobby.feature.vpn_service.common.reservedBypassSubnets
+import com.dobby.feature.vpn_service.domain.GeoRoutingService
+import kotlinx.coroutines.runBlocking
+import java.net.InetAddress
 
 class DobbyVpnInterfaceFactory(
-    private val logger: Logger
+    private val logger: Logger,
+    private val geoRoutingService: GeoRoutingService
 ) {
 
-    fun create(context: Context, vpnService: DobbyVpnService): Builder {
+    fun create(context: Context, vpnService: DobbyVpnService, countryCode: String? = null): Builder {
         logger.log("Creating VPN Interface")
         val builder = vpnService.Builder()
             .setSession("Outline")
@@ -37,7 +42,59 @@ class DobbyVpnInterfaceFactory(
                 Log.e("MyVpnService", "Error: $subnet", e)
             }
         }
+
+        addGeoRoutingRoutes(builder, countryCode)
+
         return builder
+    }
+
+    private fun addGeoRoutingRoutes(builder: Builder, countryCode: String? = null) {
+        try {
+            runBlocking {
+                if (countryCode != null && countryCode.isNotEmpty()) {
+                    logger.log("GeoRouting: Country detected: $countryCode")
+
+                    val countryIpRanges = geoRoutingService.getCountryIpRanges(countryCode)
+
+                    if (countryIpRanges.isNotEmpty()) {
+                        logger.log("GeoRouting: Adding ${countryIpRanges.size} IP ranges to bypass VPN")
+
+                        countryIpRanges.forEach { cidr ->
+                            try {
+                                val parts = cidr.split("/")
+                                if (parts.size == 2) {
+                                    val address = parts[0]
+                                    val prefixLength = parts[1].toInt()
+
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                        try {
+                                            val ipPrefix = IpPrefix(
+                                                InetAddress.getByName(address),
+                                                prefixLength
+                                            )
+                                            builder.excludeRoute(ipPrefix)
+                                        } catch (e: Exception) {
+                                            logger.log("GeoRouting: Error excluding route $cidr: ${e.message}")
+                                            builder.addRoute(address, prefixLength)
+                                        }
+                                    } else {
+                                        builder.addRoute(address, prefixLength)
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                logger.log("GeoRouting: Error processing CIDR $cidr: ${e.message}")
+                            }
+                        }
+                    } else {
+                        logger.log("GeoRouting: No IP ranges found for country: $countryCode")
+                    }
+                } else {
+                    logger.log("GeoRouting: Could not determine country, skipping geo-routing")
+                }
+            }
+        } catch (e: Exception) {
+            logger.log("GeoRouting: Error in addGeoRoutingRoutes: ${e.message}")
+        }
     }
 
     private fun getDnsServers(context: Context): List<String> {

--- a/kmp_client/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/GeoRoutingService.kt
+++ b/kmp_client/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/GeoRoutingService.kt
@@ -1,0 +1,161 @@
+package com.dobby.feature.vpn_service.domain
+
+import android.content.Context
+import com.dobby.feature.logging.Logger
+import com.dobby.feature.main.domain.ConnectionStateRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.concurrent.TimeUnit
+
+class GeoRoutingService(
+    private val logger: Logger,
+    private val connectionStateRepository: ConnectionStateRepository,
+    private val context: Context
+) {
+    suspend fun getCountryCode(): String? {
+        return withContext(Dispatchers.IO) {
+            // VPN connection check.
+            val isVpnConnected = connectionStateRepository.flow.value
+            if (isVpnConnected) {
+                logger.log("GeoRouting: VPN is connected, cannot fetch country")
+                return@withContext null
+            }
+
+            try {
+                val result = withTimeoutOrNull(10000L) {
+                    val client = OkHttpClient.Builder()
+                        .connectTimeout(5, TimeUnit.SECONDS)
+                        .readTimeout(5, TimeUnit.SECONDS)
+                        .build()
+
+                    val url = "https://ipinfo.io/json"
+                    val request = Request.Builder()
+                        .url(url)
+                        .build()
+
+                    val response = client.newCall(request).execute()
+
+                    if (response.isSuccessful) {
+                        val content = response.body?.string() ?: return@withTimeoutOrNull null
+                        val json = Json { ignoreUnknownKeys = true }
+                        val ipInfo = json.decodeFromString<IpInfoResponse>(content)
+                        logger.log("GeoRouting: Country code fetched: ${ipInfo.country}")
+                        ipInfo.country
+                    } else {
+                        logger.log("GeoRouting: Failed to fetch country, status: ${response.code}")
+                        null
+                    }
+                }
+
+                result
+            } catch (e: Exception) {
+                logger.log("GeoRouting: Error fetching country: ${e.message}")
+                null
+            }
+        }
+    }
+
+    suspend fun getCountryIpRanges(countryCode: String): List<String> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val result = withTimeoutOrNull(60000L) {
+                    val client = OkHttpClient.Builder()
+                        .connectTimeout(10, TimeUnit.SECONDS)
+                        .readTimeout(10, TimeUnit.SECONDS)
+                        .build()
+
+                    val cidrRanges = fetchCountryCidrRanges(countryCode, client)
+
+                    cidrRanges
+                }
+
+                result ?: emptyList()
+            } catch (e: Exception) {
+                logger.log("GeoRouting: Error fetching IP ranges: ${e.message}")
+                emptyList()
+            }
+        }
+    }
+
+    private suspend fun fetchCountryCidrRanges(
+        countryCode: String,
+        client: OkHttpClient
+    ): List<String> {
+        val cidrRanges = mutableListOf<String>()
+
+        try {
+            logger.log("GeoRouting: Attempting to fetch CIDR ranges for $countryCode")
+
+            // Try to load from assets (generated during CI build)
+            val assetsCidrRanges = loadCidrRangesFromAssets(countryCode.uppercase())
+            if (assetsCidrRanges.isNotEmpty()) {
+                cidrRanges.addAll(assetsCidrRanges)
+            } else {
+                logger.log("GeoRouting: No CIDR file found in assets for $countryCode")
+            }
+        } catch (e: Exception) {
+            logger.log("GeoRouting: Error in fetchCountryCidrRanges: ${e.message}")
+        }
+
+        return cidrRanges
+    }
+
+    private suspend fun loadCidrRangesFromAssets(countryCode: String): List<String> {
+        val cidrRanges = mutableListOf<String>()
+        
+        try {
+            val fileName = "cidr/$countryCode.cidr"
+            logger.log("GeoRouting: Starting to load CIDR file from assets: $fileName")
+            
+            val inputStream = context.assets.open(fileName)
+            
+            var lineCount = 0
+            BufferedReader(InputStreamReader(inputStream), 8192).use { reader ->
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    lineCount++
+                    val trimmed = line?.trim() ?: continue
+                    
+                    if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+                        if (trimmed.matches(Regex("^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/\\d{1,2}$"))) {
+                            cidrRanges.add(trimmed)
+                        }
+                    }
+                    
+                    // Log progress for large files
+                    if (lineCount % 10000 == 0) {
+                        logger.log("GeoRouting: Loaded $lineCount lines, ${cidrRanges.size} valid CIDR ranges so far...")
+                    }
+                }
+            }
+            
+            logger.log("GeoRouting: Successfully loaded ${cidrRanges.size} CIDR ranges from assets/$fileName (total lines: $lineCount)")
+        } catch (e: Exception) {
+            logger.log("GeoRouting: Error loading CIDR from assets: ${e.message}")
+            e.printStackTrace()
+        }
+        
+        return cidrRanges
+    }
+
+    @Serializable
+    private data class IpInfoResponse(
+        val ip: String,
+        val hostname: String? = null,
+        val city: String? = null,
+        val region: String? = null,
+        val country: String,
+        val loc: String? = null,
+        val org: String? = null,
+        val postal: String? = null,
+        val timezone: String? = null,
+        val readme: String? = null
+    )
+}

--- a/kmp_client/app/src/androidMain/kotlin/nativeModule.kt
+++ b/kmp_client/app/src/androidMain/kotlin/nativeModule.kt
@@ -12,6 +12,7 @@ import com.dobby.feature.vpn_service.DobbyVpnInterfaceFactory
 import com.dobby.feature.vpn_service.OutlineLibFacade
 import com.dobby.feature.vpn_service.domain.CloakConnectionInteractor
 import com.dobby.feature.vpn_service.domain.CloakLibFacadeImpl
+import com.dobby.feature.vpn_service.domain.GeoRoutingService
 import com.dobby.feature.vpn_service.domain.IpFetcher
 import com.dobby.feature.vpn_service.domain.OutlineLibFacadeImpl
 import org.koin.android.ext.koin.androidContext
@@ -38,5 +39,6 @@ val androidVpnModule = module {
     factory<CloakLibFacade> { CloakLibFacadeImpl() }
     factory<OutlineLibFacade> { OutlineLibFacadeImpl() }
     single<CloakConnectionInteractor> { CloakConnectionInteractor(get()) }
+    single { GeoRoutingService(get(), get(), androidContext()) }
     factoryOf(::DobbyVpnInterfaceFactory)
 }


### PR DESCRIPTION
В этом ПРе геороутинг добавлен только для андроида.

Список IP-диапазонов для стран ожидается в папке `kmp_client/app/src/androidMain/assets/cidr/`. Ожидается, что она будет создана и заполнена отдельной CI джобой. Скрипт для скачивания диапазонов прикреплю.

Для этого кода была обнаружена (но не исправлена) проблема. Для RU есть 30k диапазонов и добавление всех приводит к крашу приложения. При этом добавление 10k работает нормально. Я считаю, что все дело в таймаутах (тк добавление 30k роутов занимает некоторое время). Потенциальное решение -- добавлять роуты асинхронно. Или увеличить таймаут в нужном месте.

Для работы скрипта получения диапазонов необходим ipinfo токен. Даже бесплатный подойдет, для его выпуска нужно просто зарегистрироваться, и затем во вкладке API получить API Token.

[generate_routes.py](https://github.com/user-attachments/files/24754919/generate_routes.py)