### PR TITLE
Harden iOS tunnel startup for iOS 26

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -72,6 +72,7 @@ jobs:
           path: swift_module/build/ipa/*.ipa
 
       - name: Fastlane upload_testflight
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           APP_STORE_API_KEY: ${{ secrets.APP_STORE_API_KEY }}
           APP_STORE_KEY_ID: ${{ secrets.APP_STORE_KEY_ID }}

--- a/go_module/cloak/client.go
+++ b/go_module/cloak/client.go
@@ -21,13 +21,14 @@ var (
 	cloakConfig exported_client.Config
 )
 
-func StartCloakClient(localHost, localPort, config string, udp bool) {
+func StartCloakClient(localHost, localPort, config string, udp bool) (err error) {
 	log.Infof("StartCloakClient inner")
 
 	// Handle panic
 	defer func() {
 		if r := recover(); r != nil {
 			log.Infof("StartCloakClient: recovered from panic: %v", r)
+			err = fmt.Errorf("StartCloakClient panic: %v", r)
 		}
 	}()
 
@@ -46,17 +47,17 @@ func StartCloakClient(localHost, localPort, config string, udp bool) {
 	log.Infof("deleted old cloak client")
 
 	var rawConfig exported_client.Config
-	err := json.Unmarshal([]byte(config), &rawConfig)
+	err = json.Unmarshal([]byte(config), &rawConfig)
 	if err != nil {
 		log.Infof("cloak client: Failed to unmarshal config - %v", err)
-		return
+		return fmt.Errorf("cloak client: failed to unmarshal config: %w", err)
 	}
 	log.Infof("cloak client: rawConfig parsed successfully")
 
 	rawConfig.RemoteHost, err = resolveRemoteHostIfNeeded(rawConfig.RemoteHost)
 	if err != nil {
 		log.Infof("Can't resolve Remote Host: %v", err)
-		return
+		return fmt.Errorf("cloak client: can't resolve remote host: %w", err)
 	}
 	rawConfig.LocalHost = localHost
 	rawConfig.LocalPort = localPort
@@ -77,7 +78,7 @@ func StartCloakClient(localHost, localPort, config string, udp bool) {
 	common.Client.MarkOutOffCriticalSection(Name)
 	if err != nil {
 		log.Infof("Can't routing cloak, %v", err)
-		return
+		return fmt.Errorf("cloak client: can't route cloak: %w", err)
 	}
 	log.Infof("cloak client: Routed")
 
@@ -87,12 +88,21 @@ func StartCloakClient(localHost, localPort, config string, udp bool) {
 	err = common.Client.Connect(Name)
 	if err != nil {
 		log.Infof("cloak client: Failed to connect to cloak client - %v", err)
-		return
+		client = nil
+		if cloakConfig.RemoteHost != "" {
+			common.Client.MarkInCriticalSection(Name)
+			StopRoutingCloak(cloakConfig.RemoteHost)
+			common.Client.MarkOutOffCriticalSection(Name)
+			cloakConfig.RemoteHost = ""
+		}
+		common.Client.MarkInactive(Name)
+		return fmt.Errorf("cloak client: failed to connect: %w", err)
 	}
 
 	log.Infof("cloak client connected")
 
 	common.Client.MarkActive(Name)
+	return nil
 }
 
 func StopCloakClient() {

--- a/go_module/ios_exports/cloak.go
+++ b/go_module/ios_exports/cloak.go
@@ -1,13 +1,13 @@
 package cloak_outline
 
 import (
-    "go_module/cloak"
+	"go_module/cloak"
 )
 
-func StartCloakClient(localHost string, localPort string, config string, udp bool) {
-    cloak.StartCloakClient(localHost, localPort, config, udp)
+func StartCloakClient(localHost string, localPort string, config string, udp bool) error {
+	return cloak.StartCloakClient(localHost, localPort, config, udp)
 }
 
 func StopCloakClient() {
-    cloak.StopCloakClient()
+	cloak.StopCloakClient()
 }

--- a/go_module/ios_exports/exitfunc_ios.go
+++ b/go_module/ios_exports/exitfunc_ios.go
@@ -1,0 +1,13 @@
+//go:build ios
+// +build ios
+
+package cloak_outline
+
+import "github.com/sirupsen/logrus"
+
+// Network extensions must not be terminated from Go dependency goroutines.
+// Android already suppresses logrus.Fatal exit behavior; iOS needs the same
+// protection because the tunnel extension otherwise exits without a Swift error.
+func init() {
+	logrus.StandardLogger().ExitFunc = func(int) {}
+}

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -31,8 +31,12 @@ public final class CloakInteractor {
                 return
             }
             logs.writeLog(log: "startCloakOutline: starting cloak, config.length=\(cloakConfig.count)")
-            Cloak_outlineStartCloakClient("127.0.0.1", localPort, cloakConfig, false)
-            // Cloak_outlineStartCloakClient does not return an error — failure is detectable only by absent traffic
+            var err: NSError?
+            Cloak_outlineStartCloakClient("127.0.0.1", localPort, cloakConfig, false, &err)
+            if let error = err {
+                logs.writeLog(log: "startCloakOutline: failed to start cloak: \(error.localizedDescription)")
+                throw error
+            }
             cloakStarted = true
             logs.writeLog(log: "startCloakOutline: Cloak_outlineStartCloakClient returned (cloakStarted=true)")
         } else {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -75,6 +75,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             startPathLogging()
 
+            let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
+            logs.writeLog(log: "Start go logger init path = \(path)")
+            Cloak_outlineInitLogger(path)
+            logs.writeLog(log: "Finish go logger init")
+            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
+
             let cloakConfig = configsRepository.getCloakConfig()
             // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
             // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
@@ -120,6 +126,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 logs.writeLog(log: "Excluded IPv4 routes: (none)")
             }
 
+            // Cloak must bind/connect before the full-tunnel route is installed; otherwise
+            // iOS can route the upstream bootstrap traffic into a tunnel that is not ready yet.
+            try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
+
             let remoteAddress = "254.1.1.1"
             let localAddress = "198.18.0.1"
             let subnetMask = "255.255.0.0"
@@ -143,14 +153,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             logInterfaces()
 
-            let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
-            logs.writeLog(log: "Start go logger init path = \(path)")
-            Cloak_outlineInitLogger(path)
-            logs.writeLog(log: "Finish go logger init")
-            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
             try outlineInteractor.startOutline()
             logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
-            try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
 
             logs.writeLog(log: "startTunnel: all packet loops started")
         } catch {


### PR DESCRIPTION
## Summary

This PR hardens the iOS packet tunnel startup path for the failure mode seen on iOS 26 while preserving the Android/lower-iOS behavior that already works.

Changes:
- Start the Go logger and geo-routing setup before any native Cloak/Outline startup work.
- Start Cloak before installing full-tunnel `NEPacketTunnelNetworkSettings`, then start Outline after the utun interface is configured.
- Return Cloak startup errors from Go through the gomobile iOS export and throw them from Swift instead of reporting a fake successful tunnel start.
- Suppress `logrus.Fatal` process exits for iOS exports, matching the existing Android protection so a Go dependency goroutine cannot terminate the Network Extension without a Swift error.

## Why

The iOS path differed from Android in two important ways:

- Android starts Cloak before Outline, and Outline creates the VPN interface only after Cloak is ready.
- iOS installed the full-tunnel route first, then started Outline, then started Cloak.

For Cloak profiles, the TOML applier rewrites Outline to connect to `127.0.0.1:1984`. Starting Outline before Cloak is therefore inherently racy. Installing `includeAllNetworks` / full-tunnel routing before Cloak bootstrap also makes iOS depend on best-effort route exclusions and socket behavior. iOS 26 appears stricter here, so bootstrap traffic can be routed into a tunnel that is not usable yet.

The old iOS Cloak export also returned no error. DNS failures, config failures, route failures, or local listener failures were only logged in Go; Swift would set `cloakStarted = true` and continue. That makes the UI and health checks see a started VPN even when the data path never came up.

Finally, Android already disables `logrus.Fatal` from terminating the process. iOS did not. A fatal path in a Go dependency can kill the packet tunnel extension without producing a useful Swift-side failure.

## Validation

- Ran `gofmt` on modified Go files.
- Ran `git diff --check`.
- Tried `go test ./cloak` from `go_module`, but it did not reach compilation because the current module is missing `go.sum` entries for `google.golang.org/grpc`:

```text
google.golang.org/grpc@v1.79.3: missing go.sum entry for go.mod file
```

The iOS CI path regenerates `MyLibrary.xcframework` from `go_module` via `gomobile bind`, so this PR intentionally changes both the Go iOS export signature and the Swift call site together.

## Follow-ups

This PR does not solve the larger architectural risk that iOS finds the utun fd by scanning process file descriptors. A more complete iOS 26 hardening pass should replace that with a supported `NEPacketTunnelFlow` bridge or another explicit interface between Swift and Go.

Other follow-ups worth tracking:
- IPv6/NAT64/CDN-aware upstream bypass handling.
- More deterministic iOS upstream socket protection.
- MTU alignment between `NEPacketTunnelNetworkSettings` and the tun2socks engine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting and automatic cleanup when Cloak startup or connection fails.
  * Prevent iOS app termination from fatal logs by disabling the default exit behavior.
  * Tunnel startup now detects and surfaces Cloak startup failures instead of silently continuing.

* **Chores**
  * TestFlight upload step in CI now runs only for main-branch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->