### PR TITLE
Improve iOS VPN observability coverage

### DIFF
--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"time"
 )
 
 type OutlineClient struct {
@@ -47,12 +48,14 @@ func NewClientWithFD(transportConfig string, fd int, mtu int) *OutlineClient {
 		tunFD:  fd,
 		mtu:    mtu,
 	}
-	log.Infof("outline client created (tun2socks version)")
+	log.Infof("outline client created (tun2socks version) fd=%d mtu=%d configLen=%d", fd, mtu, len(transportConfig))
 	common.Client.SetVpnClient(outlineCommon.Name, c)
 	return c
 }
 
 func (c *OutlineClient) Connect() error {
+	start := time.Now()
+	log.Infof("outline client connect begin fd=%d mtu=%d configLen=%d", c.tunFD, c.mtu, len(c.config))
 	defer func() {
 		if r := recover(); r != nil {
 			log.Infof("RECOVERED from fail in Connect: %v", r)
@@ -74,9 +77,11 @@ func (c *OutlineClient) Connect() error {
 	err = unix.SetNonblock(fd, true)
 	if err != nil {
 		log.Infof("Set unix.SetNonblock error: %v", err)
+	} else {
+		log.Infof("[DEBUG][Outline] tun fd set non-blocking fd=%d", fd)
 	}
 
-	log.Infof("starting tun2socks engine with proxy %s", od.GetProxyAddr())
+	log.Infof("starting tun2socks engine with proxy %s fd=%d mtu=%d", od.GetProxyAddr(), fd, c.mtu)
 	err = tunnel.StartEngine(platform_engine.EngineConfig{
 		ProxyAddr:   od.GetProxyAddr(),
 		FD:          fd,
@@ -90,15 +95,18 @@ func (c *OutlineClient) Connect() error {
 	c.engineStarted = true
 
 	common.Client.MarkActive(outlineCommon.Name)
-	log.Infof("outline client connected successfully via tun2socks")
+	log.Infof("outline client connected successfully via tun2socks in %dms", time.Since(start).Milliseconds())
 	return nil
 }
 
 func (c *OutlineClient) Disconnect() error {
+	log.Infof("outline client disconnect begin engineStarted=%v fd=%d deviceNil=%v", c.engineStarted, c.tunFD, c.device == nil)
 	tunnel.StopEngine()
 	if !c.engineStarted && c.tunFD >= 0 {
 		if err := unix.Close(c.tunFD); err != nil {
 			log.Infof("failed to close unused tun fd: %v\n", err)
+		} else {
+			log.Infof("[DEBUG][Outline] closed unused tun fd=%d", c.tunFD)
 		}
 	}
 	c.engineStarted = false

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -46,7 +46,17 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	}
 
 	hasUDPPath := strings.Contains(transportConfig, "udp_path=")
-	log.Infof("outline client: packetDialer type=%T udpPath=%v", pd, hasUDPPath)
+	hasTCPPath := strings.Contains(transportConfig, "tcp_path=")
+	isWebSocket := strings.Contains(transportConfig, "ws:")
+	log.Infof(
+		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v streamDialer=%T packetDialer=%T",
+		len(transportConfig),
+		isWebSocket,
+		hasTCPPath,
+		hasUDPPath,
+		sd,
+		pd,
+	)
 
 	useCloak := ip.IsLoopback()
 
@@ -101,6 +111,7 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 			return nil, err
 		}
 		log.Infof("[SOCKS5 TCP OK] %s in %dms", addr, elapsed)
+		log.Infof("[DEBUG][SOCKS5 TCP] %s local=%s remote=%s", addr, conn.LocalAddr(), conn.RemoteAddr())
 		return conn, nil
 
 	case "udp":
@@ -118,6 +129,7 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 			return nil, err
 		}
 		log.Infof("[SOCKS5 UDP OK] %s in %dms", addr, elapsed)
+		log.Infof("[DEBUG][SOCKS5 UDP] %s local=%s", addr, conn.LocalAddr())
 		return conn, nil
 	}
 
@@ -198,6 +210,7 @@ func ResolveServerIPFromConfig(transportConfig string) (net.IP, error) {
 	if err != nil {
 		return nil, fmt.Errorf("DNS lookup for %s timed out or failed: %w", host, err)
 	}
+	log.Infof("outline client: DNS returned %d addresses for %s", len(ipList), host)
 
 	for _, ip := range ipList {
 		if v4 := ip.IP.To4(); v4 != nil {

--- a/go_module/tunnel/platform_engine/engine.go
+++ b/go_module/tunnel/platform_engine/engine.go
@@ -23,6 +23,8 @@ func StartPlatformEngine(cfg EngineConfig) error {
 }
 
 func EngineStop() {
+	// engine.Stop() is process-global inside tun2socks; keep this visible in logs
+	// because stale goroutines look like packet-flow stalls on the platform side.
 	stopPlatformEngine()
 	engine.Stop()
 }

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -90,6 +90,7 @@ func DialContextWithProtect(ctx context.Context, network, address string) (net.C
 		return nil, err
 	}
 
+	log.Infof("[DEBUG][Protect] TCP dial OK network=%s destination=%s local=%s remote=%s", realNet, address, conn.LocalAddr(), conn.RemoteAddr())
 	return conn, nil
 }
 
@@ -103,15 +104,18 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 		pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 		if err != nil {
+			log.Infof("[Protect] UDP BYPASS loopback listen error network=%s destination=%s: %v", realNet, address, err)
 			return nil, err
 		}
 
 		udpAddr, err := net.ResolveUDPAddr(realNet, address)
 		if err != nil {
 			_ = pc.Close()
+			log.Infof("[Protect] UDP BYPASS loopback resolve error network=%s destination=%s: %v", realNet, address, err)
 			return nil, err
 		}
 
+		log.Infof("[DEBUG][Protect] UDP BYPASS loopback ready network=%s destination=%s local=%s remote=%s", realNet, address, pc.LocalAddr(), udpAddr)
 		return &connectedUDPConn{
 			PacketConn: pc,
 			remoteAddr: udpAddr,
@@ -133,15 +137,18 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 	pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 	if err != nil {
+		log.Infof("[Protect] UDP listen error network=%s destination=%s: %v", realNet, address, err)
 		return nil, err
 	}
 
 	udpAddr, err := net.ResolveUDPAddr(realNet, address)
 	if err != nil {
 		_ = pc.Close()
+		log.Infof("[Protect] UDP resolve error network=%s destination=%s: %v", realNet, address, err)
 		return nil, err
 	}
 
+	log.Infof("[DEBUG][Protect] UDP dial ready network=%s destination=%s local=%s remote=%s", realNet, address, pc.LocalAddr(), udpAddr)
 	return &connectedUDPConn{
 		PacketConn: pc,
 		remoteAddr: udpAddr,

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -111,7 +111,13 @@ type DobbyProxy struct {
 
 func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net.Conn, error) {
 	if IsBypass(metadata) {
-		return p.direct.DialContext(ctx, metadata)
+		conn, err := p.direct.DialContext(ctx, metadata)
+		if err != nil {
+			log.Infof("[Router] BYPASS TCP dial error %s: %v", metadata.DestinationAddress(), err)
+			return nil, err
+		}
+		log.Infof("[DEBUG][Router] BYPASS TCP dial OK %s local=%s remote=%s", metadata.DestinationAddress(), conn.LocalAddr(), conn.RemoteAddr())
+		return conn, nil
 	}
 
 	// Increment first, then check — prevents TOCTOU race where multiple goroutines
@@ -126,6 +132,7 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 	conn, err := p.vpn.DialContext(ctx, metadata)
 	if err != nil {
 		p.activeTCP.Add(-1)
+		log.Infof("[Router] PROXY TCP dial error %s: %v", metadata.DestinationAddress(), err)
 		return nil, err
 	}
 
@@ -137,7 +144,13 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 
 func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 	if IsBypass(metadata) {
-		return p.direct.DialUDP(metadata)
+		conn, err := p.direct.DialUDP(metadata)
+		if err != nil {
+			log.Infof("[Router] BYPASS UDP dial error %s: %v", metadata.DestinationAddress(), err)
+			return nil, err
+		}
+		log.Infof("[DEBUG][Router] BYPASS UDP dial OK %s local=%s", metadata.DestinationAddress(), conn.LocalAddr())
+		return conn, nil
 	}
 
 	active := p.activeUDP.Add(1)
@@ -150,6 +163,7 @@ func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 	conn, err := p.vpn.DialUDP(metadata)
 	if err != nil {
 		p.activeUDP.Add(-1)
+		log.Infof("[Router] PROXY UDP dial error %s: %v", metadata.DestinationAddress(), err)
 		return nil, err
 	}
 
@@ -168,8 +182,10 @@ func (p *DobbyProxy) Proto() proto.Proto {
 }
 
 func stopLocked() {
+	log.Infof("[Engine] stopping tun2socks engine")
 	platform_engine.EngineStop()
 	isRunning = false
+	log.Infof("[Engine] tun2socks engine stopped")
 }
 
 func StartEngine(cfg platform_engine.EngineConfig) error {
@@ -177,9 +193,11 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 	defer mu.Unlock()
 
 	if isRunning {
+		log.Infof("[Engine] StartEngine requested while already running; stopping previous engine first")
 		stopLocked()
 	}
 
+	log.Infof("[Engine] StartEngine config proxy=%s fd=%d mtu=%d uplinkIface=%s", cfg.ProxyAddr, cfg.FD, cfg.MTU, cfg.UplinkIface)
 	log.Infof("[Engine] StartEngine: calling StartPlatformEngine")
 	err := platform_engine.StartPlatformEngine(cfg)
 	if err != nil {
@@ -222,6 +240,7 @@ func StopEngine() {
 	defer mu.Unlock()
 
 	if !isRunning {
+		log.Infof("[Engine] StopEngine skipped: not running")
 		return
 	}
 

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -31,6 +31,7 @@ class HealthCheckManager(
     private var consecutiveFailuresCount: Int = 0
     private var lastVpnStartMark: TimeMark? = null
     private var lastFullConnectionSucceed = false
+    private var healthTickId = 0
 
     suspend fun startHealthCheck(address: String, port: Int) {
         logger.log("[HC] startHealthCheck() called")
@@ -66,15 +67,24 @@ class HealthCheckManager(
 
             while (isActive) {
                 var nextDelay: Duration? = null
+                val tickId = ++healthTickId
+                logger.log(
+                    "[HC] tick#$tickId begin " +
+                        "lastFullConnectionSucceed=$lastFullConnectionSucceed " +
+                        "consecutiveFailuresCount=$consecutiveFailuresCount"
+                )
 
                 if (configsRepository.getIsUserInitStop()) {
-                    logger.log("[HC] Stop condition: getIsUserInitStop() == true → exiting health check loop")
+                    logger.log(
+                        "[HC] tick#$tickId stop condition: " +
+                            "getIsUserInitStop() == true → exiting health check loop"
+                    )
                     resetHealthCheckState()
                     return@launch
                 }
 
                 if (mainViewModel.connectionStateRepository.vpnTransitioningFlow.value) {
-                    logger.log("[HC] VPN is transitioning → skipping checks for this tick")
+                    logger.log("[HC] tick#$tickId VPN is transitioning → skipping checks for this tick")
                     nextDelay = getHealthCheckDelay()
                     logger.log("[HC] Next tick in $nextDelay")
                     delay(nextDelay)
@@ -82,17 +92,22 @@ class HealthCheckManager(
                 }
 
                 val connected = try {
-                    val result = isConnected()
-                    logger.log("[HC] isConnected() result = $result")
+                    val result = isConnected(tickId)
+                    logger.log("[HC] tick#$tickId isConnected() result = $result")
                     result
                 } catch (t: Throwable) {
-                    logger.log("[HC] isConnected() threw exception: ${t.message}")
+                    logger.log("[HC] tick#$tickId isConnected() threw exception: ${t.message}")
                     false
                 }
 
-                var vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
+                if (!isActive) {
+                    logger.log("[HC] tick#$tickId result ignored because health job was cancelled")
+                    return@launch
+                }
+
+                val vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
                 if (!vpnStarted) {
-                    logger.log("[HC] vpnStarted=false → exiting health check loop")
+                    logger.log("[HC] tick#$tickId vpnStarted=false → exiting health check loop")
                     resetHealthCheckState()
                     return@launch
                 }
@@ -107,7 +122,10 @@ class HealthCheckManager(
                     val sinceStartMs = (lastVpnStartMark?.elapsedNow()?.inWholeMilliseconds)
                         ?: Long.MAX_VALUE
                     if (sinceStartMs < gracePeriodMs) {
-                        logger.log("[HC] Not connected during grace period (${sinceStartMs}ms < ${gracePeriodMs}ms) → ignore")
+                        logger.log(
+                            "[HC] Not connected during grace period " +
+                                "(${sinceStartMs}ms < ${gracePeriodMs}ms) → ignore"
+                        )
                         nextDelay = getHealthCheckDelay()
                     }
 
@@ -176,6 +194,7 @@ class HealthCheckManager(
         consecutiveFailuresCount = 0
         lastVpnStartMark = null
         lastFullConnectionSucceed = false
+        healthTickId = 0
     }
 
     suspend fun turnOffVpn() {
@@ -185,14 +204,17 @@ class HealthCheckManager(
         mainViewModel.stopVpnService()
     }
 
-    private fun isConnected(): Boolean {
+    private fun isConnected(tickId: Int): Boolean {
         var result = false
         if (lastFullConnectionSucceed) {
+            logger.log("[HC] tick#$tickId using shortConnectionCheckUp() first")
             result = healthCheck.shortConnectionCheckUp()
         }
         if (!result) {
+            logger.log("[HC] tick#$tickId using fullConnectionCheckUp()")
             result = healthCheck.fullConnectionCheckUp()
             lastFullConnectionSucceed = result
+            logger.log("[HC] tick#$tickId fullConnectionCheckUp() result=$result")
         }
         return result
     }

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -62,9 +62,12 @@ public final class HealthCheckImpl: HealthCheck {
 
     public private(set) var currentMemmoryUsageMb = 0.0
     private var lastMemoryMB: Double = 0
+    private var checkSequence: Int = 0
+    private let checkSequenceLock = NSLock()
 
     public func shortConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "Start shortConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "short")
+        logs.writeLog(log: "[HC] Start shortConnectionCheckUp id=\(checkId)")
 
         let checks: [(String, () -> Bool)] = [
             ("HTTP https://google.com/gen_204", {
@@ -99,12 +102,16 @@ public final class HealthCheckImpl: HealthCheck {
         }
 
         let result = vpnOk && networkOk && heartbeatOk
-        logs.writeLog(log: "End shortConnectionCheckUp => \(result)")
+        logs.writeLog(
+            log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) " +
+            "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk))"
+        )
         return result
     }
 
     public func fullConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "[HC] Start fullConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "full")
+        logs.writeLog(log: "[HC] Start fullConnectionCheckUp id=\(checkId)")
 
         // --- Standard check groups ---
         let groups: [(String, [(String, () -> Bool)])] = [
@@ -113,8 +120,8 @@ public final class HealthCheckImpl: HealthCheck {
                 ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
             ]),
             ("DNS Resolve group", [
-                ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") != "Timeout" }),
-                ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") != "Timeout" })
+                ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") }),
+                ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") })
             ]),
             ("DNS Ping group", [
                 ("Ping google.com (DNS)", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
@@ -170,7 +177,7 @@ public final class HealthCheckImpl: HealthCheck {
                      failedGroups.joined(separator: ", ")
             )
         }
-        logs.writeLog(log: "[HC] RESULT = \(result)")
+        logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result)")
 
         // --- DIAGNOSIS — single line with actionable verdict ---
         let tcpProxyOk = groupResults["TCP Ping group"] ?? false
@@ -186,6 +193,14 @@ public final class HealthCheckImpl: HealthCheck {
         )
 
         return result
+    }
+
+    private func nextCheckId(prefix: String) -> String {
+        checkSequenceLock.lock()
+        checkSequence += 1
+        let value = checkSequence
+        checkSequenceLock.unlock()
+        return "\(prefix)-\(value)"
     }
 
     private func logDiagnosis(
@@ -266,8 +281,8 @@ public final class HealthCheckImpl: HealthCheck {
         return value
     }
 
-    private func resolveDNSWithTimeout(host: String) -> String? {
-        var result: String?
+    private func resolveDNSWithTimeout(host: String) -> Bool {
+        var result: (ok: Bool, message: String)?
         let group = DispatchGroup()
         group.enter()
 
@@ -278,14 +293,15 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
-            logs.writeLog(log: "[HC] [DNS] \(host) → Timeout")
-            return "Timeout"
+            logs.writeLog(log: "[HC] [DNS] \(host) FAILED: timeout after \(Int(timeout * 1000))ms")
+            return false
         }
-        logs.writeLog(log: "[HC] [DNS] \(host) → \(result ?? "nil")")
-        return result
+        let value = result ?? (false, "nil result")
+        logs.writeLog(log: "[HC] [DNS] \(host) \(value.ok ? "OK" : "FAILED"): \(value.message)")
+        return value.ok
     }
 
-    private func resolveDNS(host: String) -> String {
+    private func resolveDNS(host: String) -> (ok: Bool, message: String) {
         var hints = addrinfo(
             ai_flags: AI_PASSIVE,
             ai_family: AF_UNSPEC,
@@ -301,7 +317,7 @@ public final class HealthCheckImpl: HealthCheck {
         let status = getaddrinfo(host, nil, &hints, &infoPointer)
 
         guard status == 0, let first = infoPointer else {
-            return String(cString: gai_strerror(status))
+            return (false, String(cString: gai_strerror(status)))
         }
 
         defer { freeaddrinfo(infoPointer) }
@@ -318,12 +334,12 @@ public final class HealthCheckImpl: HealthCheck {
                 0,
                 NI_NUMERICHOST
             ) == 0 {
-                return String(cString: buffer)
+                return (true, String(cString: buffer))
             }
             ptr = current.pointee.ai_next
         }
 
-        return "Can't resolve DNS"
+        return (false, "Can't resolve DNS")
     }
 
     private func httpPing(urlString: String) -> Bool {
@@ -344,6 +360,10 @@ public final class HealthCheckImpl: HealthCheck {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = timeout
         config.timeoutIntervalForResource = timeout
+        logs.writeLog(
+            log: "[DEBUG][HC] [httpPing] start url=\(urlString) timeoutMs=\(Int(timeout * 1000)) " +
+            "cachePolicy=reloadIgnoringLocalCacheData"
+        )
         let delegate = HttpMetricsDelegate(url: urlString) { [weak self] msg in
             self?.logs.writeLog(log: msg)
         }
@@ -369,6 +389,7 @@ public final class HealthCheckImpl: HealthCheck {
                     log: "[HC] [httpPing] \(urlString) no HTTP response in \(elapsed)ms"
                 )
             }
+            session.finishTasksAndInvalidate()
             semaphore.signal()
         }
         task.resume()

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -94,6 +94,7 @@ public class VpnManagerImpl: VpnManager {
     public func start() {
         self.logs.writeLog(log: "call start")
         self.logs.writeLog(log: "Routing table without vpn:")
+        self.logs.writeLog(log: "[DEBUG][VPNManager] start requested launchId=\(Self.launchId)")
         getOrCreateManager { manager, _ in
             self.handleStart(manager: manager)
         }
@@ -105,6 +106,7 @@ public class VpnManagerImpl: VpnManager {
             return
         }
         let status = manager.connection.status
+        self.logs.writeLog(log: "[DEBUG][VPNManager] handleStart currentStatus=\(status.rawValue)")
         if status == .connecting || status == .disconnecting || status == .reasserting {
             self.logs.writeLog(log: "[start] Skip: connection is transitioning (\(status.rawValue))")
             self.updateTransitionState(for: status)
@@ -144,7 +146,7 @@ public class VpnManagerImpl: VpnManager {
             self.logs.writeLog(log: "[stop] Skip: vpnManager is nil")
             return
         }
-        self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel()")
+        self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel() currentStatus=\(manager.connection.status.rawValue)")
         connectionRepository.tryUpdateVpnTransitioning(isTransitioning: true)
         stopInitiatedByUser = true
         manager.connection.stopVPNTunnel()
@@ -152,8 +154,15 @@ public class VpnManagerImpl: VpnManager {
     }
 
     private func getOrCreateManager(completion: @escaping (NETunnelProviderManager?, Error?) -> Void) {
+        logs.writeLog(log: "[DEBUG][VPNManager] loadAllFromPreferences begin")
         NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
             guard let self else { return }
+
+            if let error {
+                self.logs.writeLog(log: "[VPNManager] loadAllFromPreferences error: \(error.localizedDescription)")
+            } else {
+                self.logs.writeLog(log: "[DEBUG][VPNManager] loadAllFromPreferences managers=\(managers?.count ?? -1)")
+            }
 
             if let existingManager = managers?.first(where: { $0.localizedDescription == Self.dobbyName }) {
                 vpnManager = existingManager

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -46,8 +46,12 @@ public final class CloakInteractor {
 
     func stopCloak() {
         if cloakStarted {
+            logs.writeLog(log: "stopCloak: stopping Cloak client")
             Cloak_outlineStopCloakClient()
             cloakStarted = false
+            logs.writeLog(log: "stopCloak: Cloak client stopped")
+        } else {
+            logs.writeLog(log: "[DEBUG] stopCloak: skipped, cloakStarted=false")
         }
     }
 }

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -22,7 +22,11 @@ public final class OutlineInteractor {
         let websocketEnabled = configsRepository.getIsWebsocketEnabled()
         let tcpPath = configsRepository.getTcpPathOutline()
         let udpPath = configsRepository.getUdpPathOutline()
-        logs.writeLog(log: "Config snapshot: serverPort.len=\(serverPort.count) methodPassword.len=\(methodPassword.count) ws=\(websocketEnabled) tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count)")
+        logs.writeLog(
+            log: "Config snapshot: serverPort.len=\(serverPort.count) methodPassword.len=\(methodPassword.count) " +
+            "ws=\(websocketEnabled) tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count) " +
+            "tunnelFD=\(tunnelFileDescriptor) mtu=\(mtu)"
+        )
 
         // Validate config early (prevents passing empty config into native layer).
         if methodPassword.isEmpty || serverPort.isEmpty {
@@ -49,25 +53,33 @@ public final class OutlineInteractor {
         
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native NewOutlineClient fd=\(tunnelFileDescriptor) mtu=\(mtu)")
         Cloak_outlineNewOutlineClient(config, Int(tunnelFileDescriptor), mtu, &err)
         if let error = err {
+            logs.writeLog(log: "[Outline] NewOutlineClient failed: \(error.localizedDescription)")
             throw error
         }
         nativeClientCreated()
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineConnect")
         Cloak_outlineOutlineConnect(&err)
         if let error = err {
+            logs.writeLog(log: "[Outline] OutlineConnect failed: \(error.localizedDescription)")
             throw error
         }
+        logs.writeLog(log: "[Outline] OutlineConnect succeeded")
     }
 
     func stopOutline() throws {
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineDisconnect")
         Cloak_outlineOutlineDisconnect(&err)
         if let error = err {
+            logs.writeLog(log: "[Outline] OutlineDisconnect failed: \(error.localizedDescription)")
             throw error
         }
+        logs.writeLog(log: "[DEBUG][Outline] OutlineDisconnect returned")
     }
     
     func buildOutlineConfig(

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -11,11 +11,23 @@ final class PacketFlowBridge {
     private let utunHeaderLength = 4
 
     private var readSource: DispatchSourceRead?
+    private var statsTimer: DispatchSourceTimer?
     private var swiftFileDescriptor: Int32 = -1
     private var goFileDescriptor: Int32 = -1
     private var running = false
     private var writeErrorCount = 0
     private var readErrorCount = 0
+    private var oversizedPacketCount = 0
+    private var tunnelReadBatches = 0
+    private var tunnelReadEmptyBatches = 0
+    private var tunnelToGoPackets = 0
+    private var tunnelToGoBytes = 0
+    private var goToTunnelPackets = 0
+    private var goToTunnelBytes = 0
+    private var tunnelToGoDrops = 0
+    private var goToTunnelDrops = 0
+    private var firstTunnelPacketLogged = false
+    private var firstGoPacketLogged = false
 
     var tunnelFileDescriptor: Int32 {
         lock.lock()
@@ -25,8 +37,10 @@ final class PacketFlowBridge {
 
     func releaseTunnelFileDescriptor() {
         lock.lock()
-        defer { lock.unlock() }
+        let releasedFD = goFileDescriptor
         goFileDescriptor = -1
+        lock.unlock()
+        log("[DEBUG][PacketFlowBridge] Go fd ownership released fd=\(releasedFD)")
     }
 
     init(packetFlow: NEPacketTunnelFlow, mtu: Int, tunnelId: String, log: @escaping (String) -> Void) throws {
@@ -56,6 +70,8 @@ final class PacketFlowBridge {
             closeIfOpen(&goFileDescriptor)
             throw error
         }
+
+        log("[DEBUG][PacketFlowBridge] socketpair ready swiftFD=\(swiftFileDescriptor) goFD=\(goFileDescriptor) mtu=\(mtu)")
     }
 
     func start() {
@@ -81,8 +97,9 @@ final class PacketFlowBridge {
         lock.unlock()
 
         source.resume()
+        startStatsTimer()
         readPacketsFromTunnel()
-        log("[PacketFlowBridge] started mtu=\(mtu)")
+        log("[PacketFlowBridge] started mtu=\(mtu) swiftFD=\(sourceFD) goFD=\(tunnelFileDescriptor)")
     }
 
     func stop() {
@@ -94,6 +111,8 @@ final class PacketFlowBridge {
         running = false
         let source = readSource
         readSource = nil
+        let timer = statsTimer
+        statsTimer = nil
         let shouldCloseSwiftFD = source == nil
         let swiftFD = swiftFileDescriptor
         swiftFileDescriptor = -1
@@ -101,6 +120,8 @@ final class PacketFlowBridge {
         goFileDescriptor = -1
         lock.unlock()
 
+        logStats(reason: "stop")
+        timer?.cancel()
         source?.cancel()
         if shouldCloseSwiftFD, swiftFD >= 0 {
             close(swiftFD)
@@ -112,11 +133,12 @@ final class PacketFlowBridge {
     }
 
     private func readPacketsFromTunnel() {
-        packetFlow.readPackets { [weak self] packets, _ in
+        packetFlow.readPackets { [weak self] packets, protocols in
             guard let self, self.isRunning else {
                 return
             }
 
+            self.recordTunnelReadBatch(packetCount: packets.count, protocolCount: protocols.count)
             for packet in packets where !packet.isEmpty {
                 self.writePacketToGo(packet)
             }
@@ -131,6 +153,10 @@ final class PacketFlowBridge {
             return
         }
 
+        if packet.count > mtu {
+            logOversizedPacket(packet.count)
+        }
+
         let framedPacket = utunFramedPacket(packet)
         let written = framedPacket.withUnsafeBytes { rawBuffer -> Int in
             guard let baseAddress = rawBuffer.baseAddress else {
@@ -140,8 +166,14 @@ final class PacketFlowBridge {
         }
 
         if written != framedPacket.count {
-            logWriteError("write packet to Go failed written=\(written) errno=\(errno)")
+            recordTunnelToGoDrop()
+            logWriteError(
+                "write packet to Go failed packetBytes=\(packet.count) framedBytes=\(framedPacket.count) " +
+                "written=\(written) errno=\(errno) \(errnoDescription())"
+            )
+            return
         }
+        recordTunnelToGo(packetBytes: packet.count)
     }
 
     private func drainPacketsFromGo() {
@@ -161,11 +193,13 @@ final class PacketFlowBridge {
 
             if readCount > 0 {
                 guard readCount > utunHeaderLength else {
+                    recordGoToTunnelDrop()
                     logReadError("short packet from Go readCount=\(readCount)")
                     continue
                 }
                 let packet = Data(buffer[utunHeaderLength..<readCount])
                 packetFlow.writePackets([packet], withProtocols: [protocolFamily(for: packet)])
+                recordGoToTunnel(packetBytes: packet.count)
                 continue
             }
 
@@ -177,9 +211,111 @@ final class PacketFlowBridge {
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 return
             }
-            logReadError("read packet from Go failed errno=\(errno)")
+            logReadError("read packet from Go failed errno=\(errno) \(errnoDescription())")
             return
         }
+    }
+
+    private func startStatsTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: readQueue)
+        timer.schedule(deadline: .now() + 5, repeating: 5)
+        timer.setEventHandler { [weak self] in
+            self?.logStats(reason: "periodic")
+        }
+
+        lock.lock()
+        statsTimer = timer
+        lock.unlock()
+        timer.resume()
+    }
+
+    private func recordTunnelReadBatch(packetCount: Int, protocolCount: Int) {
+        lock.lock()
+        tunnelReadBatches += 1
+        if packetCount == 0 {
+            tunnelReadEmptyBatches += 1
+        }
+        let shouldLogProtocolMismatch = packetCount != protocolCount && tunnelReadBatches <= 5
+        lock.unlock()
+
+        if shouldLogProtocolMismatch {
+            log(
+                "[DEBUG][PacketFlowBridge] packetFlow read protocol count mismatch " +
+                "packets=\(packetCount) protocols=\(protocolCount)"
+            )
+        }
+    }
+
+    private func recordTunnelToGo(packetBytes: Int) {
+        lock.lock()
+        tunnelToGoPackets += 1
+        tunnelToGoBytes += packetBytes
+        let shouldLogFirst = !firstTunnelPacketLogged
+        firstTunnelPacketLogged = true
+        lock.unlock()
+
+        if shouldLogFirst {
+            log("[DEBUG][PacketFlowBridge] first packet tunnel->go bytes=\(packetBytes)")
+        }
+    }
+
+    private func recordGoToTunnel(packetBytes: Int) {
+        lock.lock()
+        goToTunnelPackets += 1
+        goToTunnelBytes += packetBytes
+        let shouldLogFirst = !firstGoPacketLogged
+        firstGoPacketLogged = true
+        lock.unlock()
+
+        if shouldLogFirst {
+            log("[DEBUG][PacketFlowBridge] first packet go->tunnel bytes=\(packetBytes)")
+        }
+    }
+
+    private func recordTunnelToGoDrop() {
+        lock.lock()
+        tunnelToGoDrops += 1
+        lock.unlock()
+    }
+
+    private func recordGoToTunnelDrop() {
+        lock.lock()
+        goToTunnelDrops += 1
+        lock.unlock()
+    }
+
+    private func logOversizedPacket(_ packetBytes: Int) {
+        lock.lock()
+        oversizedPacketCount += 1
+        let shouldLog = oversizedPacketCount <= 5 || oversizedPacketCount % 100 == 0
+        lock.unlock()
+
+        if shouldLog {
+            log("[DEBUG][PacketFlowBridge] packet larger than configured MTU packetBytes=\(packetBytes) mtu=\(mtu)")
+        }
+    }
+
+    private func logStats(reason: String) {
+        lock.lock()
+        let batches = tunnelReadBatches
+        let emptyBatches = tunnelReadEmptyBatches
+        let t2gPackets = tunnelToGoPackets
+        let t2gBytes = tunnelToGoBytes
+        let g2tPackets = goToTunnelPackets
+        let g2tBytes = goToTunnelBytes
+        let t2gDrops = tunnelToGoDrops
+        let g2tDrops = goToTunnelDrops
+        let oversized = oversizedPacketCount
+        let isActive = running
+        lock.unlock()
+
+        log(
+            "[DEBUG][PacketFlowBridge] stats reason=\(reason) running=\(isActive) " +
+            "batches=\(batches) emptyBatches=\(emptyBatches) " +
+            "tunnel_to_go=\(t2gPackets)p/\(t2gBytes)B " +
+            "go_to_tunnel=\(g2tPackets)p/\(g2tBytes)B " +
+            "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) oversized=\(oversized)"
+        )
     }
 
     private var isRunning: Bool {
@@ -230,6 +366,10 @@ final class PacketFlowBridge {
         if shouldLog {
             log("[PacketFlowBridge] \(message)")
         }
+    }
+
+    private func errnoDescription() -> String {
+        String(cString: strerror(errno))
     }
 
     private func setNonBlocking(_ fd: Int32) throws {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -23,7 +23,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var userDefaults: UserDefaults = UserDefaults(suiteName: appGroupIdentifier)!
 
     private var pathMonitor: Network.NWPathMonitor?
-    private var lastPathStatus: Network.NWPath.Status?
+    private var lastPathFingerprint: String?
     private var packetFlowBridge: PacketFlowBridge?
 
     deinit {
@@ -52,37 +52,79 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     func logInterfaces() {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        getifaddrs(&ifaddrPtr)
+        guard getifaddrs(&ifaddrPtr) == 0, ifaddrPtr != nil else {
+            logs.writeLog(log: "[DEBUG][Interfaces] getifaddrs failed")
+            return
+        }
+        defer { freeifaddrs(ifaddrPtr) }
+
+        var interfaces: [String: [String]] = [:]
         var ptr = ifaddrPtr
         while ptr != nil {
-            if let name = ptr?.pointee.ifa_name {
-                let s = String(cString: name)
-                if s.starts(with: "utun") {
-                    logs.writeLog(log: "Active interface: \(s)")
+            guard let rawName = ptr?.pointee.ifa_name,
+                  let addr = ptr?.pointee.ifa_addr else {
+                ptr = ptr?.pointee.ifa_next
+                continue
+            }
+            let name = String(cString: rawName)
+            if name.starts(with: "utun") {
+                let family = Int32(addr.pointee.sa_family)
+                var values = interfaces[name] ?? []
+                if family == AF_INET {
+                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                    var ip = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                        $0.pointee.sin_addr
+                    }
+                    if inet_ntop(AF_INET, &ip, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
+                        values.append("ipv4=\(String(cString: buffer))")
+                    }
+                } else if family == AF_INET6 {
+                    values.append("ipv6")
+                } else {
+                    values.append("family=\(family)")
                 }
+                interfaces[name] = values
             }
             ptr = ptr?.pointee.ifa_next
         }
-        freeifaddrs(ifaddrPtr)
+
+        if interfaces.isEmpty {
+            logs.writeLog(log: "[DEBUG][Interfaces] no utun interfaces visible")
+            return
+        }
+
+        for name in interfaces.keys.sorted() {
+            let details = (interfaces[name] ?? []).joined(separator: ",")
+            logs.writeLog(log: "[DEBUG][Interfaces] active \(name) \(details)")
+        }
     }
 
     override func startTunnel(options: [String : NSObject]?) async throws {
         let tid = UInt64(pthread_mach_thread_np(pthread_self()))
-        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId)")
+        var startupStage = "entered"
+        let optionKeys = options?.keys.sorted().joined(separator: ",") ?? "(none)"
+        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId) optionKeys=\(optionKeys)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")
 
         do {
             // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
+            startupStage = "pre-start cleanup"
             await teardownForStop(reason: "pre-start cleanup")
 
+            startupStage = "path monitor"
             startPathLogging()
 
+            startupStage = "go logger init"
             let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
             logs.writeLog(log: "Start go logger init path = \(path)")
             Cloak_outlineInitLogger(path)
             logs.writeLog(log: "Finish go logger init")
-            Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
+            startupStage = "geo routing config"
+            let geoRoutingConf = configsRepository.getGeoRoutingConf()
+            logs.writeLog(log: "[DEBUG][Routing] applying geo routing config length=\(geoRoutingConf.count)")
+            Cloak_outlineSetGeoRoutingConf(geoRoutingConf)
 
+            startupStage = "route exclusions"
             let cloakConfig = configsRepository.getCloakConfig()
             // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
             // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
@@ -101,7 +143,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                         )
                     }
                 } else {
-                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(trimmed)")
+                    logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
             }
             if let remoteHost = extractRemoteHost(from: cloakConfig) {
@@ -130,8 +172,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             // Cloak must bind/connect before the full-tunnel route is installed; otherwise
             // iOS can route the upstream bootstrap traffic into a tunnel that is not ready yet.
+            startupStage = "cloak startup"
+            logs.writeLog(log: "[tunnel:\(tunnelId)] starting Cloak phase")
             try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
 
+            startupStage = "network settings build"
             let remoteAddress = "254.1.1.1"
             let localAddress = "198.18.0.1"
             let subnetMask = "255.255.0.0"
@@ -149,14 +194,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             settings.dnsSettings = NEDNSSettings(servers: dnsServers)
             settings.dnsSettings?.matchDomains = [""]
 
-            logs.writeLog(log: "Settings are ready:")
+            logNetworkSettings(
+                localAddress: localAddress,
+                remoteAddress: remoteAddress,
+                subnetMask: subnetMask,
+                mtu: tunnelMTU,
+                dnsServers: dnsServers,
+                excludedRoutes: excludedRoutes
+            )
+            startupStage = "setTunnelNetworkSettings"
+            let settingsStart = Date()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings begin")
             try await self.setTunnelNetworkSettings(settings)
-            logs.writeLog(log: "Tunnel settings applied")
+            logs.writeLog(
+                log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings applied in \(elapsedMs(since: settingsStart))ms"
+            )
 
             logInterfaces()
 
+            startupStage = "packetFlow bridge"
             let bridgeTunnelId = tunnelId
             let bridgeLogs = logs
+            logs.writeLog(log: "[tunnel:\(tunnelId)] creating PacketFlowBridge mtu=\(tunnelMTU)")
             let bridge = try PacketFlowBridge(
                 packetFlow: packetFlow,
                 mtu: tunnelMTU,
@@ -168,10 +227,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             packetFlowBridge = bridge
             bridge.start()
 
+            startupStage = "outline startup"
+            logs.writeLog(log: "[tunnel:\(tunnelId)] starting Outline phase tunnelFD=\(bridge.tunnelFileDescriptor) mtu=\(tunnelMTU)")
             try outlineInteractor.startOutline(
                 tunnelFileDescriptor: bridge.tunnelFileDescriptor,
                 mtu: tunnelMTU,
                 nativeClientCreated: {
+                    bridgeLogs.writeLog(log: "[tunnel:\(bridgeTunnelId)] native Outline client created; releasing bridge fd to Go")
                     bridge.releaseTunnelFileDescriptor()
                 }
             )
@@ -182,7 +244,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let nsError = error as NSError
             logs.writeLog(
                 log: "[tunnel:\(tunnelId)] startTunnel failed: " +
-                    "\(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
+                    "stage=\(startupStage) \(nsError.domain) code=\(nsError.code) desc=\(error.localizedDescription)"
             )
             await teardownForStop(reason: "startTunnel failure")
             throw error
@@ -219,8 +281,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
         if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory")
             completionHandler?("Memory:\(reportMemoryUsageMB())".data(using: .utf8))
         } else {
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage echo bytes=\(messageData.count)")
             completionHandler?(messageData)
         }
     }
@@ -233,15 +297,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
-            let status = path.status
-            if self.lastPathStatus != status {
-                self.lastPathStatus = status
-                let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
-                let expensive = path.isExpensive
-                let constrained = path.isConstrained
+            let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
+            let expensive = path.isExpensive
+            let constrained = path.isConstrained
+            let fingerprint = "status=\(path.status)|ifaces=\(ifaces)|expensive=\(expensive)|constrained=\(constrained)"
+            if self.lastPathFingerprint != fingerprint {
+                self.lastPathFingerprint = fingerprint
                 self.logs.writeLog(
                     log: "[tunnel:\(self.tunnelId)] pathUpdate " +
-                        "status=\(status) ifaces=[\(ifaces)] " +
+                        "status=\(path.status) ifaces=[\(ifaces)] " +
                         "expensive=\(expensive) constrained=\(constrained)"
                 )
             }
@@ -256,28 +320,57 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason))")
 
         do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Outline")
             try outlineInteractor.stopOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] Outline stopped")
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
         }
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping PacketFlowBridge")
         packetFlowBridge?.stop()
         packetFlowBridge = nil
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Cloak")
         cloakInteractor.stopCloak()
 
         do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing tunnel network settings")
             try await self.setTunnelNetworkSettings(nil)
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] cleared tunnel network settings")
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] failed to clear tunnel network settings: \(error.localizedDescription)")
         }
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping NWPathMonitor")
         pathMonitor?.cancel()
         pathMonitor = nil
-        lastPathStatus = nil
+        lastPathFingerprint = nil
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
+    }
+
+    private func logNetworkSettings(
+        localAddress: String,
+        remoteAddress: String,
+        subnetMask: String,
+        mtu: Int,
+        dnsServers: [String],
+        excludedRoutes: [NEIPv4Route]
+    ) {
+        let excluded = excludedRoutes
+            .map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }
+            .joined(separator: ",")
+        logs.writeLog(
+            log: "[DEBUG][tunnel:\(tunnelId)] network settings " +
+            "local=\(localAddress) remote=\(remoteAddress) mask=\(subnetMask) mtu=\(mtu) " +
+            "dns=\(dnsServers.joined(separator: ",")) included=default " +
+            "excluded=\(excluded.isEmpty ? "(none)" : excluded) ipv6=disabled"
+        )
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 
     /// Extracts the host/IP part from a string like "ip:port" or "[ipv6]:port".
@@ -320,6 +413,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         guard !trimmed.isEmpty else { return nil }
         if isValidIPv4(trimmed) { return trimmed }
 
+        let start = Date()
+        logs.writeLog(log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed))")
+
         var hints = addrinfo(
             ai_flags: AI_ADDRCONFIG,
             ai_family: AF_INET,
@@ -332,14 +428,25 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         )
         var res: UnsafeMutablePointer<addrinfo>?
         let rc = getaddrinfo(trimmed, nil, &hints, &res)
-        guard rc == 0, let first = res else { return nil }
+        guard rc == 0, let first = res else {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) failed " +
+                "rc=\(rc) error=\(String(cString: gai_strerror(rc))) elapsed=\(elapsedMs(since: start))ms"
+            )
+            return nil
+        }
         defer { freeaddrinfo(res) }
 
         var addr = first.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee.sin_addr }
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         let ptr = inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN))
         guard ptr != nil else { return nil }
-        return String(cString: buffer)
+        let value = String(cString: buffer)
+        logs.writeLog(
+            log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) ok " +
+            "ip=\(maskStr(value: value)) elapsed=\(elapsedMs(since: start))ms"
+        )
+        return value
     }
 
     private func resolveIPv4IfNeededWithTimeout(_ host: String, timeout: TimeInterval) -> String? {
@@ -358,6 +465,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: host)) " +
+                "timed out after \(Int(timeout * 1000))ms"
+            )
             return nil
         }
         lock.lock()


### PR DESCRIPTION
## Summary

This PR expands VPN observability so an iOS failure can be diagnosed from logs instead of requiring source-level reconstruction.

It is stacked on PR #147 (`codex/ios-packetflow-hardening`) because the most important missing signal is packetFlow-level visibility: tunnel establishment can succeed while traffic forwarding silently stalls.

## Why

The latest iOS log (`DobbyVPN_logs_2026-05-02_09-49-14.txt`) was ambiguous:

- the app reached `VPN connected`
- Outline/tun2socks emitted TCP/UDP `OK` logs
- health checks repeatedly timed out on HTTP before intermittently succeeding
- after user stop, an in-flight health check continued logging failures
- the log still contained `Start fd search` / `Fd was found`, which means the tested build was not running the packetFlow bridge from PR #147

That left several meaningful gaps:

- no proof that packets crossed the Swift `packetFlow` bridge in both directions
- no stage marker for where `startTunnel` failed when native or NetworkExtension setup throws
- no timing or details for `setTunnelNetworkSettings`
- no route-resolution timing/errors for excluded upstream routes
- no visibility into path changes unless only `NWPath.Status` changed
- no correlation between health-check ticks and short/full diagnostic decisions
- DNS resolver error strings were incorrectly counted as DNS group success
- teardown did not log each native subsystem stop/cleanup step

## Changes

- Adds explicit iOS tunnel startup stages, network settings details, route-resolution timing/errors, `setTunnelNetworkSettings` timing, and native Outline fd handoff logs.
- Adds PacketFlowBridge DEBUG stats: first packet in each direction, periodic packet/byte counts, drops, empty read batches, oversized packets, and final stop summary.
- Logs NWPath changes using status + interfaces + expensive/constrained flags, not just status.
- Adds health-check correlation IDs and tick IDs so short/full checks and results can be matched to a manager tick.
- Makes cancelled/inactive health-check results explicit.
- Fixes DNS diagnostics so resolver errors fail the DNS group instead of being reported as OK.
- Adds Go-side observability for engine start/stop config, proxy dial errors, protected direct dial local/remote addresses, Outline transport summary, and SOCKS local/remote addresses.

## Validation

- `gofmt` on changed Go files
- `go test ./tunnel ./tunnel/protected_dialer ./tunnel/platform_engine ./outline`
- `GOOS=ios GOARCH=arm64 go test ./tunnel ./tunnel/protected_dialer ./tunnel/platform_engine ./outline`
- `GOOS=android GOARCH=arm64 go test ./tunnel ./tunnel/protected_dialer ./tunnel/platform_engine ./outline`
- `git diff --check`

Not completed locally:

- `./gradlew detekt` is blocked in this environment. The default Java is `25.0.3-ea`, which Gradle/Kotlin cannot parse; with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`, Gradle proceeds but fails because `ANDROID_HOME` / Android SDK is not configured.
- Xcode/iOS NetworkExtension build and device test were not available in this Linux environment.
