### PR TITLE
Replace iOS utun scan with packetFlow bridge

### DIFF
--- a/go_module/go.sum
+++ b/go_module/go.sum
@@ -138,6 +138,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
 google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go_module/ios_exports/outline.go
+++ b/go_module/ios_exports/outline.go
@@ -4,13 +4,8 @@ import (
 	"fmt"
 	"go_module/log"
 	"go_module/outline"
-	"os"
 	"runtime/debug"
-
-	"golang.org/x/sys/unix"
 )
-
-const utunControlName = "com.apple.net.utun_control"
 
 var client *outline.OutlineClient
 
@@ -32,7 +27,7 @@ func unsafeToString(v any) string {
 	}
 }
 
-func NewOutlineClient(transportConfig string) (err error) {
+func NewOutlineClient(transportConfig string, tunnelFD int, mtu int) (err error) {
 	defer guardExport("NewOutlineClient")()
 	log.Infof("NewOutlineClient() called")
 
@@ -42,19 +37,14 @@ func NewOutlineClient(transportConfig string) (err error) {
 		}
 	}
 
-	log.Infof("Start fd search")
-
-	fd := GetTunnelFileDescriptor()
-	if fd < 0 {
-		return fmt.Errorf("NewOutlineClient(): utun fd not found")
+	if tunnelFD < 0 {
+		return fmt.Errorf("NewOutlineClient(): invalid tunnel fd %d", tunnelFD)
 	}
 
-	log.Infof("Fd was found, fd = %d", fd)
+	log.Infof("Using tunnel fd=%d mtu=%d", tunnelFD, mtu)
 	log.Infof("Config length=%d", len(transportConfig))
 
-	tunFile := os.NewFile(uintptr(fd), "utun")
-
-	client = outline.NewClient(transportConfig, tunFile)
+	client = outline.NewClientWithFD(transportConfig, tunnelFD, mtu)
 
 	log.Infof("NewOutlineClient() finished")
 	return nil
@@ -90,33 +80,4 @@ func OutlineDisconnect() error {
 
 	log.Infof("OutlineDisconnect() finished")
 	return nil
-}
-
-func GetTunnelFileDescriptor() int {
-	ctlInfo := &unix.CtlInfo{}
-	copy(ctlInfo.Name[:], utunControlName)
-
-	for fd := 0; fd < 1024; fd++ {
-		addr, err := unix.Getpeername(fd)
-		if err != nil {
-			continue
-		}
-
-		addrCTL, ok := addr.(*unix.SockaddrCtl)
-		if !ok {
-			continue
-		}
-
-		if ctlInfo.Id == 0 {
-			if err := unix.IoctlCtlInfo(fd, ctlInfo); err != nil {
-				continue
-			}
-		}
-
-		if addrCTL.ID == ctlInfo.Id {
-			return fd
-		}
-	}
-
-	return -1
 }

--- a/go_module/kotlin_exports/outline.go
+++ b/go_module/kotlin_exports/outline.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"go_module/log"
 	"go_module/outline"
-	"os"
 	"runtime/debug"
 	"sync"
 )
@@ -72,9 +71,7 @@ func NewOutlineClient(config *C.char, fd C.int) {
 
 	log.Infof("Config length=%d", len(goConfig))
 
-	tunFile := os.NewFile(uintptr(goFD), "tun")
-
-	client = outline.NewClient(goConfig, tunFile)
+	client = outline.NewClientWithFD(goConfig, goFD, 0)
 
 	log.Infof("NewOutlineClient() finished")
 }

--- a/go_module/kotlin_exports/sockets.go
+++ b/go_module/kotlin_exports/sockets.go
@@ -7,7 +7,7 @@ import "C"
 import "go_module/tunnel/protected_dialer"
 
 func init() {
-	protected_dialer.MakeSocketProtected = func(fd uintptr) {
-		C.go_protect_socket(C.int(fd))
+	protected_dialer.MakeSocketProtected = func(fd uintptr) bool {
+		return C.go_protect_socket(C.int(fd)) == 1
 	}
 }

--- a/go_module/modules/Cloak/exported_client/protector.go
+++ b/go_module/modules/Cloak/exported_client/protector.go
@@ -1,5 +1,5 @@
-//go:build !android
-// +build !android
+//go:build !android && !ios
+// +build !android,!ios
 
 package exported_client
 

--- a/go_module/modules/Cloak/exported_client/protector_android.go
+++ b/go_module/modules/Cloak/exported_client/protector_android.go
@@ -8,17 +8,24 @@ extern int go_protect_socket(int fd); // Import function from C/JNI layer
 */
 import "C"
 import (
+	"fmt"
 	"go_module/log"
 	"syscall"
 )
 
 func protector(network string, address string, c syscall.RawConn) error {
-	return c.Control(func(fd uintptr) {
+	var protectErr error
+	controlErr := c.Control(func(fd uintptr) {
 		res := C.go_protect_socket(C.int(fd))
 		if res != 1 {
-			log.Infof("Protect failed: go_protect_socket(fd=%d) returned %d for %s %s", fd, res, network, address)
+			protectErr = fmt.Errorf("go_protect_socket(fd=%d) returned %d", fd, res)
+			log.Infof("Protect failed: %v for %s %s", protectErr, network, address)
 		} else {
 			log.Infof("Protect success: fd=%d", fd)
 		}
 	})
+	if controlErr != nil {
+		return controlErr
+	}
+	return protectErr
 }

--- a/go_module/modules/Cloak/exported_client/protector_ios.go
+++ b/go_module/modules/Cloak/exported_client/protector_ios.go
@@ -1,0 +1,32 @@
+//go:build ios
+// +build ios
+
+package exported_client
+
+import (
+	"fmt"
+	"syscall"
+
+	"go_module/log"
+)
+
+const SO_NO_TC_NETPOLICY = 0x1101
+
+func protector(network string, address string, c syscall.RawConn) error {
+	var protectErr error
+	controlErr := c.Control(func(fd uintptr) {
+		protectErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
+		if protectErr != nil {
+			log.Infof("Cloak protect failed: fd=%d network=%s address=%s err=%v", fd, network, address, protectErr)
+			return
+		}
+		log.Infof("Cloak protect success: fd=%d network=%s address=%s", fd, network, address)
+	})
+	if controlErr != nil {
+		return controlErr
+	}
+	if protectErr != nil {
+		return fmt.Errorf("cloak iOS socket protect failed: %w", protectErr)
+	}
+	return nil
+}

--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"time"
 )
 
 type OutlineClient struct {
@@ -47,12 +48,14 @@ func NewClientWithFD(transportConfig string, fd int, mtu int) *OutlineClient {
 		tunFD:  fd,
 		mtu:    mtu,
 	}
-	log.Infof("outline client created (tun2socks version)")
+	log.Infof("outline client created (tun2socks version) fd=%d mtu=%d configLen=%d", fd, mtu, len(transportConfig))
 	common.Client.SetVpnClient(outlineCommon.Name, c)
 	return c
 }
 
 func (c *OutlineClient) Connect() error {
+	start := time.Now()
+	log.Infof("outline client connect begin fd=%d mtu=%d configLen=%d", c.tunFD, c.mtu, len(c.config))
 	defer func() {
 		if r := recover(); r != nil {
 			log.Infof("RECOVERED from fail in Connect: %v", r)
@@ -74,9 +77,11 @@ func (c *OutlineClient) Connect() error {
 	err = unix.SetNonblock(fd, true)
 	if err != nil {
 		log.Infof("Set unix.SetNonblock error: %v", err)
+	} else {
+		log.Infof("[DEBUG][Outline] tun fd set non-blocking fd=%d", fd)
 	}
 
-	log.Infof("starting tun2socks engine with proxy %s", od.GetProxyAddr())
+	log.Infof("starting tun2socks engine with proxy %s fd=%d mtu=%d", od.GetProxyAddr(), fd, c.mtu)
 	err = tunnel.StartEngine(platform_engine.EngineConfig{
 		ProxyAddr:   od.GetProxyAddr(),
 		FD:          fd,
@@ -90,15 +95,18 @@ func (c *OutlineClient) Connect() error {
 	c.engineStarted = true
 
 	common.Client.MarkActive(outlineCommon.Name)
-	log.Infof("outline client connected successfully via tun2socks")
+	log.Infof("outline client connected successfully via tun2socks in %dms", time.Since(start).Milliseconds())
 	return nil
 }
 
 func (c *OutlineClient) Disconnect() error {
+	log.Infof("outline client disconnect begin engineStarted=%v fd=%d deviceNil=%v", c.engineStarted, c.tunFD, c.device == nil)
 	tunnel.StopEngine()
 	if !c.engineStarted && c.tunFD >= 0 {
 		if err := unix.Close(c.tunFD); err != nil {
 			log.Infof("failed to close unused tun fd: %v\n", err)
+		} else {
+			log.Infof("[DEBUG][Outline] closed unused tun fd=%d", c.tunFD)
 		}
 	}
 	c.engineStarted = false

--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -17,15 +17,35 @@ import (
 )
 
 type OutlineClient struct {
-	device *internal.OutlineDevice
-	tun    io.ReadWriteCloser
-	config string
+	device        *internal.OutlineDevice
+	tunFD         int
+	engineStarted bool
+	config        string
+	mtu           int
 }
 
 func NewClient(transportConfig string, tun io.ReadWriteCloser) *OutlineClient {
+	return NewClientWithMTU(transportConfig, tun, 0)
+}
+
+func NewClientWithMTU(transportConfig string, tun io.ReadWriteCloser, mtu int) *OutlineClient {
+	fd := -1
+	if f, ok := tun.(*os.File); ok {
+		fd = int(f.Fd())
+	} else {
+		log.Infof("failed to get FD from tun: not an *os.File")
+	}
+	return NewClientWithFD(transportConfig, fd, mtu)
+}
+
+func NewClientWithFD(transportConfig string, fd int, mtu int) *OutlineClient {
+	if mtu <= 0 {
+		mtu = 1200
+	}
 	c := &OutlineClient{
 		config: transportConfig,
-		tun:    tun,
+		tunFD:  fd,
+		mtu:    mtu,
 	}
 	log.Infof("outline client created (tun2socks version)")
 	common.Client.SetVpnClient(outlineCommon.Name, c)
@@ -47,16 +67,13 @@ func (c *OutlineClient) Connect() error {
 	log.Infof("outline device (SOCKS5 bridge) created")
 	c.device = od
 
-	var fd int
-	if f, ok := c.tun.(*os.File); ok {
-		fd = int(f.Fd())
-		err := unix.SetNonblock(fd, true)
-		if err != nil {
-			log.Infof("Set unix.SetNonblock error: %v", err)
-		}
-	} else {
-		log.Infof("failed to get FD from tun: not an *os.File")
-		return fmt.Errorf("invalid tun device type")
+	fd := c.tunFD
+	if fd < 0 {
+		return fmt.Errorf("invalid tun fd")
+	}
+	err = unix.SetNonblock(fd, true)
+	if err != nil {
+		log.Infof("Set unix.SetNonblock error: %v", err)
 	}
 
 	log.Infof("starting tun2socks engine with proxy %s", od.GetProxyAddr())
@@ -64,11 +81,13 @@ func (c *OutlineClient) Connect() error {
 		ProxyAddr:   od.GetProxyAddr(),
 		FD:          fd,
 		UplinkIface: "",
+		MTU:         c.mtu,
 	})
 	if err != nil {
 		log.Infof("Can't start tun2socks: %v", err)
 		return err
 	}
+	c.engineStarted = true
 
 	common.Client.MarkActive(outlineCommon.Name)
 	log.Infof("outline client connected successfully via tun2socks")
@@ -77,6 +96,13 @@ func (c *OutlineClient) Connect() error {
 
 func (c *OutlineClient) Disconnect() error {
 	tunnel.StopEngine()
+	if !c.engineStarted && c.tunFD >= 0 {
+		if err := unix.Close(c.tunFD); err != nil {
+			log.Infof("failed to close unused tun fd: %v\n", err)
+		}
+	}
+	c.engineStarted = false
+	c.tunFD = -1
 
 	if c.device != nil {
 		if err := c.device.Close(); err != nil {

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -46,7 +46,17 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	}
 
 	hasUDPPath := strings.Contains(transportConfig, "udp_path=")
-	log.Infof("outline client: packetDialer type=%T udpPath=%v", pd, hasUDPPath)
+	hasTCPPath := strings.Contains(transportConfig, "tcp_path=")
+	isWebSocket := strings.Contains(transportConfig, "ws:")
+	log.Infof(
+		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v streamDialer=%T packetDialer=%T",
+		len(transportConfig),
+		isWebSocket,
+		hasTCPPath,
+		hasUDPPath,
+		sd,
+		pd,
+	)
 
 	useCloak := ip.IsLoopback()
 
@@ -101,6 +111,7 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 			return nil, err
 		}
 		log.Infof("[SOCKS5 TCP OK] %s in %dms", addr, elapsed)
+		log.Infof("[DEBUG][SOCKS5 TCP] %s local=%s remote=%s", addr, conn.LocalAddr(), conn.RemoteAddr())
 		return conn, nil
 
 	case "udp":
@@ -118,6 +129,7 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 			return nil, err
 		}
 		log.Infof("[SOCKS5 UDP OK] %s in %dms", addr, elapsed)
+		log.Infof("[DEBUG][SOCKS5 UDP] %s local=%s", addr, conn.LocalAddr())
 		return conn, nil
 	}
 
@@ -198,6 +210,7 @@ func ResolveServerIPFromConfig(transportConfig string) (net.IP, error) {
 	if err != nil {
 		return nil, fmt.Errorf("DNS lookup for %s timed out or failed: %w", host, err)
 	}
+	log.Infof("outline client: DNS returned %d addresses for %s", len(ipList), host)
 
 	for _, ip := range ipList {
 		if v4 := ip.IP.To4(); v4 != nil {

--- a/go_module/tunnel/platform_engine/engine.go
+++ b/go_module/tunnel/platform_engine/engine.go
@@ -23,6 +23,8 @@ func StartPlatformEngine(cfg EngineConfig) error {
 }
 
 func EngineStop() {
+	// engine.Stop() is process-global inside tun2socks; keep this visible in logs
+	// because stale goroutines look like packet-flow stalls on the platform side.
 	stopPlatformEngine()
 	engine.Stop()
 }

--- a/go_module/tunnel/platform_engine/engine.go
+++ b/go_module/tunnel/platform_engine/engine.go
@@ -8,6 +8,14 @@ type EngineConfig struct {
 	ProxyAddr   string
 	FD          int    // Linux / Mobile
 	UplinkIface string // Windows
+	MTU         int
+}
+
+func (c EngineConfig) EffectiveMTU(defaultMTU int) int {
+	if c.MTU > 0 {
+		return c.MTU
+	}
+	return defaultMTU
 }
 
 func StartPlatformEngine(cfg EngineConfig) error {

--- a/go_module/tunnel/platform_engine/engine_fd.go
+++ b/go_module/tunnel/platform_engine/engine_fd.go
@@ -14,8 +14,7 @@ func startPlatformEngine(cfg interface{}) error {
 	c := cfg.(EngineConfig)
 	fd := c.FD
 	proxyAddr := c.ProxyAddr
-
-	const mtu = 1200 // must match NEPacketTunnelNetworkSettings.mtu set in Swift
+	mtu := c.EffectiveMTU(1200)
 
 	log.Infof("[Engine] starting tun2socks fd=%d proxy=%s mtu=%d", fd, proxyAddr, mtu)
 

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -90,6 +90,7 @@ func DialContextWithProtect(ctx context.Context, network, address string) (net.C
 		return nil, err
 	}
 
+	log.Infof("[DEBUG][Protect] TCP dial OK network=%s destination=%s local=%s remote=%s", realNet, address, conn.LocalAddr(), conn.RemoteAddr())
 	return conn, nil
 }
 
@@ -103,15 +104,18 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 		pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 		if err != nil {
+			log.Infof("[Protect] UDP BYPASS loopback listen error network=%s destination=%s: %v", realNet, address, err)
 			return nil, err
 		}
 
 		udpAddr, err := net.ResolveUDPAddr(realNet, address)
 		if err != nil {
 			_ = pc.Close()
+			log.Infof("[Protect] UDP BYPASS loopback resolve error network=%s destination=%s: %v", realNet, address, err)
 			return nil, err
 		}
 
+		log.Infof("[DEBUG][Protect] UDP BYPASS loopback ready network=%s destination=%s local=%s remote=%s", realNet, address, pc.LocalAddr(), udpAddr)
 		return &connectedUDPConn{
 			PacketConn: pc,
 			remoteAddr: udpAddr,
@@ -133,15 +137,18 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 	pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 	if err != nil {
+		log.Infof("[Protect] UDP listen error network=%s destination=%s: %v", realNet, address, err)
 		return nil, err
 	}
 
 	udpAddr, err := net.ResolveUDPAddr(realNet, address)
 	if err != nil {
 		_ = pc.Close()
+		log.Infof("[Protect] UDP resolve error network=%s destination=%s: %v", realNet, address, err)
 		return nil, err
 	}
 
+	log.Infof("[DEBUG][Protect] UDP dial ready network=%s destination=%s local=%s remote=%s", realNet, address, pc.LocalAddr(), udpAddr)
 	return &connectedUDPConn{
 		PacketConn: pc,
 		remoteAddr: udpAddr,

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -2,6 +2,7 @@ package protected_dialer
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"syscall"
 
@@ -49,6 +50,18 @@ func listenAddr(network string) string {
 	return "0.0.0.0:0"
 }
 
+func protectSocket(fd uintptr, realNet string, destination string) error {
+	if protector == nil {
+		return fmt.Errorf("no socket protector registered")
+	}
+	if err := protector.Protect(fd, realNet); err != nil {
+		log.Infof("[Protect] %s fd=%d destination=%s failed: %v", realNet, fd, destination, err)
+		return err
+	}
+	log.Infof("[Protect] %s fd=%d destination=%s OK", realNet, fd, destination)
+	return nil
+}
+
 func DialContextWithProtect(ctx context.Context, network, address string) (net.Conn, error) {
 	realNet := normalizeTCP(address)
 
@@ -59,12 +72,15 @@ func DialContextWithProtect(ctx context.Context, network, address string) (net.C
 	}
 
 	d := &net.Dialer{
-		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				if protector != nil {
-					protector.Protect(fd, realNet)
-				}
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var protectErr error
+			controlErr := c.Control(func(fd uintptr) {
+				protectErr = protectSocket(fd, realNet, address)
 			})
+			if controlErr != nil {
+				return controlErr
+			}
+			return protectErr
 		},
 	}
 
@@ -103,12 +119,15 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 	}
 
 	lc := net.ListenConfig{
-		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				if protector != nil {
-					protector.Protect(fd, realNet)
-				}
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var protectErr error
+			controlErr := c.Control(func(fd uintptr) {
+				protectErr = protectSocket(fd, realNet, address)
 			})
+			if controlErr != nil {
+				return controlErr
+			}
+			return protectErr
 		},
 	}
 

--- a/go_module/tunnel/protected_dialer/platform.go
+++ b/go_module/tunnel/protected_dialer/platform.go
@@ -1,7 +1,7 @@
 package protected_dialer
 
 type platformProtector interface {
-	Protect(fd uintptr, network string)
+	Protect(fd uintptr, network string) error
 }
 
 var protector platformProtector

--- a/go_module/tunnel/protected_dialer/protect_android.go
+++ b/go_module/tunnel/protected_dialer/protect_android.go
@@ -2,14 +2,20 @@
 
 package protected_dialer
 
-var MakeSocketProtected func(fd uintptr)
+import "fmt"
+
+var MakeSocketProtected func(fd uintptr) bool
 
 type androidProtector struct{}
 
-func (a *androidProtector) Protect(fd uintptr, network string) {
-	if MakeSocketProtected != nil {
-		MakeSocketProtected(fd)
+func (a *androidProtector) Protect(fd uintptr, network string) error {
+	if MakeSocketProtected == nil {
+		return fmt.Errorf("android socket protector is not registered")
 	}
+	if !MakeSocketProtected(fd) {
+		return fmt.Errorf("android VpnService.protect(%d) returned false", fd)
+	}
+	return nil
 }
 
 func init() {

--- a/go_module/tunnel/protected_dialer/protect_ios.go
+++ b/go_module/tunnel/protected_dialer/protect_ios.go
@@ -6,8 +6,8 @@ const SO_NO_TC_NETPOLICY = 0x1101
 
 type iosProtector struct{}
 
-func (i *iosProtector) Protect(fd uintptr, network string) {
-	_ = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
+func (i *iosProtector) Protect(fd uintptr, network string) error {
+	return syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
 }
 
 func init() {

--- a/go_module/tunnel/protected_dialer/protect_linux.go
+++ b/go_module/tunnel/protected_dialer/protect_linux.go
@@ -19,17 +19,18 @@ func SetLinuxSocketMark(mark int) {
 
 type linuxProtector struct{}
 
-func (l *linuxProtector) Protect(fdU uintptr, network string) {
+func (l *linuxProtector) Protect(fdU uintptr, network string) error {
 	if linuxSocketMark == 0 {
-		return
+		return nil
 	}
 
 	fd, err := UintptrToInt(fdU)
 	if err != nil {
 		log.Infof("[Linux-Protect] Protect fd err=%v", err)
+		return err
 	}
 
-	_ = syscall.SetsockoptInt(
+	return syscall.SetsockoptInt(
 		fd,
 		syscall.SOL_SOCKET,
 		syscall.SO_MARK,

--- a/go_module/tunnel/protected_dialer/protect_macos.go
+++ b/go_module/tunnel/protected_dialer/protect_macos.go
@@ -85,17 +85,18 @@ func SetDefaultInterface(idx int) {
 
 type macosProtector struct{}
 
-func (m *macosProtector) Protect(fd uintptr, network string) {
+func (m *macosProtector) Protect(fd uintptr, network string) error {
 	if defaultInterfaceIndex == 0 {
-		return
+		return nil
 	}
 
 	switch network {
 	case "tcp4", "udp4":
-		_ = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, IP_BOUND_IF, defaultInterfaceIndex)
+		return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, IP_BOUND_IF, defaultInterfaceIndex)
 	case "tcp6", "udp6":
-		_ = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, IPV6_BOUND_IF, defaultInterfaceIndex)
+		return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, IPV6_BOUND_IF, defaultInterfaceIndex)
 	}
+	return nil
 }
 
 func init() {

--- a/go_module/tunnel/protected_dialer/protect_windows.go
+++ b/go_module/tunnel/protected_dialer/protect_windows.go
@@ -38,21 +38,22 @@ func SetDefaultInterfaceIndex(idx int) {
 
 type windowsProtector struct{}
 
-func (w *windowsProtector) Protect(fd uintptr, network string) {
+func (w *windowsProtector) Protect(fd uintptr, network string) error {
 	if defaultInterfaceIndex == 0 {
-		return
+		return nil
 	}
 
 	switch network {
 	case "tcp4", "udp4":
 		const IP_UNICAST_IF = 31
 		idx := htonl(uint32(defaultInterfaceIndex))
-		_ = syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx))
+		return syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx))
 
 	case "tcp6", "udp6":
 		const IPV6_UNICAST_IF = 31
-		_ = syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, defaultInterfaceIndex)
+		return syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, defaultInterfaceIndex)
 	}
+	return nil
 }
 
 func htonl(i uint32) uint32 {

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -111,7 +111,13 @@ type DobbyProxy struct {
 
 func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net.Conn, error) {
 	if IsBypass(metadata) {
-		return p.direct.DialContext(ctx, metadata)
+		conn, err := p.direct.DialContext(ctx, metadata)
+		if err != nil {
+			log.Infof("[Router] BYPASS TCP dial error %s: %v", metadata.DestinationAddress(), err)
+			return nil, err
+		}
+		log.Infof("[DEBUG][Router] BYPASS TCP dial OK %s local=%s remote=%s", metadata.DestinationAddress(), conn.LocalAddr(), conn.RemoteAddr())
+		return conn, nil
 	}
 
 	// Increment first, then check — prevents TOCTOU race where multiple goroutines
@@ -126,6 +132,7 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 	conn, err := p.vpn.DialContext(ctx, metadata)
 	if err != nil {
 		p.activeTCP.Add(-1)
+		log.Infof("[Router] PROXY TCP dial error %s: %v", metadata.DestinationAddress(), err)
 		return nil, err
 	}
 
@@ -137,7 +144,13 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 
 func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 	if IsBypass(metadata) {
-		return p.direct.DialUDP(metadata)
+		conn, err := p.direct.DialUDP(metadata)
+		if err != nil {
+			log.Infof("[Router] BYPASS UDP dial error %s: %v", metadata.DestinationAddress(), err)
+			return nil, err
+		}
+		log.Infof("[DEBUG][Router] BYPASS UDP dial OK %s local=%s", metadata.DestinationAddress(), conn.LocalAddr())
+		return conn, nil
 	}
 
 	active := p.activeUDP.Add(1)
@@ -150,6 +163,7 @@ func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 	conn, err := p.vpn.DialUDP(metadata)
 	if err != nil {
 		p.activeUDP.Add(-1)
+		log.Infof("[Router] PROXY UDP dial error %s: %v", metadata.DestinationAddress(), err)
 		return nil, err
 	}
 
@@ -168,8 +182,10 @@ func (p *DobbyProxy) Proto() proto.Proto {
 }
 
 func stopLocked() {
+	log.Infof("[Engine] stopping tun2socks engine")
 	platform_engine.EngineStop()
 	isRunning = false
+	log.Infof("[Engine] tun2socks engine stopped")
 }
 
 func StartEngine(cfg platform_engine.EngineConfig) error {
@@ -177,9 +193,11 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 	defer mu.Unlock()
 
 	if isRunning {
+		log.Infof("[Engine] StartEngine requested while already running; stopping previous engine first")
 		stopLocked()
 	}
 
+	log.Infof("[Engine] StartEngine config proxy=%s fd=%d mtu=%d uplinkIface=%s", cfg.ProxyAddr, cfg.FD, cfg.MTU, cfg.UplinkIface)
 	log.Infof("[Engine] StartEngine: calling StartPlatformEngine")
 	err := platform_engine.StartPlatformEngine(cfg)
 	if err != nil {
@@ -222,6 +240,7 @@ func StopEngine() {
 	defer mu.Unlock()
 
 	if !isRunning {
+		log.Infof("[Engine] StopEngine skipped: not running")
 		return
 	}
 

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -31,6 +31,7 @@ class HealthCheckManager(
     private var consecutiveFailuresCount: Int = 0
     private var lastVpnStartMark: TimeMark? = null
     private var lastFullConnectionSucceed = false
+    private var healthTickId = 0
 
     suspend fun startHealthCheck(address: String, port: Int) {
         logger.log("[HC] startHealthCheck() called")
@@ -66,15 +67,24 @@ class HealthCheckManager(
 
             while (isActive) {
                 var nextDelay: Duration? = null
+                val tickId = ++healthTickId
+                logger.log(
+                    "[HC] tick#$tickId begin " +
+                        "lastFullConnectionSucceed=$lastFullConnectionSucceed " +
+                        "consecutiveFailuresCount=$consecutiveFailuresCount"
+                )
 
                 if (configsRepository.getIsUserInitStop()) {
-                    logger.log("[HC] Stop condition: getIsUserInitStop() == true → exiting health check loop")
+                    logger.log(
+                        "[HC] tick#$tickId stop condition: " +
+                            "getIsUserInitStop() == true → exiting health check loop"
+                    )
                     resetHealthCheckState()
                     return@launch
                 }
 
                 if (mainViewModel.connectionStateRepository.vpnTransitioningFlow.value) {
-                    logger.log("[HC] VPN is transitioning → skipping checks for this tick")
+                    logger.log("[HC] tick#$tickId VPN is transitioning → skipping checks for this tick")
                     nextDelay = getHealthCheckDelay()
                     logger.log("[HC] Next tick in $nextDelay")
                     delay(nextDelay)
@@ -82,17 +92,22 @@ class HealthCheckManager(
                 }
 
                 val connected = try {
-                    val result = isConnected()
-                    logger.log("[HC] isConnected() result = $result")
+                    val result = isConnected(tickId)
+                    logger.log("[HC] tick#$tickId isConnected() result = $result")
                     result
                 } catch (t: Throwable) {
-                    logger.log("[HC] isConnected() threw exception: ${t.message}")
+                    logger.log("[HC] tick#$tickId isConnected() threw exception: ${t.message}")
                     false
                 }
 
-                var vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
+                if (!isActive) {
+                    logger.log("[HC] tick#$tickId result ignored because health job was cancelled")
+                    return@launch
+                }
+
+                val vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
                 if (!vpnStarted) {
-                    logger.log("[HC] vpnStarted=false → exiting health check loop")
+                    logger.log("[HC] tick#$tickId vpnStarted=false → exiting health check loop")
                     resetHealthCheckState()
                     return@launch
                 }
@@ -107,7 +122,10 @@ class HealthCheckManager(
                     val sinceStartMs = (lastVpnStartMark?.elapsedNow()?.inWholeMilliseconds)
                         ?: Long.MAX_VALUE
                     if (sinceStartMs < gracePeriodMs) {
-                        logger.log("[HC] Not connected during grace period (${sinceStartMs}ms < ${gracePeriodMs}ms) → ignore")
+                        logger.log(
+                            "[HC] Not connected during grace period " +
+                                "(${sinceStartMs}ms < ${gracePeriodMs}ms) → ignore"
+                        )
                         nextDelay = getHealthCheckDelay()
                     }
 
@@ -176,6 +194,7 @@ class HealthCheckManager(
         consecutiveFailuresCount = 0
         lastVpnStartMark = null
         lastFullConnectionSucceed = false
+        healthTickId = 0
     }
 
     suspend fun turnOffVpn() {
@@ -185,14 +204,17 @@ class HealthCheckManager(
         mainViewModel.stopVpnService()
     }
 
-    private fun isConnected(): Boolean {
+    private fun isConnected(tickId: Int): Boolean {
         var result = false
         if (lastFullConnectionSucceed) {
+            logger.log("[HC] tick#$tickId using shortConnectionCheckUp() first")
             result = healthCheck.shortConnectionCheckUp()
         }
         if (!result) {
+            logger.log("[HC] tick#$tickId using fullConnectionCheckUp()")
             result = healthCheck.fullConnectionCheckUp()
             lastFullConnectionSucceed = result
+            logger.log("[HC] tick#$tickId fullConnectionCheckUp() result=$result")
         }
         return result
     }

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -62,9 +62,12 @@ public final class HealthCheckImpl: HealthCheck {
 
     public private(set) var currentMemmoryUsageMb = 0.0
     private var lastMemoryMB: Double = 0
+    private var checkSequence: Int = 0
+    private let checkSequenceLock = NSLock()
 
     public func shortConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "Start shortConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "short")
+        logs.writeLog(log: "[HC] Start shortConnectionCheckUp id=\(checkId)")
 
         let checks: [(String, () -> Bool)] = [
             ("HTTP https://google.com/gen_204", {
@@ -99,12 +102,16 @@ public final class HealthCheckImpl: HealthCheck {
         }
 
         let result = vpnOk && networkOk && heartbeatOk
-        logs.writeLog(log: "End shortConnectionCheckUp => \(result)")
+        logs.writeLog(
+            log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) " +
+            "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk))"
+        )
         return result
     }
 
     public func fullConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "[HC] Start fullConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "full")
+        logs.writeLog(log: "[HC] Start fullConnectionCheckUp id=\(checkId)")
 
         // --- Standard check groups ---
         let groups: [(String, [(String, () -> Bool)])] = [
@@ -113,8 +120,8 @@ public final class HealthCheckImpl: HealthCheck {
                 ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
             ]),
             ("DNS Resolve group", [
-                ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") != "Timeout" }),
-                ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") != "Timeout" })
+                ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") }),
+                ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") })
             ]),
             ("DNS Ping group", [
                 ("Ping google.com (DNS)", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
@@ -170,7 +177,7 @@ public final class HealthCheckImpl: HealthCheck {
                      failedGroups.joined(separator: ", ")
             )
         }
-        logs.writeLog(log: "[HC] RESULT = \(result)")
+        logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result)")
 
         // --- DIAGNOSIS — single line with actionable verdict ---
         let tcpProxyOk = groupResults["TCP Ping group"] ?? false
@@ -186,6 +193,14 @@ public final class HealthCheckImpl: HealthCheck {
         )
 
         return result
+    }
+
+    private func nextCheckId(prefix: String) -> String {
+        checkSequenceLock.lock()
+        checkSequence += 1
+        let value = checkSequence
+        checkSequenceLock.unlock()
+        return "\(prefix)-\(value)"
     }
 
     private func logDiagnosis(
@@ -266,8 +281,8 @@ public final class HealthCheckImpl: HealthCheck {
         return value
     }
 
-    private func resolveDNSWithTimeout(host: String) -> String? {
-        var result: String?
+    private func resolveDNSWithTimeout(host: String) -> Bool {
+        var result: (ok: Bool, message: String)?
         let group = DispatchGroup()
         group.enter()
 
@@ -278,14 +293,15 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
-            logs.writeLog(log: "[HC] [DNS] \(host) → Timeout")
-            return "Timeout"
+            logs.writeLog(log: "[HC] [DNS] \(host) FAILED: timeout after \(Int(timeout * 1000))ms")
+            return false
         }
-        logs.writeLog(log: "[HC] [DNS] \(host) → \(result ?? "nil")")
-        return result
+        let value = result ?? (false, "nil result")
+        logs.writeLog(log: "[HC] [DNS] \(host) \(value.ok ? "OK" : "FAILED"): \(value.message)")
+        return value.ok
     }
 
-    private func resolveDNS(host: String) -> String {
+    private func resolveDNS(host: String) -> (ok: Bool, message: String) {
         var hints = addrinfo(
             ai_flags: AI_PASSIVE,
             ai_family: AF_UNSPEC,
@@ -301,7 +317,7 @@ public final class HealthCheckImpl: HealthCheck {
         let status = getaddrinfo(host, nil, &hints, &infoPointer)
 
         guard status == 0, let first = infoPointer else {
-            return String(cString: gai_strerror(status))
+            return (false, String(cString: gai_strerror(status)))
         }
 
         defer { freeaddrinfo(infoPointer) }
@@ -318,12 +334,12 @@ public final class HealthCheckImpl: HealthCheck {
                 0,
                 NI_NUMERICHOST
             ) == 0 {
-                return String(cString: buffer)
+                return (true, String(cString: buffer))
             }
             ptr = current.pointee.ai_next
         }
 
-        return "Can't resolve DNS"
+        return (false, "Can't resolve DNS")
     }
 
     private func httpPing(urlString: String) -> Bool {
@@ -344,6 +360,10 @@ public final class HealthCheckImpl: HealthCheck {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = timeout
         config.timeoutIntervalForResource = timeout
+        logs.writeLog(
+            log: "[DEBUG][HC] [httpPing] start url=\(urlString) timeoutMs=\(Int(timeout * 1000)) " +
+            "cachePolicy=reloadIgnoringLocalCacheData"
+        )
         let delegate = HttpMetricsDelegate(url: urlString) { [weak self] msg in
             self?.logs.writeLog(log: msg)
         }
@@ -369,6 +389,7 @@ public final class HealthCheckImpl: HealthCheck {
                     log: "[HC] [httpPing] \(urlString) no HTTP response in \(elapsed)ms"
                 )
             }
+            session.finishTasksAndInvalidate()
             semaphore.signal()
         }
         task.resume()

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -94,6 +94,7 @@ public class VpnManagerImpl: VpnManager {
     public func start() {
         self.logs.writeLog(log: "call start")
         self.logs.writeLog(log: "Routing table without vpn:")
+        self.logs.writeLog(log: "[DEBUG][VPNManager] start requested launchId=\(Self.launchId)")
         getOrCreateManager { manager, _ in
             self.handleStart(manager: manager)
         }
@@ -105,6 +106,7 @@ public class VpnManagerImpl: VpnManager {
             return
         }
         let status = manager.connection.status
+        self.logs.writeLog(log: "[DEBUG][VPNManager] handleStart currentStatus=\(status.rawValue)")
         if status == .connecting || status == .disconnecting || status == .reasserting {
             self.logs.writeLog(log: "[start] Skip: connection is transitioning (\(status.rawValue))")
             self.updateTransitionState(for: status)
@@ -144,7 +146,7 @@ public class VpnManagerImpl: VpnManager {
             self.logs.writeLog(log: "[stop] Skip: vpnManager is nil")
             return
         }
-        self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel()")
+        self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel() currentStatus=\(manager.connection.status.rawValue)")
         connectionRepository.tryUpdateVpnTransitioning(isTransitioning: true)
         stopInitiatedByUser = true
         manager.connection.stopVPNTunnel()
@@ -152,8 +154,15 @@ public class VpnManagerImpl: VpnManager {
     }
 
     private func getOrCreateManager(completion: @escaping (NETunnelProviderManager?, Error?) -> Void) {
+        logs.writeLog(log: "[DEBUG][VPNManager] loadAllFromPreferences begin")
         NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
             guard let self else { return }
+
+            if let error {
+                self.logs.writeLog(log: "[VPNManager] loadAllFromPreferences error: \(error.localizedDescription)")
+            } else {
+                self.logs.writeLog(log: "[DEBUG][VPNManager] loadAllFromPreferences managers=\(managers?.count ?? -1)")
+            }
 
             if let existingManager = managers?.first(where: { $0.localizedDescription == Self.dobbyName }) {
                 vpnManager = existingManager

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -46,8 +46,12 @@ public final class CloakInteractor {
 
     func stopCloak() {
         if cloakStarted {
+            logs.writeLog(log: "stopCloak: stopping Cloak client")
             Cloak_outlineStopCloakClient()
             cloakStarted = false
+            logs.writeLog(log: "stopCloak: Cloak client stopped")
+        } else {
+            logs.writeLog(log: "[DEBUG] stopCloak: skipped, cloakStarted=false")
         }
     }
 }

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -10,7 +10,11 @@ import Network
 public final class OutlineInteractor {
     private var logs = NativeModuleHolder.logsRepository
 
-    func startOutline() throws {
+    func startOutline(
+        tunnelFileDescriptor: Int32,
+        mtu: Int,
+        nativeClientCreated: () -> Void
+    ) throws {
         
         let methodPassword = configsRepository.getMethodPasswordOutline()
         let serverPort = configsRepository.getServerPortOutline()
@@ -45,10 +49,11 @@ public final class OutlineInteractor {
         
         var err: NSError?
 
-        Cloak_outlineNewOutlineClient(config, &err)
+        Cloak_outlineNewOutlineClient(config, Int(tunnelFileDescriptor), mtu, &err)
         if let error = err {
             throw error
         }
+        nativeClientCreated()
 
         Cloak_outlineOutlineConnect(&err)
         if let error = err {

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -22,7 +22,11 @@ public final class OutlineInteractor {
         let websocketEnabled = configsRepository.getIsWebsocketEnabled()
         let tcpPath = configsRepository.getTcpPathOutline()
         let udpPath = configsRepository.getUdpPathOutline()
-        logs.writeLog(log: "Config snapshot: serverPort.len=\(serverPort.count) methodPassword.len=\(methodPassword.count) ws=\(websocketEnabled) tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count)")
+        logs.writeLog(
+            log: "Config snapshot: serverPort.len=\(serverPort.count) methodPassword.len=\(methodPassword.count) " +
+            "ws=\(websocketEnabled) tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count) " +
+            "tunnelFD=\(tunnelFileDescriptor) mtu=\(mtu)"
+        )
 
         // Validate config early (prevents passing empty config into native layer).
         if methodPassword.isEmpty || serverPort.isEmpty {
@@ -49,25 +53,33 @@ public final class OutlineInteractor {
         
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native NewOutlineClient fd=\(tunnelFileDescriptor) mtu=\(mtu)")
         Cloak_outlineNewOutlineClient(config, Int(tunnelFileDescriptor), mtu, &err)
         if let error = err {
+            logs.writeLog(log: "[Outline] NewOutlineClient failed: \(error.localizedDescription)")
             throw error
         }
         nativeClientCreated()
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineConnect")
         Cloak_outlineOutlineConnect(&err)
         if let error = err {
+            logs.writeLog(log: "[Outline] OutlineConnect failed: \(error.localizedDescription)")
             throw error
         }
+        logs.writeLog(log: "[Outline] OutlineConnect succeeded")
     }
 
     func stopOutline() throws {
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineDisconnect")
         Cloak_outlineOutlineDisconnect(&err)
         if let error = err {
+            logs.writeLog(log: "[Outline] OutlineDisconnect failed: \(error.localizedDescription)")
             throw error
         }
+        logs.writeLog(log: "[DEBUG][Outline] OutlineDisconnect returned")
     }
     
     func buildOutlineConfig(

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -11,11 +11,23 @@ final class PacketFlowBridge {
     private let utunHeaderLength = 4
 
     private var readSource: DispatchSourceRead?
+    private var statsTimer: DispatchSourceTimer?
     private var swiftFileDescriptor: Int32 = -1
     private var goFileDescriptor: Int32 = -1
     private var running = false
     private var writeErrorCount = 0
     private var readErrorCount = 0
+    private var oversizedPacketCount = 0
+    private var tunnelReadBatches = 0
+    private var tunnelReadEmptyBatches = 0
+    private var tunnelToGoPackets = 0
+    private var tunnelToGoBytes = 0
+    private var goToTunnelPackets = 0
+    private var goToTunnelBytes = 0
+    private var tunnelToGoDrops = 0
+    private var goToTunnelDrops = 0
+    private var firstTunnelPacketLogged = false
+    private var firstGoPacketLogged = false
 
     var tunnelFileDescriptor: Int32 {
         lock.lock()
@@ -25,8 +37,10 @@ final class PacketFlowBridge {
 
     func releaseTunnelFileDescriptor() {
         lock.lock()
-        defer { lock.unlock() }
+        let releasedFD = goFileDescriptor
         goFileDescriptor = -1
+        lock.unlock()
+        log("[DEBUG][PacketFlowBridge] Go fd ownership released fd=\(releasedFD)")
     }
 
     init(packetFlow: NEPacketTunnelFlow, mtu: Int, tunnelId: String, log: @escaping (String) -> Void) throws {
@@ -56,6 +70,8 @@ final class PacketFlowBridge {
             closeIfOpen(&goFileDescriptor)
             throw error
         }
+
+        log("[DEBUG][PacketFlowBridge] socketpair ready swiftFD=\(swiftFileDescriptor) goFD=\(goFileDescriptor) mtu=\(mtu)")
     }
 
     func start() {
@@ -81,8 +97,9 @@ final class PacketFlowBridge {
         lock.unlock()
 
         source.resume()
+        startStatsTimer()
         readPacketsFromTunnel()
-        log("[PacketFlowBridge] started mtu=\(mtu)")
+        log("[PacketFlowBridge] started mtu=\(mtu) swiftFD=\(sourceFD) goFD=\(tunnelFileDescriptor)")
     }
 
     func stop() {
@@ -94,6 +111,8 @@ final class PacketFlowBridge {
         running = false
         let source = readSource
         readSource = nil
+        let timer = statsTimer
+        statsTimer = nil
         let shouldCloseSwiftFD = source == nil
         let swiftFD = swiftFileDescriptor
         swiftFileDescriptor = -1
@@ -101,6 +120,8 @@ final class PacketFlowBridge {
         goFileDescriptor = -1
         lock.unlock()
 
+        logStats(reason: "stop")
+        timer?.cancel()
         source?.cancel()
         if shouldCloseSwiftFD, swiftFD >= 0 {
             close(swiftFD)
@@ -112,11 +133,12 @@ final class PacketFlowBridge {
     }
 
     private func readPacketsFromTunnel() {
-        packetFlow.readPackets { [weak self] packets, _ in
+        packetFlow.readPackets { [weak self] packets, protocols in
             guard let self, self.isRunning else {
                 return
             }
 
+            self.recordTunnelReadBatch(packetCount: packets.count, protocolCount: protocols.count)
             for packet in packets where !packet.isEmpty {
                 self.writePacketToGo(packet)
             }
@@ -131,6 +153,10 @@ final class PacketFlowBridge {
             return
         }
 
+        if packet.count > mtu {
+            logOversizedPacket(packet.count)
+        }
+
         let framedPacket = utunFramedPacket(packet)
         let written = framedPacket.withUnsafeBytes { rawBuffer -> Int in
             guard let baseAddress = rawBuffer.baseAddress else {
@@ -140,8 +166,14 @@ final class PacketFlowBridge {
         }
 
         if written != framedPacket.count {
-            logWriteError("write packet to Go failed written=\(written) errno=\(errno)")
+            recordTunnelToGoDrop()
+            logWriteError(
+                "write packet to Go failed packetBytes=\(packet.count) framedBytes=\(framedPacket.count) " +
+                "written=\(written) errno=\(errno) \(errnoDescription())"
+            )
+            return
         }
+        recordTunnelToGo(packetBytes: packet.count)
     }
 
     private func drainPacketsFromGo() {
@@ -161,11 +193,13 @@ final class PacketFlowBridge {
 
             if readCount > 0 {
                 guard readCount > utunHeaderLength else {
+                    recordGoToTunnelDrop()
                     logReadError("short packet from Go readCount=\(readCount)")
                     continue
                 }
                 let packet = Data(buffer[utunHeaderLength..<readCount])
                 packetFlow.writePackets([packet], withProtocols: [protocolFamily(for: packet)])
+                recordGoToTunnel(packetBytes: packet.count)
                 continue
             }
 
@@ -177,9 +211,111 @@ final class PacketFlowBridge {
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 return
             }
-            logReadError("read packet from Go failed errno=\(errno)")
+            logReadError("read packet from Go failed errno=\(errno) \(errnoDescription())")
             return
         }
+    }
+
+    private func startStatsTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: readQueue)
+        timer.schedule(deadline: .now() + 5, repeating: 5)
+        timer.setEventHandler { [weak self] in
+            self?.logStats(reason: "periodic")
+        }
+
+        lock.lock()
+        statsTimer = timer
+        lock.unlock()
+        timer.resume()
+    }
+
+    private func recordTunnelReadBatch(packetCount: Int, protocolCount: Int) {
+        lock.lock()
+        tunnelReadBatches += 1
+        if packetCount == 0 {
+            tunnelReadEmptyBatches += 1
+        }
+        let shouldLogProtocolMismatch = packetCount != protocolCount && tunnelReadBatches <= 5
+        lock.unlock()
+
+        if shouldLogProtocolMismatch {
+            log(
+                "[DEBUG][PacketFlowBridge] packetFlow read protocol count mismatch " +
+                "packets=\(packetCount) protocols=\(protocolCount)"
+            )
+        }
+    }
+
+    private func recordTunnelToGo(packetBytes: Int) {
+        lock.lock()
+        tunnelToGoPackets += 1
+        tunnelToGoBytes += packetBytes
+        let shouldLogFirst = !firstTunnelPacketLogged
+        firstTunnelPacketLogged = true
+        lock.unlock()
+
+        if shouldLogFirst {
+            log("[DEBUG][PacketFlowBridge] first packet tunnel->go bytes=\(packetBytes)")
+        }
+    }
+
+    private func recordGoToTunnel(packetBytes: Int) {
+        lock.lock()
+        goToTunnelPackets += 1
+        goToTunnelBytes += packetBytes
+        let shouldLogFirst = !firstGoPacketLogged
+        firstGoPacketLogged = true
+        lock.unlock()
+
+        if shouldLogFirst {
+            log("[DEBUG][PacketFlowBridge] first packet go->tunnel bytes=\(packetBytes)")
+        }
+    }
+
+    private func recordTunnelToGoDrop() {
+        lock.lock()
+        tunnelToGoDrops += 1
+        lock.unlock()
+    }
+
+    private func recordGoToTunnelDrop() {
+        lock.lock()
+        goToTunnelDrops += 1
+        lock.unlock()
+    }
+
+    private func logOversizedPacket(_ packetBytes: Int) {
+        lock.lock()
+        oversizedPacketCount += 1
+        let shouldLog = oversizedPacketCount <= 5 || oversizedPacketCount % 100 == 0
+        lock.unlock()
+
+        if shouldLog {
+            log("[DEBUG][PacketFlowBridge] packet larger than configured MTU packetBytes=\(packetBytes) mtu=\(mtu)")
+        }
+    }
+
+    private func logStats(reason: String) {
+        lock.lock()
+        let batches = tunnelReadBatches
+        let emptyBatches = tunnelReadEmptyBatches
+        let t2gPackets = tunnelToGoPackets
+        let t2gBytes = tunnelToGoBytes
+        let g2tPackets = goToTunnelPackets
+        let g2tBytes = goToTunnelBytes
+        let t2gDrops = tunnelToGoDrops
+        let g2tDrops = goToTunnelDrops
+        let oversized = oversizedPacketCount
+        let isActive = running
+        lock.unlock()
+
+        log(
+            "[DEBUG][PacketFlowBridge] stats reason=\(reason) running=\(isActive) " +
+            "batches=\(batches) emptyBatches=\(emptyBatches) " +
+            "tunnel_to_go=\(t2gPackets)p/\(t2gBytes)B " +
+            "go_to_tunnel=\(g2tPackets)p/\(g2tBytes)B " +
+            "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) oversized=\(oversized)"
+        )
     }
 
     private var isRunning: Bool {
@@ -230,6 +366,10 @@ final class PacketFlowBridge {
         if shouldLog {
             log("[PacketFlowBridge] \(message)")
         }
+    }
+
+    private func errnoDescription() -> String {
+        String(cString: strerror(errno))
     }
 
     private func setNonBlocking(_ fd: Int32) throws {

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -1,0 +1,265 @@
+import Darwin
+import Foundation
+import NetworkExtension
+
+final class PacketFlowBridge {
+    private let packetFlow: NEPacketTunnelFlow
+    private let mtu: Int
+    private let log: (String) -> Void
+    private let readQueue: DispatchQueue
+    private let lock = NSLock()
+    private let utunHeaderLength = 4
+
+    private var readSource: DispatchSourceRead?
+    private var swiftFileDescriptor: Int32 = -1
+    private var goFileDescriptor: Int32 = -1
+    private var running = false
+    private var writeErrorCount = 0
+    private var readErrorCount = 0
+
+    var tunnelFileDescriptor: Int32 {
+        lock.lock()
+        defer { lock.unlock() }
+        return goFileDescriptor
+    }
+
+    func releaseTunnelFileDescriptor() {
+        lock.lock()
+        defer { lock.unlock() }
+        goFileDescriptor = -1
+    }
+
+    init(packetFlow: NEPacketTunnelFlow, mtu: Int, tunnelId: String, log: @escaping (String) -> Void) throws {
+        self.packetFlow = packetFlow
+        self.mtu = mtu
+        self.log = log
+        self.readQueue = DispatchQueue(label: "vpn.dobby.app.packetflow.\(tunnelId)")
+
+        var descriptors: [Int32] = [-1, -1]
+        let rc = descriptors.withUnsafeMutableBufferPointer { buffer in
+            socketpair(AF_UNIX, SOCK_DGRAM, 0, buffer.baseAddress)
+        }
+        guard rc == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        swiftFileDescriptor = descriptors[0]
+        goFileDescriptor = descriptors[1]
+
+        do {
+            try disableSigpipe(swiftFileDescriptor)
+            try disableSigpipe(goFileDescriptor)
+            try setNonBlocking(swiftFileDescriptor)
+            try setNonBlocking(goFileDescriptor)
+        } catch {
+            closeIfOpen(&swiftFileDescriptor)
+            closeIfOpen(&goFileDescriptor)
+            throw error
+        }
+    }
+
+    func start() {
+        lock.lock()
+        guard !running, swiftFileDescriptor >= 0, goFileDescriptor >= 0 else {
+            lock.unlock()
+            return
+        }
+        running = true
+        let sourceFD = swiftFileDescriptor
+        lock.unlock()
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: sourceFD, queue: readQueue)
+        source.setEventHandler { [weak self] in
+            self?.drainPacketsFromGo()
+        }
+        source.setCancelHandler {
+            close(sourceFD)
+        }
+
+        lock.lock()
+        readSource = source
+        lock.unlock()
+
+        source.resume()
+        readPacketsFromTunnel()
+        log("[PacketFlowBridge] started mtu=\(mtu)")
+    }
+
+    func stop() {
+        lock.lock()
+        guard running || swiftFileDescriptor >= 0 || goFileDescriptor >= 0 else {
+            lock.unlock()
+            return
+        }
+        running = false
+        let source = readSource
+        readSource = nil
+        let shouldCloseSwiftFD = source == nil
+        let swiftFD = swiftFileDescriptor
+        swiftFileDescriptor = -1
+        let unreleasedGoFD = goFileDescriptor
+        goFileDescriptor = -1
+        lock.unlock()
+
+        source?.cancel()
+        if shouldCloseSwiftFD, swiftFD >= 0 {
+            close(swiftFD)
+        }
+        if unreleasedGoFD >= 0 {
+            close(unreleasedGoFD)
+        }
+        log("[PacketFlowBridge] stopped")
+    }
+
+    private func readPacketsFromTunnel() {
+        packetFlow.readPackets { [weak self] packets, _ in
+            guard let self, self.isRunning else {
+                return
+            }
+
+            for packet in packets where !packet.isEmpty {
+                self.writePacketToGo(packet)
+            }
+
+            self.readPacketsFromTunnel()
+        }
+    }
+
+    private func writePacketToGo(_ packet: Data) {
+        let fd = currentSwiftFileDescriptor()
+        guard fd >= 0 else {
+            return
+        }
+
+        let framedPacket = utunFramedPacket(packet)
+        let written = framedPacket.withUnsafeBytes { rawBuffer -> Int in
+            guard let baseAddress = rawBuffer.baseAddress else {
+                return -1
+            }
+            return Darwin.write(fd, baseAddress, framedPacket.count)
+        }
+
+        if written != framedPacket.count {
+            logWriteError("write packet to Go failed written=\(written) errno=\(errno)")
+        }
+    }
+
+    private func drainPacketsFromGo() {
+        let fd = currentSwiftFileDescriptor()
+        guard fd >= 0 else {
+            return
+        }
+
+        var buffer = [UInt8](repeating: 0, count: max(mtu + utunHeaderLength + 128, 2048))
+        while isRunning {
+            let readCount = buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+                guard let baseAddress = rawBuffer.baseAddress else {
+                    return -1
+                }
+                return Darwin.read(fd, baseAddress, rawBuffer.count)
+            }
+
+            if readCount > 0 {
+                guard readCount > utunHeaderLength else {
+                    logReadError("short packet from Go readCount=\(readCount)")
+                    continue
+                }
+                let packet = Data(buffer[utunHeaderLength..<readCount])
+                packetFlow.writePackets([packet], withProtocols: [protocolFamily(for: packet)])
+                continue
+            }
+
+            if readCount == 0 {
+                logReadError("Go packet fd closed")
+                return
+            }
+
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                return
+            }
+            logReadError("read packet from Go failed errno=\(errno)")
+            return
+        }
+    }
+
+    private var isRunning: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return running
+    }
+
+    private func currentSwiftFileDescriptor() -> Int32 {
+        lock.lock()
+        defer { lock.unlock() }
+        return swiftFileDescriptor
+    }
+
+    private func protocolFamily(for packet: Data) -> NSNumber {
+        guard let first = packet.first else {
+            return NSNumber(value: AF_INET)
+        }
+        let version = first >> 4
+        if version == 6 {
+            return NSNumber(value: AF_INET6)
+        }
+        return NSNumber(value: AF_INET)
+    }
+
+    private func utunFramedPacket(_ packet: Data) -> Data {
+        let family = protocolFamily(for: packet).uint8Value
+        var framed = Data([0, 0, 0, family])
+        framed.append(packet)
+        return framed
+    }
+
+    private func logWriteError(_ message: String) {
+        lock.lock()
+        writeErrorCount += 1
+        let shouldLog = writeErrorCount <= 5 || writeErrorCount % 100 == 0
+        lock.unlock()
+        if shouldLog {
+            log("[PacketFlowBridge] \(message)")
+        }
+    }
+
+    private func logReadError(_ message: String) {
+        lock.lock()
+        readErrorCount += 1
+        let shouldLog = readErrorCount <= 5 || readErrorCount % 100 == 0
+        lock.unlock()
+        if shouldLog {
+            log("[PacketFlowBridge] \(message)")
+        }
+    }
+
+    private func setNonBlocking(_ fd: Int32) throws {
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private func disableSigpipe(_ fd: Int32) throws {
+        var value: Int32 = 1
+        let result = setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_NOSIGPIPE,
+            &value,
+            socklen_t(MemoryLayout<Int32>.size)
+        )
+        guard result == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private func closeIfOpen(_ fd: inout Int32) {
+        if fd >= 0 {
+            close(fd)
+            fd = -1
+        }
+    }
+}

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -23,7 +23,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var userDefaults: UserDefaults = UserDefaults(suiteName: appGroupIdentifier)!
 
     private var pathMonitor: Network.NWPathMonitor?
-    private var lastPathStatus: Network.NWPath.Status?
+    private var lastPathFingerprint: String?
     private var packetFlowBridge: PacketFlowBridge?
 
     deinit {
@@ -52,37 +52,79 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     func logInterfaces() {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        getifaddrs(&ifaddrPtr)
+        guard getifaddrs(&ifaddrPtr) == 0, ifaddrPtr != nil else {
+            logs.writeLog(log: "[DEBUG][Interfaces] getifaddrs failed")
+            return
+        }
+        defer { freeifaddrs(ifaddrPtr) }
+
+        var interfaces: [String: [String]] = [:]
         var ptr = ifaddrPtr
         while ptr != nil {
-            if let name = ptr?.pointee.ifa_name {
-                let s = String(cString: name)
-                if s.starts(with: "utun") {
-                    logs.writeLog(log: "Active interface: \(s)")
+            guard let rawName = ptr?.pointee.ifa_name,
+                  let addr = ptr?.pointee.ifa_addr else {
+                ptr = ptr?.pointee.ifa_next
+                continue
+            }
+            let name = String(cString: rawName)
+            if name.starts(with: "utun") {
+                let family = Int32(addr.pointee.sa_family)
+                var values = interfaces[name] ?? []
+                if family == AF_INET {
+                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                    var ip = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                        $0.pointee.sin_addr
+                    }
+                    if inet_ntop(AF_INET, &ip, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
+                        values.append("ipv4=\(String(cString: buffer))")
+                    }
+                } else if family == AF_INET6 {
+                    values.append("ipv6")
+                } else {
+                    values.append("family=\(family)")
                 }
+                interfaces[name] = values
             }
             ptr = ptr?.pointee.ifa_next
         }
-        freeifaddrs(ifaddrPtr)
+
+        if interfaces.isEmpty {
+            logs.writeLog(log: "[DEBUG][Interfaces] no utun interfaces visible")
+            return
+        }
+
+        for name in interfaces.keys.sorted() {
+            let details = (interfaces[name] ?? []).joined(separator: ",")
+            logs.writeLog(log: "[DEBUG][Interfaces] active \(name) \(details)")
+        }
     }
 
     override func startTunnel(options: [String : NSObject]?) async throws {
         let tid = UInt64(pthread_mach_thread_np(pthread_self()))
-        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId)")
+        var startupStage = "entered"
+        let optionKeys = options?.keys.sorted().joined(separator: ",") ?? "(none)"
+        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId) optionKeys=\(optionKeys)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")
 
         do {
             // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
+            startupStage = "pre-start cleanup"
             await teardownForStop(reason: "pre-start cleanup")
 
+            startupStage = "path monitor"
             startPathLogging()
 
+            startupStage = "go logger init"
             let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
             logs.writeLog(log: "Start go logger init path = \(path)")
             Cloak_outlineInitLogger(path)
             logs.writeLog(log: "Finish go logger init")
-            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
+            startupStage = "geo routing config"
+            let geoRoutingConf = configsRepository.getGeoRoutingConf()
+            logs.writeLog(log: "[DEBUG][Routing] applying geo routing config length=\(geoRoutingConf.count)")
+            Cloak_outlineSetGeoRoutingConf(geoRoutingConf)
 
+            startupStage = "route exclusions"
             let cloakConfig = configsRepository.getCloakConfig()
             // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
             // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
@@ -101,7 +143,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                         )
                     }
                 } else {
-                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
+                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
             }
             if let remoteHost = extractRemoteHost(from: cloakConfig) {
@@ -130,8 +172,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             // Cloak must bind/connect before the full-tunnel route is installed; otherwise
             // iOS can route the upstream bootstrap traffic into a tunnel that is not ready yet.
+            startupStage = "cloak startup"
+            logs.writeLog(log: "[tunnel:\(tunnelId)] starting Cloak phase")
             try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
 
+            startupStage = "network settings build"
             let remoteAddress = "254.1.1.1"
             let localAddress = "198.18.0.1"
             let subnetMask = "255.255.0.0"
@@ -149,14 +194,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             settings.dnsSettings = NEDNSSettings(servers: dnsServers)
             settings.dnsSettings?.matchDomains = [""]
 
-            logs.writeLog(log: "Settings are ready:")
+            logNetworkSettings(
+                localAddress: localAddress,
+                remoteAddress: remoteAddress,
+                subnetMask: subnetMask,
+                mtu: tunnelMTU,
+                dnsServers: dnsServers,
+                excludedRoutes: excludedRoutes
+            )
+            startupStage = "setTunnelNetworkSettings"
+            let settingsStart = Date()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings begin")
             try await self.setTunnelNetworkSettings(settings)
-            logs.writeLog(log: "Tunnel settings applied")
+            logs.writeLog(
+                log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings applied in \(elapsedMs(since: settingsStart))ms"
+            )
 
             logInterfaces()
 
+            startupStage = "packetFlow bridge"
             let bridgeTunnelId = tunnelId
             let bridgeLogs = logs
+            logs.writeLog(log: "[tunnel:\(tunnelId)] creating PacketFlowBridge mtu=\(tunnelMTU)")
             let bridge = try PacketFlowBridge(
                 packetFlow: packetFlow,
                 mtu: tunnelMTU,
@@ -168,10 +227,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             packetFlowBridge = bridge
             bridge.start()
 
+            startupStage = "outline startup"
+            logs.writeLog(log: "[tunnel:\(tunnelId)] starting Outline phase tunnelFD=\(bridge.tunnelFileDescriptor) mtu=\(tunnelMTU)")
             try outlineInteractor.startOutline(
                 tunnelFileDescriptor: bridge.tunnelFileDescriptor,
                 mtu: tunnelMTU,
                 nativeClientCreated: {
+                    bridgeLogs.writeLog(log: "[tunnel:\(bridgeTunnelId)] native Outline client created; releasing bridge fd to Go")
                     bridge.releaseTunnelFileDescriptor()
                 }
             )
@@ -182,7 +244,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let nsError = error as NSError
             logs.writeLog(
                 log: "[tunnel:\(tunnelId)] startTunnel failed: " +
-                    "\(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
+                    "stage=\(startupStage) \(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
             )
             await teardownForStop(reason: "startTunnel failure")
             throw error
@@ -219,8 +281,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
         if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory")
             completionHandler?("Memory:\(reportMemoryUsageMB())".data(using: .utf8))
         } else {
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage echo bytes=\(messageData.count)")
             completionHandler?(messageData)
         }
     }
@@ -233,15 +297,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
-            let status = path.status
-            if self.lastPathStatus != status {
-                self.lastPathStatus = status
-                let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
-                let expensive = path.isExpensive
-                let constrained = path.isConstrained
+            let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
+            let expensive = path.isExpensive
+            let constrained = path.isConstrained
+            let fingerprint = "status=\(path.status)|ifaces=\(ifaces)|expensive=\(expensive)|constrained=\(constrained)"
+            if self.lastPathFingerprint != fingerprint {
+                self.lastPathFingerprint = fingerprint
                 self.logs.writeLog(
                     log: "[tunnel:\(self.tunnelId)] pathUpdate " +
-                        "status=\(status) ifaces=[\(ifaces)] " +
+                        "status=\(path.status) ifaces=[\(ifaces)] " +
                         "expensive=\(expensive) constrained=\(constrained)"
                 )
             }
@@ -256,28 +320,57 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason))")
 
         do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Outline")
             try outlineInteractor.stopOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] Outline stopped")
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
         }
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping PacketFlowBridge")
         packetFlowBridge?.stop()
         packetFlowBridge = nil
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Cloak")
         cloakInteractor.stopCloak()
 
         do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing tunnel network settings")
             try await self.setTunnelNetworkSettings(nil)
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] cleared tunnel network settings")
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] failed to clear tunnel network settings: \(error.localizedDescription)")
         }
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping NWPathMonitor")
         pathMonitor?.cancel()
         pathMonitor = nil
-        lastPathStatus = nil
+        lastPathFingerprint = nil
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
+    }
+
+    private func logNetworkSettings(
+        localAddress: String,
+        remoteAddress: String,
+        subnetMask: String,
+        mtu: Int,
+        dnsServers: [String],
+        excludedRoutes: [NEIPv4Route]
+    ) {
+        let excluded = excludedRoutes
+            .map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }
+            .joined(separator: ",")
+        logs.writeLog(
+            log: "[DEBUG][tunnel:\(tunnelId)] network settings " +
+            "local=\(localAddress) remote=\(remoteAddress) mask=\(subnetMask) mtu=\(mtu) " +
+            "dns=\(dnsServers.joined(separator: ",")) included=default " +
+            "excluded=\(excluded.isEmpty ? "(none)" : excluded) ipv6=disabled"
+        )
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 
     /// Extracts the host/IP part from a string like "ip:port" or "[ipv6]:port".
@@ -320,6 +413,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         guard !trimmed.isEmpty else { return nil }
         if isValidIPv4(trimmed) { return trimmed }
 
+        let start = Date()
+        logs.writeLog(log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed))")
+
         var hints = addrinfo(
             ai_flags: AI_ADDRCONFIG,
             ai_family: AF_INET,
@@ -332,14 +428,25 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         )
         var res: UnsafeMutablePointer<addrinfo>?
         let rc = getaddrinfo(trimmed, nil, &hints, &res)
-        guard rc == 0, let first = res else { return nil }
+        guard rc == 0, let first = res else {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) failed " +
+                "rc=\(rc) error=\(String(cString: gai_strerror(rc))) elapsed=\(elapsedMs(since: start))ms"
+            )
+            return nil
+        }
         defer { freeaddrinfo(res) }
 
         var addr = first.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee.sin_addr }
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         let ptr = inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN))
         guard ptr != nil else { return nil }
-        return String(cString: buffer)
+        let value = String(cString: buffer)
+        logs.writeLog(
+            log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) ok " +
+            "ip=\(maskStr(value: value)) elapsed=\(elapsedMs(since: start))ms"
+        )
+        return value
     }
 
     private func resolveIPv4IfNeededWithTimeout(_ host: String, timeout: TimeInterval) -> String? {
@@ -358,6 +465,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: host)) " +
+                "timed out after \(Int(timeout * 1000))ms"
+            )
             return nil
         }
         lock.lock()

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -14,6 +14,7 @@ import Network
 class PacketTunnelProvider: NEPacketTunnelProvider {
     private let launchId = UUID().uuidString
     private let tunnelId = String(UUID().uuidString.prefix(8))
+    private let tunnelMTU = 1200
 
     private let outlineInteractor: OutlineInteractor = OutlineInteractor()
     private let cloakInteractor: CloakInteractor = CloakInteractor()
@@ -23,6 +24,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private var pathMonitor: Network.NWPathMonitor?
     private var lastPathStatus: Network.NWPath.Status?
+    private var packetFlowBridge: PacketFlowBridge?
 
     deinit {
         logs.writeLog(log: "[tunnel:\(tunnelId)] deinit")
@@ -136,7 +138,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let dnsServers = ["1.1.1.1", "8.8.8.8"]
 
             let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
-            settings.mtu = 1200
+            settings.mtu = NSNumber(value: tunnelMTU)
             settings.ipv4Settings = NEIPv4Settings(
                 addresses: [localAddress],
                 subnetMasks: [subnetMask]
@@ -153,7 +155,26 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             logInterfaces()
 
-            try outlineInteractor.startOutline()
+            let bridgeTunnelId = tunnelId
+            let bridgeLogs = logs
+            let bridge = try PacketFlowBridge(
+                packetFlow: packetFlow,
+                mtu: tunnelMTU,
+                tunnelId: tunnelId,
+                log: { message in
+                    bridgeLogs.writeLog(log: "[tunnel:\(bridgeTunnelId)] \(message)")
+                }
+            )
+            packetFlowBridge = bridge
+            bridge.start()
+
+            try outlineInteractor.startOutline(
+                tunnelFileDescriptor: bridge.tunnelFileDescriptor,
+                mtu: tunnelMTU,
+                nativeClientCreated: {
+                    bridge.releaseTunnelFileDescriptor()
+                }
+            )
             logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
 
             logs.writeLog(log: "startTunnel: all packet loops started")
@@ -163,6 +184,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 log: "[tunnel:\(tunnelId)] startTunnel failed: " +
                     "\(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
             )
+            await teardownForStop(reason: "startTunnel failure")
             throw error
         }
     }
@@ -238,6 +260,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
         }
+
+        packetFlowBridge?.stop()
+        packetFlowBridge = nil
 
         cloakInteractor.stopCloak()
 


### PR DESCRIPTION
## Summary

This PR is stacked on #145 and implements the remaining iOS hardening follow-ups from `AGENTS.md`.

It addresses three concrete risks:

- iOS Outline startup no longer scans process file descriptors looking for `com.apple.net.utun_control`.
- iOS MTU is now passed from Swift tunnel settings into Go/tun2socks instead of relying on implicit matching constants.
- Upstream socket protection now reports failures, and Cloak on iOS uses the same `SO_NO_TC_NETPOLICY` protection path as Outline direct bypass sockets.

## Why

The old iOS path depended on `go_module/ios_exports/outline.go` scanning every process fd and selecting the one whose peer looked like `com.apple.net.utun_control`. That is not a stable NetworkExtension API contract. It can fail if iOS changes fd ownership, visibility, timing, ordering, or peer metadata.

Android does not have this class of bug because `VpnService.Builder.establish()` returns an explicit TUN fd that is passed into Go. This PR makes iOS explicit too.

## Changes

- Added `PacketFlowBridge` in Swift:
  - Uses `NEPacketTunnelProvider.packetFlow.readPackets` / `writePackets`.
  - Bridges packets to Go through a local datagram `socketpair`.
  - Adds/removes the 4-byte utun header expected by tun2socks `fd://` on iOS.
  - Keeps Swift ownership of the fd until `NewOutlineClient` succeeds, then hands ownership to Go.
  - Disables `SIGPIPE` and uses non-blocking sockets.

- Changed iOS Go export:
  - `NewOutlineClient` now requires an explicit tunnel fd and MTU.
  - Removed `GetTunnelFileDescriptor()` and the `com.apple.net.utun_control` scan.

- Plumbed MTU:
  - Swift keeps a single `tunnelMTU`.
  - Go `EngineConfig` carries `MTU`.
  - fd-backed tun2socks uses that MTU.

- Improved socket protection:
  - Platform protectors now return errors instead of silently ignoring failures.
  - Protected dials log success/failure and fail the dial if protection fails.
  - Android now respects the boolean result from `VpnService.protect()`.
  - Added iOS Cloak socket protection using `SO_NO_TC_NETPOLICY`.

- Added missing `google.golang.org/grpc v1.79.3` go.sum entries already required by `go_module/go.mod`.

## Validation

Passed:

- `gofmt` on changed Go files.
- `go test ./tunnel/protected_dialer ./tunnel/platform_engine ./outline` from `go_module`.
- `GOOS=ios GOARCH=arm64 go test ./tunnel/protected_dialer ./tunnel/platform_engine` from `go_module`.
- `GOOS=android GOARCH=arm64 go test ./kotlin_exports` from `go_module`.
- `git diff --check`.

Blocked in this checkout:

- `GOOS=ios GOARCH=arm64 go test -mod=mod ./ios_exports` still fails because `go_module/modules/Cloak` does not include the copied `internal` sources required by `github.com/cbeuw/Cloak/exported_client` (`internal/client`, `internal/common`, `internal/multiplex`). This matches the repository README requirement to copy Cloak internals before building the mobile library.

Not run:

- Xcode/iOS NetworkExtension build and device test. This environment does not provide a macOS/Xcode build setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable MTU support for mobile tunnels.
  * Introduced packet flow bridging for improved tunnel data handling.

* **Bug Fixes**
  * Enhanced error handling and validation for socket protection across all platforms.
  * Improved tunnel file descriptor management and lifecycle.

* **Documentation**
  * Expanded diagnostic logging and health-check monitoring with detailed status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->