### PR TITLE
Fix VPN lifecycle races and teardown handling

### DIFF
--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
@@ -94,7 +94,11 @@ class DobbyVpnService : VpnService() {
                         if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) add("ETH")
                         if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) add("VPN")
                     }.joinToString("|")
-                    logger.log("[svc:$serviceId] net:onCapabilitiesChanged net=$network transports=$transports internet=$hasInternet validated=$validated")
+                    logger.log(
+                        "[svc:$serviceId] net:onCapabilitiesChanged " +
+                            "net=$network transports=$transports " +
+                            "internet=$hasInternet validated=$validated"
+                    )
                 }
             }
             defaultNetworkCallback = cb
@@ -124,7 +128,10 @@ class DobbyVpnService : VpnService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val intentFromUi = intent?.getBooleanExtra(IS_FROM_UI, false) == true
-        logger.log("[svc:$serviceId] onStartCommand(startId=$startId flags=$flags intentFromUi=$intentFromUi) vpnInterface=${vpnInterface?.fd}")
+        logger.log(
+            "[svc:$serviceId] onStartCommand(startId=$startId flags=$flags " +
+                "intentFromUi=$intentFromUi) vpnInterface=${vpnInterface?.fd}"
+        )
 
         serviceScope.launch {
             startStopMutex.withLock {

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
@@ -123,14 +123,32 @@ class DobbyVpnService : VpnService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        logger.log("[svc:$serviceId] onStartCommand(startId=$startId flags=$flags intentFromUi=${intent?.getBooleanExtra(IS_FROM_UI, false)}) vpnInterface=${vpnInterface?.fd}")
-        teardownVpn()
-        geoRouting.setGeoRoutingConf(dobbyConfigsRepository.getGeoRoutingConf())
-        when (dobbyConfigsRepository.getVpnInterface()) {
-            VpnInterface.CLOAK_OUTLINE -> startCloakOutline(intent)
-            VpnInterface.AMNEZIA_WG -> startAwg()
+        val intentFromUi = intent?.getBooleanExtra(IS_FROM_UI, false) == true
+        logger.log("[svc:$serviceId] onStartCommand(startId=$startId flags=$flags intentFromUi=$intentFromUi) vpnInterface=${vpnInterface?.fd}")
+
+        serviceScope.launch {
+            startStopMutex.withLock {
+                val hasActiveTunnel = vpnInterface != null || goTunFd != null
+
+                if (!intentFromUi && !hasActiveTunnel) {
+                    logger.log("[svc:$serviceId] onStartCommand(): ignoring implicit restart without active tunnel")
+                    stopSelf(startId)
+                    return@withLock
+                }
+
+                if (hasActiveTunnel) {
+                    logger.log("[svc:$serviceId] onStartCommand(): existing tunnel detected → teardown before start")
+                    teardownVpn()
+                }
+
+                geoRouting.setGeoRoutingConf(dobbyConfigsRepository.getGeoRoutingConf())
+                when (dobbyConfigsRepository.getVpnInterface()) {
+                    VpnInterface.CLOAK_OUTLINE -> startCloakOutline(intent)
+                    VpnInterface.AMNEZIA_WG -> startAwg()
+                }
+            }
         }
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onDestroy() {
@@ -160,15 +178,11 @@ class DobbyVpnService : VpnService() {
         return memInfo.totalPss / 1024.0
     }
 
-    private fun startCloakOutline(intent: Intent?) {
-        serviceScope.launch {
-            startStopMutex.withLock {
-                if (dobbyConfigsRepository.getIsCloakEnabled()) {
-                    cloakConnectInteractor.startCloak(instance)
-                }
-                outlineInteractor.startOutline(intent, instance)
-            }
+    private suspend fun startCloakOutline(intent: Intent?) {
+        if (dobbyConfigsRepository.getIsCloakEnabled()) {
+            cloakConnectInteractor.startCloak(instance)
         }
+        outlineInteractor.startOutline(intent, instance)
     }
 
     private fun startAwg() {
@@ -197,7 +211,11 @@ class DobbyVpnService : VpnService() {
     }
 
     fun teardownVpn() {
-        val fdBefore = runCatching { vpnInterface?.fd }.getOrNull()
+        val interfaceToClose = vpnInterface
+        val targetGoTunFd = goTunFd
+        val fdBefore = runCatching { interfaceToClose?.fd }.getOrNull()
+        vpnInterface = null
+        goTunFd = null
         logger.log("[svc:$serviceId] teardownVpn(): begin fd=$fdBefore")
         runCatching {
             outlineInteractor.stopOutline();
@@ -211,7 +229,7 @@ class DobbyVpnService : VpnService() {
         }.onFailure { e ->
             logger.log("[svc:$serviceId] onDestroy(): failed to stop Cloak: ${e.message}")
         }
-        goTunFd?.let { targetFd ->
+        targetGoTunFd?.let { targetFd ->
             logger.log("[svc:$serviceId] teardownVpn(): safely terminating goTunFd=$targetFd")
             try {
                 // Open /dev/null
@@ -232,11 +250,9 @@ class DobbyVpnService : VpnService() {
                 logger.log("[svc:$serviceId] teardownVpn(): safe termination warning: ${e.message}")
             }
         }
-        goTunFd = null
         runCatching {
-            vpnInterface?.close()
+            interfaceToClose?.close()
         }
-        vpnInterface = null
         logger.log("[svc:$serviceId] teardownVpn(): end fd=$fdBefore")
     }
     fun setupVpn() {

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/DobbyVpnService.kt
@@ -153,7 +153,14 @@ class DobbyVpnService : VpnService() {
 
     override fun onDestroy() {
         logger.log("[svc:$serviceId] onDestroy() begin vpnInterface=${vpnInterface?.fd}")
-        teardownVpn()
+        // Cancel the scope first so any coroutine currently holding startStopMutex
+        // is interrupted at its next suspension point and releases the lock.
+        serviceScope.cancel()
+        runBlocking {
+            startStopMutex.withLock {
+                teardownVpn()
+            }
+        }
         geoRouting.clearGeoRoutingConf()
         runCatching {
             val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -164,7 +171,6 @@ class DobbyVpnService : VpnService() {
         }.onFailure { e ->
             logger.log("[svc:$serviceId] net:unregisterNetworkCallback FAILED: ${e.message}")
         }
-        serviceScope.cancel()
         tunnelManager.updateState(null, TunnelState.DOWN)
         instance = null
         super.onDestroy()
@@ -179,8 +185,13 @@ class DobbyVpnService : VpnService() {
     }
 
     private suspend fun startCloakOutline(intent: Intent?) {
-        if (dobbyConfigsRepository.getIsCloakEnabled()) {
-            cloakConnectInteractor.startCloak(instance)
+        val cloakStarted = cloakConnectInteractor.startCloak()
+        if (!cloakStarted) {
+            logger.log("[svc:$serviceId] startCloakOutline(): Cloak failed → teardown")
+            connectionState.tryUpdateStatus(false)
+            teardownVpn()
+            stopSelf()
+            return
         }
         outlineInteractor.startOutline(intent, instance)
     }

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/cloak/CloakConnectionInteractor.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/cloak/CloakConnectionInteractor.kt
@@ -3,7 +3,6 @@ package com.dobby.feature.vpn_service.domain.cloak
 import com.dobby.feature.logging.Logger
 import com.dobby.feature.main.domain.DobbyConfigsRepository
 import com.dobby.feature.vpn_service.CloakLibFacade
-import com.dobby.feature.vpn_service.DobbyVpnService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
@@ -17,8 +16,9 @@ class CloakConnectionInteractor(
     private val wasPreviouslyConnected = AtomicBoolean(false)
 
 
-    suspend fun startCloak(dobbyVpnService: DobbyVpnService?) {
-        // If Cloak is enabled, start it BEFORE Outline tries to connect to 127.0.0.1:LocalPort.
+    // Returns true on success, false on failure.
+    // The caller is responsible for teardown on false.
+    suspend fun startCloak(): Boolean {
         if (dobbyConfigsRepository.getIsCloakEnabled()) {
             val cloakConfig = dobbyConfigsRepository.getCloakConfig()
             val localPort = dobbyConfigsRepository.getCloakLocalPort().toString()
@@ -31,20 +31,15 @@ class CloakConnectionInteractor(
                 )
                 logger.log("Cloak connection result is $cloakResult")
                 if (cloakResult is ConnectResult.Error || cloakResult is ConnectResult.ValidationError) {
-                    logger.log("Cloak failed to start, stopping VPN service")
-                    dobbyVpnService?.connectionState?.tryUpdateStatus(false)
-                    dobbyVpnService?.teardownVpn()
-                    dobbyVpnService?.stopSelf()
-                    return
+                    logger.log("Cloak failed to start")
+                    return false
                 }
             } else {
-                logger.log("Cloak is turn on in config, but no config for it was found. Stopping VPN service")
-                dobbyVpnService?.connectionState?.tryUpdateStatus(false)
-                dobbyVpnService?.teardownVpn()
-                dobbyVpnService?.stopSelf()
-                return
+                logger.log("Cloak is enabled but config is empty")
+                return false
             }
         }
+        return true
     }
 
     fun stopCloak() {

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/cloak/CloakConnectionInteractor.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/cloak/CloakConnectionInteractor.kt
@@ -70,6 +70,7 @@ class CloakConnectionInteractor(
                 if (result.isSuccess) {
                     ConnectResult.Success
                 } else {
+                    isConnected.set(false)
                     ConnectResult.Error(result.exceptionOrNull()!!)
                 }
             } else {

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -69,6 +69,7 @@ class HealthCheckManager(
 
                 if (configsRepository.getIsUserInitStop()) {
                     logger.log("[HC] Stop condition: getIsUserInitStop() == true → exiting health check loop")
+                    resetHealthCheckState()
                     return@launch
                 }
 
@@ -92,6 +93,7 @@ class HealthCheckManager(
                 var vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
                 if (!vpnStarted) {
                     logger.log("[HC] vpnStarted=false → exiting health check loop")
+                    resetHealthCheckState()
                     return@launch
                 }
 
@@ -162,12 +164,15 @@ class HealthCheckManager(
         healthJob?.cancel()
         healthJob = null
 
-        consecutiveFailuresCount = 0
-        lastVpnStartMark = null
-
-        lastFullConnectionSucceed = false
+        resetHealthCheckState()
 
         logger.log("[HC] State reset after stop")
+    }
+
+    private fun resetHealthCheckState() {
+        consecutiveFailuresCount = 0
+        lastVpnStartMark = null
+        lastFullConnectionSucceed = false
     }
 
     suspend fun turnOffVpn() {

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -113,7 +113,10 @@ class HealthCheckManager(
 
                     if (nextDelay == null) {
                         consecutiveFailuresCount++
-                        logger.log("[HC] Not connected → consecutiveFailuresCount=$consecutiveFailuresCount/$consecutiveFailuresBeforeTurnOff")
+                        logger.log(
+                            "[HC] Not connected → " +
+                                "consecutiveFailuresCount=$consecutiveFailuresCount/$consecutiveFailuresBeforeTurnOff"
+                        )
 
                         if (consecutiveFailuresCount >= consecutiveFailuresBeforeTurnOff) {
                             logger.log("[HC] Failure threshold reached → turning off VPN & stopping health check")

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -72,6 +72,14 @@ class HealthCheckManager(
                     return@launch
                 }
 
+                if (mainViewModel.connectionStateRepository.vpnTransitioningFlow.value) {
+                    logger.log("[HC] VPN is transitioning → skipping checks for this tick")
+                    nextDelay = getHealthCheckDelay()
+                    logger.log("[HC] Next tick in $nextDelay")
+                    delay(nextDelay)
+                    continue
+                }
+
                 val connected = try {
                     val result = isConnected()
                     logger.log("[HC] isConnected() result = $result")

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -68,8 +68,7 @@ class HealthCheckManager(
                 var nextDelay: Duration? = null
 
                 if (configsRepository.getIsUserInitStop()) {
-                    logger.log("[HC] Stop condition: getIsUserInitStop() == true")
-                    turnOffVpn()
+                    logger.log("[HC] Stop condition: getIsUserInitStop() == true → exiting health check loop")
                     return@launch
                 }
 

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/ConnectionStateRepository.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/ConnectionStateRepository.kt
@@ -10,6 +10,9 @@ class ConnectionStateRepository {
     private val _vpnStartedFlow = MutableStateFlow(false)
     val vpnStartedFlow = _vpnStartedFlow.asStateFlow()
 
+    private val _vpnTransitioningFlow = MutableStateFlow(false)
+    val vpnTransitioningFlow = _vpnTransitioningFlow.asStateFlow()
+
     suspend fun updateStatus(isConnected: Boolean) {
         _statusFlow.emit(isConnected)
     }
@@ -24,5 +27,13 @@ class ConnectionStateRepository {
 
     fun tryUpdateVpnStarted(isStarted: Boolean) {
         _vpnStartedFlow.tryEmit(isStarted)
+    }
+
+    suspend fun updateVpnTransitioning(isTransitioning: Boolean) {
+        _vpnTransitioningFlow.emit(isTransitioning)
+    }
+
+    fun tryUpdateVpnTransitioning(isTransitioning: Boolean) {
+        _vpnTransitioningFlow.tryEmit(isTransitioning)
     }
 }

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/config/TomlConfigApplier.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/config/TomlConfigApplier.kt
@@ -55,6 +55,7 @@ class TomlConfigApplier(
             mainRepo.setGeoRoutingConf(cidrsString)
         } else {
             logger.log("ExcludeIPs not found or empty → clearing routing")
+            mainRepo.setGeoRoutingConf("")
         }
 
         logger.log("Finish parseToml()")
@@ -64,5 +65,6 @@ class TomlConfigApplier(
     private fun disableOutlineAndCloak() {
         outlineRepo.clearOutlineConfig()
         cloakRepo.clearCloakConfig()
+        mainRepo.setGeoRoutingConf("")
     }
 }

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -28,12 +28,13 @@ public class VpnManagerImpl: VpnManager {
         self.connectionRepository = connectionRepository
         getOrCreateManager { [weak self] manager, _ in
             guard let self else { return }
-            if manager?.connection.status == .connected {
-                self.state = manager?.connection.status ?? .invalid
+            let status = manager?.connection.status ?? .invalid
+            self.state = status
+            self.updateTransitionState(for: status)
+            if status == .connected {
                 connectionRepository.tryUpdateVpnStarted(isStarted: true)
                 self.vpnManager = manager
             } else {
-                self.state = manager?.connection.status ?? .invalid
                 connectionRepository.tryUpdateVpnStarted(isStarted: false)
             }
         }
@@ -49,6 +50,9 @@ public class VpnManagerImpl: VpnManager {
             if let myConnection = self.vpnManager?.connection, myConnection !== connection {
                 return
             }
+
+            self.state = connection.status
+            self.updateTransitionState(for: connection.status)
 
             switch connection.status {
             case .connected:
@@ -97,18 +101,20 @@ public class VpnManagerImpl: VpnManager {
         let status = manager.connection.status
         if status == .connecting || status == .disconnecting || status == .reasserting {
             self.logs.writeLog(log: "[start] Skip: connection is transitioning (\(status.rawValue))")
+            self.updateTransitionState(for: status)
             return
         }
         if status == .connected {
             self.logs.writeLog(log: "[start] Skip: already connected")
             return
         }
+        self.vpnManager = manager
+        self.vpnManager?.isEnabled = true
+        self.applyProtocolDefaults(manager: manager)
         if let proto = manager.protocolConfiguration as? NETunnelProviderProtocol {
             let address = proto.serverAddress ?? "nil"
             self.logs.writeLog(log: "VPN Manager serverAddress = \(address)")
         }
-        self.vpnManager = manager
-        self.vpnManager?.isEnabled = true
         manager.saveToPreferences { saveError in
             if let saveError = saveError {
                 self.logs.writeLog(log: "Failed to save VPN configuration: \(saveError)")
@@ -133,6 +139,7 @@ public class VpnManagerImpl: VpnManager {
             return
         }
         self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel()")
+        connectionRepository.tryUpdateVpnTransitioning(isTransitioning: true)
         manager.connection.stopVPNTunnel()
         self.logs.writeLog(log: "[stop] stopVPNTunnel() called, waiting for .disconnecting")
     }
@@ -162,7 +169,7 @@ public class VpnManagerImpl: VpnManager {
 
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
-        proto.serverAddress = "159.69.19.209:443"
+        proto.serverAddress = currentServerAddress()
         proto.providerConfiguration = [:]
         proto.includeAllNetworks = true
         proto.excludeLocalNetworks = true
@@ -182,6 +189,7 @@ public class VpnManagerImpl: VpnManager {
     private func applyProtocolDefaults(manager: NETunnelProviderManager) {
         guard let proto = manager.protocolConfiguration as? NETunnelProviderProtocol else { return }
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
+        proto.serverAddress = currentServerAddress()
         proto.includeAllNetworks = true
         proto.excludeLocalNetworks = true
         if #available(iOS 16.4, *) {
@@ -193,6 +201,25 @@ public class VpnManagerImpl: VpnManager {
             proto.excludeDeviceCommunication = false
         }
         manager.protocolConfiguration = proto
+    }
+
+    private func currentServerAddress() -> String {
+        let outlineServer = configsRepository.getServerPortOutline().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !outlineServer.isEmpty {
+            return outlineServer
+        }
+
+        let connectionUrl = configsRepository.getConnectionURL().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !connectionUrl.isEmpty {
+            return connectionUrl
+        }
+
+        return Self.dobbyName
+    }
+
+    private func updateTransitionState(for status: NEVPNStatus) {
+        let isTransitioning = status == .connecting || status == .disconnecting || status == .reasserting
+        connectionRepository.tryUpdateVpnTransitioning(isTransitioning: isTransitioning)
     }
 
 //    static func startSentry() {

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -209,11 +209,6 @@ public class VpnManagerImpl: VpnManager {
             return outlineServer
         }
 
-        let connectionUrl = configsRepository.getConnectionURL().trimmingCharacters(in: .whitespacesAndNewlines)
-        if !connectionUrl.isEmpty {
-            return connectionUrl
-        }
-
         return Self.dobbyName
     }
 

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -41,11 +41,8 @@ public final class CloakInteractor {
 
     func stopCloak() throws {
         if cloakStarted {
-            var err: NSError?
-            Cloak_outlineOutlineDisconnect(&err)
-            if let error = err {
-                throw error
-            }
+            Cloak_outlineStopCloakClient()
+            cloakStarted = false
         }
     }
 }

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -39,7 +39,7 @@ public final class CloakInteractor {
         }
     }
 
-    func stopCloak() throws {
+    func stopCloak() {
         if cloakStarted {
             Cloak_outlineStopCloakClient()
             cloakStarted = false

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -186,7 +186,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     @MainActor
     private func teardownForStop(reason: String) async {
-        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason)")
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason))")
+
+        do {
+            try outlineInteractor.stopOutline()
+        } catch {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
+        }
 
         do {
             try cloakInteractor.stopCloak()

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -222,11 +222,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
         }
 
-        do {
-            try cloakInteractor.stopCloak()
-        } catch {
-            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop cloak: \(error.localizedDescription)")
-        }
+        cloakInteractor.stopCloak()
 
         do {
             try await self.setTunnelNetworkSettings(nil)

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -24,6 +24,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var pathMonitor: Network.NWPathMonitor?
     private var lastPathStatus: Network.NWPath.Status?
 
+    deinit {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] deinit")
+    }
+
     func reportMemoryUsageMB() -> Double {
         var info = task_vm_info_data_t()
         var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.stride / MemoryLayout<natural_t>.stride)
@@ -65,83 +69,89 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")
 
-        // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
-        await teardownForStop(reason: "pre-start cleanup")
+        do {
+            // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
+            await teardownForStop(reason: "pre-start cleanup")
 
-        startPathLogging()
+            startPathLogging()
 
-        let cloakConfig = configsRepository.getCloakConfig()
-        // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
-        // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
-        var excludedRoutes: [NEIPv4Route] = []
-        if let hostOrIp = extractIP(from: configsRepository.getServerPortOutline()) {
-            let trimmed = hostOrIp.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
-               let route = makeExcludedRoute(host: ip) {
-                excludedRoutes.append(route)
-                if ip == trimmed {
-                    logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
+            let cloakConfig = configsRepository.getCloakConfig()
+            // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
+            // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
+            var excludedRoutes: [NEIPv4Route] = []
+            if let hostOrIp = extractIP(from: configsRepository.getServerPortOutline()) {
+                let trimmed = hostOrIp.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
+                   let route = makeExcludedRoute(host: ip) {
+                    excludedRoutes.append(route)
+                    if ip == trimmed {
+                        logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
+                    } else {
+                        logs.writeLog(log: "Excluded route for Outline host resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    }
                 } else {
-                    logs.writeLog(log: "Excluded route for Outline host resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
                 }
-            } else {
-                logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
             }
-        }
-        if let remoteHost = extractRemoteHost(from: cloakConfig) {
-            let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
-               let route = makeExcludedRoute(host: ip) {
-                excludedRoutes.append(route)
-                if ip == trimmed {
-                    logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
+            if let remoteHost = extractRemoteHost(from: cloakConfig) {
+                let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
+                   let route = makeExcludedRoute(host: ip) {
+                    excludedRoutes.append(route)
+                    if ip == trimmed {
+                        logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
+                    } else {
+                        logs.writeLog(log: "Excluded route for Cloak RemoteHost resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    }
                 } else {
-                    logs.writeLog(log: "Excluded route for Cloak RemoteHost resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
-            } else {
-                logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
             }
+            if !excludedRoutes.isEmpty {
+                let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
+                logs.writeLog(log: "Excluded IPv4 routes: \(list)")
+            } else {
+                logs.writeLog(log: "Excluded IPv4 routes: (none)")
+            }
+
+            let remoteAddress = "254.1.1.1"
+            let localAddress = "198.18.0.1"
+            let subnetMask = "255.255.0.0"
+            let dnsServers = ["1.1.1.1", "8.8.8.8"]
+
+            let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
+            settings.mtu = 1200
+            settings.ipv4Settings = NEIPv4Settings(
+                addresses: [localAddress],
+                subnetMasks: [subnetMask]
+            )
+            settings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
+            settings.ipv4Settings?.excludedRoutes = excludedRoutes
+            settings.ipv6Settings = nil
+            settings.dnsSettings = NEDNSSettings(servers: dnsServers)
+            settings.dnsSettings?.matchDomains = [""]
+
+            logs.writeLog(log: "Settings are ready:")
+            try await self.setTunnelNetworkSettings(settings)
+            logs.writeLog(log: "Tunnel settings applied")
+
+            logInterfaces()
+
+            let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
+            logs.writeLog(log: "Start go logger init path = \(path)")
+            Cloak_outlineInitLogger(path)
+            logs.writeLog(log: "Finish go logger init")
+            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
+            try outlineInteractor.startOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
+            try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
+
+            logs.writeLog(log: "startTunnel: all packet loops started")
+        } catch {
+            let nsError = error as NSError
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel failed: \(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)")
+            throw error
         }
-        if !excludedRoutes.isEmpty {
-            let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
-            logs.writeLog(log: "Excluded IPv4 routes: \(list)")
-        } else {
-            logs.writeLog(log: "Excluded IPv4 routes: (none)")
-        }
-
-        let remoteAddress = "254.1.1.1"
-        let localAddress = "198.18.0.1"
-        let subnetMask = "255.255.0.0"
-        let dnsServers = ["1.1.1.1", "8.8.8.8"]
-
-        let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
-        settings.mtu = 1200
-        settings.ipv4Settings = NEIPv4Settings(
-            addresses: [localAddress],
-            subnetMasks: [subnetMask]
-        )
-        settings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
-        settings.ipv4Settings?.excludedRoutes = excludedRoutes
-        settings.ipv6Settings = nil
-        settings.dnsSettings = NEDNSSettings(servers: dnsServers)
-        settings.dnsSettings?.matchDomains = [""]
-
-        logs.writeLog(log: "Settings are ready:")
-        try await self.setTunnelNetworkSettings(settings)
-        logs.writeLog(log: "Tunnel settings applied")
-
-        logInterfaces()
-
-        let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
-        logs.writeLog(log: "Start go logger init path = \(path)")
-        Cloak_outlineInitLogger(path)
-        logs.writeLog(log: "Finish go logger init")
-        Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
-        try outlineInteractor.startOutline()
-        logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
-        try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
-
-        logs.writeLog(log: "startTunnel: all packet loops started")
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
@@ -152,6 +162,24 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             await teardownForStop(reason: "stopTunnel(\(reason))")
             completionHandler()
         }
+    }
+
+    override func cancelTunnelWithError(_ error: Error?) {
+        if let error {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: \(error.localizedDescription)")
+        } else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: nil")
+        }
+        super.cancelTunnelWithError(error)
+    }
+
+    override func sleep(completionHandler: @escaping () -> Void) {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] sleep()")
+        completionHandler()
+    }
+
+    override func wake() {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] wake()")
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
@@ -214,10 +242,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
     }
 
-    /// Extracts the host/IP part from a string like "ip:port"
+    /// Extracts the host/IP part from a string like "ip:port" or "[ipv6]:port".
     func extractIP(from serverPort: String) -> String? {
-        guard !serverPort.isEmpty else { return nil }
-        return serverPort.split(separator: ":").first.map(String.init)
+        let host = OutlineInteractor.extractHost(from: serverPort).trimmingCharacters(in: .whitespacesAndNewlines)
+        return host.isEmpty ? nil : host
     }
 
     /// Extracts `RemoteHost` from Cloak JSON

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -87,7 +87,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
                     } else {
-                        logs.writeLog(log: "Excluded route for Outline host resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                        logs.writeLog(
+                            log: "Excluded route for Outline host resolved: " +
+                                "\(maskStr(value: trimmed)) → \(maskStr(value: ip))/32"
+                        )
                     }
                 } else {
                     logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
@@ -101,7 +104,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
                     } else {
-                        logs.writeLog(log: "Excluded route for Cloak RemoteHost resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                        logs.writeLog(
+                            log: "Excluded route for Cloak RemoteHost resolved: " +
+                                "\(maskStr(value: trimmed)) → \(maskStr(value: ip))/32"
+                        )
                     }
                 } else {
                     logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
@@ -149,7 +155,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(log: "startTunnel: all packet loops started")
         } catch {
             let nsError = error as NSError
-            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel failed: \(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)")
+            logs.writeLog(
+                log: "[tunnel:\(tunnelId)] startTunnel failed: " +
+                    "\(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
+            )
             throw error
         }
     }
@@ -204,7 +213,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
                 let expensive = path.isExpensive
                 let constrained = path.isConstrained
-                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] pathUpdate status=\(status) ifaces=[\(ifaces)] expensive=\(expensive) constrained=\(constrained)")
+                self.logs.writeLog(
+                    log: "[tunnel:\(self.tunnelId)] pathUpdate " +
+                        "status=\(status) ifaces=[\(ifaces)] " +
+                        "expensive=\(expensive) constrained=\(constrained)"
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes a set of VPN lifecycle and teardown bugs found while investigating user-provided iOS and Android connection logs.

The main changes are:

- fix Apple tunnel teardown so Outline and Cloak are stopped via the correct platform entrypoints
- stop the common health-check loop from issuing a second forced shutdown after a user-initiated stop
- clear stale geo-routing state when TOML `ExcludeIPs` is empty or the config is rejected
- fix an Android service start race that could tear down a just-created tunnel while another start was still in flight
- harden Android teardown so an old teardown path cannot close a newly created TUN fd
- reset Android Cloak connection state after startup failures so reconnects are not blocked by stale state

## Root Cause Analysis

### 1. Apple teardown bugs

The iOS packet tunnel teardown path had two concrete lifecycle bugs:

- `swift_module/tunnel/CloakInteractor.swift` stopped Cloak by calling `OutlineDisconnect` instead of the Cloak stop export
- `swift_module/tunnel/PacketTunnelProvider.swift` cleared tunnel network settings without explicitly stopping Outline first

These bugs could leave Apple-side tunnel state inconsistent during stop/restart sequences.

### 2. Common cross-platform state bugs

Two bugs lived in shared code and were therefore not Apple-specific:

- `kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt`
  - the health-check loop treated `isUserInitStop=true` as a reason to call `turnOffVpn()` again, causing duplicate stop flows after a user-initiated disconnect
- `kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/config/TomlConfigApplier.kt`
  - when `ExcludeIPs` was empty, the code logged "clearing routing" but did not actually clear the persisted geo-routing config

That second issue could leak stale bypass CIDRs between profile switches.

### 3. Android malfunction and crash

The Android failure was caused by a service lifecycle race, not by an invalid server config.

From the user-provided Android log:

- the service received two starts almost back-to-back during one connection attempt
- the second `onStartCommand()` unconditionally called `teardownVpn()` while the first start was still bringing up Cloak + Outline
- that teardown raced with native startup and later killed the old TUN fd while the service was already rebuilding the tunnel
- Cloak was also restarted before the old listener had fully exited, which produced `bind: address already in use`

The separate Android crash dump matches that race exactly:

- abort: `fdsan: failed to exchange ownership of file descriptor: fd 136 is owned by unique_fd ...`

That fd number matches the TUN fd seen in the Android app log during the raced startup/teardown sequence.

The log also explains the "VPN tunnel stayed stuck until I disabled it in OS settings manually" symptom:

- stop began
- native traffic was still flowing briefly through the half-torn session
- teardown got stuck long enough that the service was only fully destroyed much later

## Scope / Platform Applicability

- The incorrect Cloak stop call and missing explicit Outline stop were Apple-specific.
- The health-check duplicate-stop bug was shared code and applicable to Android / iOS / desktop.
- The stale geo-routing config bug was shared code and applicable to Android / iOS / desktop.
- The Android `onStartCommand()` / teardown / detached-fd race was Android-specific.
- The JVM desktop service already uses a serialized start/stop path and the correct native stop entrypoints, so the Apple-specific stop bugs do not directly apply there.

## Implementation Notes

### Apple

- stop Outline explicitly during packet tunnel teardown
- stop Cloak via `Cloak_outlineStopCloakClient()`

### Shared

- exit the health-check loop on user stop instead of calling another shutdown path
- actually clear persisted geo-routing config when the current TOML has no `ExcludeIPs`

### Android

- serialize the full service start sequence under `startStopMutex`
- ignore implicit non-UI restarts when there is no active tunnel to recover
- switch the service return mode from `START_STICKY` to `START_NOT_STICKY`
- snapshot `vpnInterface` / `goTunFd` at teardown start so a stale teardown cannot close a newly created tunnel
- clear the Cloak interactor's `isConnected` flag on startup failure

## Validation

- `git diff --check`

I did not run a full Android/iOS build in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset Cloak connection state on failed connect attempts.
  * Prevent unintended VPN shutdowns during health-check transitions.
  * Safer tunnel teardown to avoid race conditions.

* **Improvements**
  * More robust VPN service start/stop behavior and non-sticky restart policy.
  * Clear geo-routing when TOML disables routing or provides no exclusions.
  * More detailed lifecycle and error logging for tunnel startup/teardown.

* **New Features**
  * Expose a VPN "transitioning" state stream for UI/state tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->