### PR TITLE
Improve Apple VPN observability and transition handling

### DIFF
--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -72,6 +72,14 @@ class HealthCheckManager(
                     return@launch
                 }
 
+                if (mainViewModel.connectionStateRepository.vpnTransitioningFlow.value) {
+                    logger.log("[HC] VPN is transitioning → skipping checks for this tick")
+                    nextDelay = getHealthCheckDelay()
+                    logger.log("[HC] Next tick in $nextDelay")
+                    delay(nextDelay)
+                    continue
+                }
+
                 val connected = try {
                     val result = isConnected()
                     logger.log("[HC] isConnected() result = $result")

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/ConnectionStateRepository.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/ConnectionStateRepository.kt
@@ -10,6 +10,9 @@ class ConnectionStateRepository {
     private val _vpnStartedFlow = MutableStateFlow(false)
     val vpnStartedFlow = _vpnStartedFlow.asStateFlow()
 
+    private val _vpnTransitioningFlow = MutableStateFlow(false)
+    val vpnTransitioningFlow = _vpnTransitioningFlow.asStateFlow()
+
     suspend fun updateStatus(isConnected: Boolean) {
         _statusFlow.emit(isConnected)
     }
@@ -24,5 +27,13 @@ class ConnectionStateRepository {
 
     fun tryUpdateVpnStarted(isStarted: Boolean) {
         _vpnStartedFlow.tryEmit(isStarted)
+    }
+
+    suspend fun updateVpnTransitioning(isTransitioning: Boolean) {
+        _vpnTransitioningFlow.emit(isTransitioning)
+    }
+
+    fun tryUpdateVpnTransitioning(isTransitioning: Boolean) {
+        _vpnTransitioningFlow.tryEmit(isTransitioning)
     }
 }

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -28,12 +28,13 @@ public class VpnManagerImpl: VpnManager {
         self.connectionRepository = connectionRepository
         getOrCreateManager { [weak self] manager, _ in
             guard let self else { return }
-            if manager?.connection.status == .connected {
-                self.state = manager?.connection.status ?? .invalid
+            let status = manager?.connection.status ?? .invalid
+            self.state = status
+            self.updateTransitionState(for: status)
+            if status == .connected {
                 connectionRepository.tryUpdateVpnStarted(isStarted: true)
                 self.vpnManager = manager
             } else {
-                self.state = manager?.connection.status ?? .invalid
                 connectionRepository.tryUpdateVpnStarted(isStarted: false)
             }
         }
@@ -49,6 +50,9 @@ public class VpnManagerImpl: VpnManager {
             if let myConnection = self.vpnManager?.connection, myConnection !== connection {
                 return
             }
+
+            self.state = connection.status
+            self.updateTransitionState(for: connection.status)
 
             switch connection.status {
             case .connected:
@@ -97,18 +101,20 @@ public class VpnManagerImpl: VpnManager {
         let status = manager.connection.status
         if status == .connecting || status == .disconnecting || status == .reasserting {
             self.logs.writeLog(log: "[start] Skip: connection is transitioning (\(status.rawValue))")
+            self.updateTransitionState(for: status)
             return
         }
         if status == .connected {
             self.logs.writeLog(log: "[start] Skip: already connected")
             return
         }
+        self.vpnManager = manager
+        self.vpnManager?.isEnabled = true
+        self.applyProtocolDefaults(manager: manager)
         if let proto = manager.protocolConfiguration as? NETunnelProviderProtocol {
             let address = proto.serverAddress ?? "nil"
             self.logs.writeLog(log: "VPN Manager serverAddress = \(address)")
         }
-        self.vpnManager = manager
-        self.vpnManager?.isEnabled = true
         manager.saveToPreferences { saveError in
             if let saveError = saveError {
                 self.logs.writeLog(log: "Failed to save VPN configuration: \(saveError)")
@@ -133,6 +139,7 @@ public class VpnManagerImpl: VpnManager {
             return
         }
         self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel()")
+        connectionRepository.tryUpdateVpnTransitioning(isTransitioning: true)
         manager.connection.stopVPNTunnel()
         self.logs.writeLog(log: "[stop] stopVPNTunnel() called, waiting for .disconnecting")
     }
@@ -162,7 +169,7 @@ public class VpnManagerImpl: VpnManager {
 
         let proto = NETunnelProviderProtocol()
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
-        proto.serverAddress = "159.69.19.209:443"
+        proto.serverAddress = currentServerAddress()
         proto.providerConfiguration = [:]
         proto.includeAllNetworks = true
         proto.excludeLocalNetworks = true
@@ -182,6 +189,7 @@ public class VpnManagerImpl: VpnManager {
     private func applyProtocolDefaults(manager: NETunnelProviderManager) {
         guard let proto = manager.protocolConfiguration as? NETunnelProviderProtocol else { return }
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
+        proto.serverAddress = currentServerAddress()
         proto.includeAllNetworks = true
         proto.excludeLocalNetworks = true
         if #available(iOS 16.4, *) {
@@ -193,6 +201,25 @@ public class VpnManagerImpl: VpnManager {
             proto.excludeDeviceCommunication = false
         }
         manager.protocolConfiguration = proto
+    }
+
+    private func currentServerAddress() -> String {
+        let outlineServer = configsRepository.getServerPortOutline().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !outlineServer.isEmpty {
+            return outlineServer
+        }
+
+        let connectionUrl = configsRepository.getConnectionURL().trimmingCharacters(in: .whitespacesAndNewlines)
+        if !connectionUrl.isEmpty {
+            return connectionUrl
+        }
+
+        return Self.dobbyName
+    }
+
+    private func updateTransitionState(for status: NEVPNStatus) {
+        let isTransitioning = status == .connecting || status == .disconnecting || status == .reasserting
+        connectionRepository.tryUpdateVpnTransitioning(isTransitioning: isTransitioning)
     }
 
 //    static func startSentry() {

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -209,11 +209,6 @@ public class VpnManagerImpl: VpnManager {
             return outlineServer
         }
 
-        let connectionUrl = configsRepository.getConnectionURL().trimmingCharacters(in: .whitespacesAndNewlines)
-        if !connectionUrl.isEmpty {
-            return connectionUrl
-        }
-
         return Self.dobbyName
     }
 

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -24,6 +24,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var pathMonitor: Network.NWPathMonitor?
     private var lastPathStatus: Network.NWPath.Status?
 
+    deinit {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] deinit")
+    }
+
     func reportMemoryUsageMB() -> Double {
         var info = task_vm_info_data_t()
         var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.stride / MemoryLayout<natural_t>.stride)
@@ -65,83 +69,89 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")
 
-        // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
-        await teardownForStop(reason: "pre-start cleanup")
+        do {
+            // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
+            await teardownForStop(reason: "pre-start cleanup")
 
-        startPathLogging()
+            startPathLogging()
 
-        let cloakConfig = configsRepository.getCloakConfig()
-        // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
-        // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
-        var excludedRoutes: [NEIPv4Route] = []
-        if let hostOrIp = extractIP(from: configsRepository.getServerPortOutline()) {
-            let trimmed = hostOrIp.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
-               let route = makeExcludedRoute(host: ip) {
-                excludedRoutes.append(route)
-                if ip == trimmed {
-                    logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
+            let cloakConfig = configsRepository.getCloakConfig()
+            // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
+            // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
+            var excludedRoutes: [NEIPv4Route] = []
+            if let hostOrIp = extractIP(from: configsRepository.getServerPortOutline()) {
+                let trimmed = hostOrIp.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
+                   let route = makeExcludedRoute(host: ip) {
+                    excludedRoutes.append(route)
+                    if ip == trimmed {
+                        logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
+                    } else {
+                        logs.writeLog(log: "Excluded route for Outline host resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    }
                 } else {
-                    logs.writeLog(log: "Excluded route for Outline host resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
                 }
-            } else {
-                logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
             }
-        }
-        if let remoteHost = extractRemoteHost(from: cloakConfig) {
-            let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
-               let route = makeExcludedRoute(host: ip) {
-                excludedRoutes.append(route)
-                if ip == trimmed {
-                    logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
+            if let remoteHost = extractRemoteHost(from: cloakConfig) {
+                let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
+                   let route = makeExcludedRoute(host: ip) {
+                    excludedRoutes.append(route)
+                    if ip == trimmed {
+                        logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
+                    } else {
+                        logs.writeLog(log: "Excluded route for Cloak RemoteHost resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    }
                 } else {
-                    logs.writeLog(log: "Excluded route for Cloak RemoteHost resolved: \(maskStr(value: trimmed)) → \(maskStr(value: ip))/32")
+                    logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
-            } else {
-                logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
             }
+            if !excludedRoutes.isEmpty {
+                let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
+                logs.writeLog(log: "Excluded IPv4 routes: \(list)")
+            } else {
+                logs.writeLog(log: "Excluded IPv4 routes: (none)")
+            }
+
+            let remoteAddress = "254.1.1.1"
+            let localAddress = "198.18.0.1"
+            let subnetMask = "255.255.0.0"
+            let dnsServers = ["1.1.1.1", "8.8.8.8"]
+
+            let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
+            settings.mtu = 1200
+            settings.ipv4Settings = NEIPv4Settings(
+                addresses: [localAddress],
+                subnetMasks: [subnetMask]
+            )
+            settings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
+            settings.ipv4Settings?.excludedRoutes = excludedRoutes
+            settings.ipv6Settings = nil
+            settings.dnsSettings = NEDNSSettings(servers: dnsServers)
+            settings.dnsSettings?.matchDomains = [""]
+
+            logs.writeLog(log: "Settings are ready:")
+            try await self.setTunnelNetworkSettings(settings)
+            logs.writeLog(log: "Tunnel settings applied")
+
+            logInterfaces()
+
+            let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
+            logs.writeLog(log: "Start go logger init path = \(path)")
+            Cloak_outlineInitLogger(path)
+            logs.writeLog(log: "Finish go logger init")
+            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
+            try outlineInteractor.startOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
+            try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
+
+            logs.writeLog(log: "startTunnel: all packet loops started")
+        } catch {
+            let nsError = error as NSError
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel failed: \(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)")
+            throw error
         }
-        if !excludedRoutes.isEmpty {
-            let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
-            logs.writeLog(log: "Excluded IPv4 routes: \(list)")
-        } else {
-            logs.writeLog(log: "Excluded IPv4 routes: (none)")
-        }
-
-        let remoteAddress = "254.1.1.1"
-        let localAddress = "198.18.0.1"
-        let subnetMask = "255.255.0.0"
-        let dnsServers = ["1.1.1.1", "8.8.8.8"]
-
-        let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
-        settings.mtu = 1200
-        settings.ipv4Settings = NEIPv4Settings(
-            addresses: [localAddress],
-            subnetMasks: [subnetMask]
-        )
-        settings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
-        settings.ipv4Settings?.excludedRoutes = excludedRoutes
-        settings.ipv6Settings = nil
-        settings.dnsSettings = NEDNSSettings(servers: dnsServers)
-        settings.dnsSettings?.matchDomains = [""]
-
-        logs.writeLog(log: "Settings are ready:")
-        try await self.setTunnelNetworkSettings(settings)
-        logs.writeLog(log: "Tunnel settings applied")
-
-        logInterfaces()
-
-        let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
-        logs.writeLog(log: "Start go logger init path = \(path)")
-        Cloak_outlineInitLogger(path)
-        logs.writeLog(log: "Finish go logger init")
-        Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
-        try outlineInteractor.startOutline()
-        logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
-        try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
-
-        logs.writeLog(log: "startTunnel: all packet loops started")
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
@@ -152,6 +162,24 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             await teardownForStop(reason: "stopTunnel(\(reason))")
             completionHandler()
         }
+    }
+
+    override func cancelTunnelWithError(_ error: Error?) {
+        if let error {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: \(error.localizedDescription)")
+        } else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: nil")
+        }
+        super.cancelTunnelWithError(error)
+    }
+
+    override func sleep(completionHandler: @escaping () -> Void) {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] sleep()")
+        completionHandler()
+    }
+
+    override func wake() {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] wake()")
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
@@ -214,10 +242,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
     }
 
-    /// Extracts the host/IP part from a string like "ip:port"
+    /// Extracts the host/IP part from a string like "ip:port" or "[ipv6]:port".
     func extractIP(from serverPort: String) -> String? {
-        guard !serverPort.isEmpty else { return nil }
-        return serverPort.split(separator: ":").first.map(String.init)
+        let host = OutlineInteractor.extractHost(from: serverPort).trimmingCharacters(in: .whitespacesAndNewlines)
+        return host.isEmpty ? nil : host
     }
 
     /// Extracts `RemoteHost` from Cloak JSON


### PR DESCRIPTION
## Summary

This is a follow-up PR on top of #135.

It implements the remaining actionable recommendations from the earlier investigation:

- add better Apple packet-tunnel lifecycle logging for abnormal exits and suspend/resume transitions
- stop using a misleading hardcoded Apple `serverAddress`
- make Apple route-host extraction IPv6-safe
- expose VPN transition state through the shared `ConnectionStateRepository`
- make the common health-check loop back off while the VPN is already transitioning

## Why This PR Is Stacked

This branch is based on `codex/fix-vpn-lifecycle-races` from #135 because both changes touch the shared `HealthCheckManager` path. Stacking avoids duplicating the earlier lifecycle fixes in a second PR against `main`.

## Changes

### 1. Apple lifecycle observability

`swift_module/tunnel/PacketTunnelProvider.swift`

- log `startTunnel` failures with NSError domain/code context
- log `cancelTunnelWithError`
- log provider `sleep()` / `wake()`
- log `deinit`

This should make it much easier to distinguish:

- clean stop
- abnormal tunnel cancellation
- start failure
- suspend/resume-related behavior

### 2. Remove misleading hardcoded Apple server address

`swift_module/CommonDI/VpnManagerImpl.swift`

Previously the Apple manager always used a fixed `159.69.19.209:443` string for `NETunnelProviderProtocol.serverAddress`, even when the real active endpoint came from a different config.

This PR replaces that with a dynamic value:

- current Outline target when available
- otherwise the stored connection URL
- otherwise the app name

That makes Apple-side VPN logs much more truthful during debugging.

### 3. IPv6-safe host extraction for Apple excluded routes

`swift_module/tunnel/PacketTunnelProvider.swift`

The previous helper split on `:` and was not safe for bracketed IPv6 host:port strings. This PR reuses the already safer host-extraction logic from `OutlineInteractor`.

### 4. Transition-aware health checks

`kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/domain/ConnectionStateRepository.kt`
`kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt`
`swift_module/CommonDI/VpnManagerImpl.swift`

This PR adds a shared `vpnTransitioningFlow` and populates it from Apple VPN manager state changes.

The health-check loop now skips a tick when the VPN is already transitioning. That avoids treating an in-progress Apple disconnect/reassert/connect transition as a fresh connectivity failure.

## Validation

- `git diff --check`

I did not run a full Apple/KMP build in this environment.
