### PR TITLE
Improve iOS tunnel runtime diagnostics

### DIFF
--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -4,10 +4,13 @@ import com.dobby.feature.logging.Logger
 import com.dobby.feature.main.domain.DobbyConfigsRepository
 import com.dobby.feature.main.presentation.MainViewModel
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
@@ -95,6 +98,9 @@ class HealthCheckManager(
                     val result = isConnected(tickId)
                     logger.log("[HC] tick#$tickId isConnected() result = $result")
                     result
+                } catch (cancelled: CancellationException) {
+                    logger.log("[HC] tick#$tickId cancelled while health checks were running")
+                    throw cancelled
                 } catch (t: Throwable) {
                     logger.log("[HC] tick#$tickId isConnected() threw exception: ${t.message}")
                     false
@@ -204,15 +210,19 @@ class HealthCheckManager(
         mainViewModel.stopVpnService()
     }
 
-    private fun isConnected(tickId: Int): Boolean {
+    private suspend fun isConnected(tickId: Int): Boolean {
+        currentCoroutineContext().ensureActive()
         var result = false
         if (lastFullConnectionSucceed) {
             logger.log("[HC] tick#$tickId using shortConnectionCheckUp() first")
             result = healthCheck.shortConnectionCheckUp()
+            currentCoroutineContext().ensureActive()
         }
         if (!result) {
+            currentCoroutineContext().ensureActive()
             logger.log("[HC] tick#$tickId using fullConnectionCheckUp()")
             result = healthCheck.fullConnectionCheckUp()
+            currentCoroutineContext().ensureActive()
             lastFullConnectionSucceed = result
             logger.log("[HC] tick#$tickId fullConnectionCheckUp() result=$result")
         }

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/presentation/MainViewModel.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/presentation/MainViewModel.kt
@@ -245,7 +245,7 @@ class MainViewModel(
             configsRepository.clearOutlineAndCloakConfig()
             connectionStateRepository.tryUpdateStatus(false)
         }
-        logger.log("VPN service stopped successfully, state reset to disconnected")
+        logger.log("VPN stop requested; local state reset to disconnected while OS tunnel tears down")
     }
 
     private fun updateServerTargetFromConfig(): Boolean {

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -59,6 +59,7 @@ public final class HealthCheckImpl: HealthCheck {
 
     private let logs = NativeModuleHolder.logsRepository
     private let timeout: TimeInterval = 4.0
+    private let tunnelIPAddress = "198.18.0.1"
 
     public private(set) var currentMemmoryUsageMb = 0.0
     private var lastMemoryMB: Double = 0
@@ -82,7 +83,7 @@ public final class HealthCheckImpl: HealthCheck {
             self.runWithRetry(name: name, block: check)
         }
 
-        let vpnOk = runWithRetry(name: "VPN Interface Check", attempts: 1) {
+        let vpnOk = runWithRetry(name: "Dobby Tunnel IP Check", attempts: 1) {
             self.isVPNInterfaceExists()
         }
 
@@ -404,12 +405,20 @@ public final class HealthCheckImpl: HealthCheck {
         return success
     }
 
-    // Checks if tunnel IP 198.18.0.1 is assigned to at least one interface.
+    // Checks if Dobby's configured tunnel IP is assigned to at least one interface.
     // If not — the tunnel did not come up at OS network level.
     private func isTunnelIPAssigned() -> Bool {
-        let tunnelIP = "198.18.0.1"
+        if let name = interfaceName(forIPv4: tunnelIPAddress) {
+            logs.writeLog(log: "[HC] [diag] tunnel IP \(tunnelIPAddress) found on \(name)")
+            return true
+        }
+        logs.writeLog(log: "[HC] [diag] tunnel IP \(tunnelIPAddress) NOT found on any interface")
+        return false
+    }
+
+    private func interfaceName(forIPv4 targetIP: String) -> String? {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return false }
+        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return nil }
         defer { freeifaddrs(ifaddrPtr) }
 
         var ptr: UnsafeMutablePointer<ifaddrs>? = first
@@ -421,17 +430,14 @@ public final class HealthCheckImpl: HealthCheck {
                 }
                 if inet_ntop(AF_INET, &sa, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
                     let ip = String(cString: buffer)
-                    if ip == tunnelIP {
-                        let name = String(cString: addr.pointee.ifa_name)
-                        logs.writeLog(log: "[HC] [diag] tunnel IP \(tunnelIP) found on \(name)")
-                        return true
+                    if ip == targetIP {
+                        return String(cString: addr.pointee.ifa_name)
                     }
                 }
             }
             ptr = addr.pointee.ifa_next
         }
-        logs.writeLog(log: "[HC] [diag] tunnel IP \(tunnelIP) NOT found on any interface")
-        return false
+        return nil
     }
 
     private func pingAddress(_ address: String, name: String) -> Bool {
@@ -495,27 +501,14 @@ public final class HealthCheckImpl: HealthCheck {
     }
 
     private func isVPNInterfaceExists() -> Bool {
-        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddrPtr) == 0, let firstAddr = ifaddrPtr else {
-            logs.writeLog(log: "[HC] [VPNIface] getifaddrs failed")
-            return false
+        if let name = interfaceName(forIPv4: tunnelIPAddress) {
+            logs.writeLog(log: "[HC] [VPNIface] Dobby tunnel IP \(tunnelIPAddress) found on \(name)")
+            return true
         }
-        defer { freeifaddrs(ifaddrPtr) }
-
-        var ptr: UnsafeMutablePointer<ifaddrs>? = firstAddr
-        while let addr = ptr {
-            let name = String(cString: addr.pointee.ifa_name).lowercased()
-            if name.contains("utun")
-                || name.contains("tun")
-                || name.contains("tap")
-                || name.contains("ppp")
-                || name.contains("ipsec") {
-                logs.writeLog(log: "[HC] [VPNIface] found: \(name)")
-                return true
-            }
-            ptr = addr.pointee.ifa_next
-        }
-        logs.writeLog(log: "[HC] [VPNIface] no VPN interface found")
+        logs.writeLog(
+            log: "[HC] [VPNIface] Dobby tunnel IP \(tunnelIPAddress) not found; " +
+                "generic utun interfaces are ignored"
+        )
         return false
     }
 

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -9,6 +9,7 @@ final class PacketFlowBridge {
     private let readQueue: DispatchQueue
     private let lock = NSLock()
     private let utunHeaderLength = 4
+    private let requestedSocketBufferBytes = 1 * 1024 * 1024
 
     private var readSource: DispatchSourceRead?
     private var statsTimer: DispatchSourceTimer?
@@ -63,8 +64,15 @@ final class PacketFlowBridge {
         do {
             try disableSigpipe(swiftFileDescriptor)
             try disableSigpipe(goFileDescriptor)
+            let swiftBuffers = configureSocketBuffers(swiftFileDescriptor, requestedBytes: requestedSocketBufferBytes)
+            let goBuffers = configureSocketBuffers(goFileDescriptor, requestedBytes: requestedSocketBufferBytes)
             try setNonBlocking(swiftFileDescriptor)
             try setNonBlocking(goFileDescriptor)
+            log(
+                "[DEBUG][PacketFlowBridge] socket buffers " +
+                "swiftFD=\(swiftFileDescriptor) snd=\(swiftBuffers.send) rcv=\(swiftBuffers.receive) " +
+                "goFD=\(goFileDescriptor) snd=\(goBuffers.send) rcv=\(goBuffers.receive)"
+            )
         } catch {
             closeIfOpen(&swiftFileDescriptor)
             closeIfOpen(&goFileDescriptor)
@@ -164,12 +172,13 @@ final class PacketFlowBridge {
             }
             return Darwin.write(fd, baseAddress, framedPacket.count)
         }
+        let writeErrno = errno
 
         if written != framedPacket.count {
             recordTunnelToGoDrop()
             logWriteError(
                 "write packet to Go failed packetBytes=\(packet.count) framedBytes=\(framedPacket.count) " +
-                "written=\(written) errno=\(errno) \(errnoDescription())"
+                "written=\(written) errno=\(writeErrno) \(errnoDescription(writeErrno))"
             )
             return
         }
@@ -190,6 +199,7 @@ final class PacketFlowBridge {
                 }
                 return Darwin.read(fd, baseAddress, rawBuffer.count)
             }
+            let readErrno = errno
 
             if readCount > 0 {
                 guard readCount > utunHeaderLength else {
@@ -208,10 +218,10 @@ final class PacketFlowBridge {
                 return
             }
 
-            if errno == EAGAIN || errno == EWOULDBLOCK {
+            if readErrno == EAGAIN || readErrno == EWOULDBLOCK {
                 return
             }
-            logReadError("read packet from Go failed errno=\(errno) \(errnoDescription())")
+            logReadError("read packet from Go failed errno=\(readErrno) \(errnoDescription(readErrno))")
             return
         }
     }
@@ -306,6 +316,8 @@ final class PacketFlowBridge {
         let t2gDrops = tunnelToGoDrops
         let g2tDrops = goToTunnelDrops
         let oversized = oversizedPacketCount
+        let writeErrors = writeErrorCount
+        let readErrors = readErrorCount
         let isActive = running
         lock.unlock()
 
@@ -314,7 +326,8 @@ final class PacketFlowBridge {
             "batches=\(batches) emptyBatches=\(emptyBatches) " +
             "tunnel_to_go=\(t2gPackets)p/\(t2gBytes)B " +
             "go_to_tunnel=\(g2tPackets)p/\(g2tBytes)B " +
-            "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) oversized=\(oversized)"
+            "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) " +
+            "oversized=\(oversized) writeErrors=\(writeErrors) readErrors=\(readErrors)"
         )
     }
 
@@ -368,8 +381,8 @@ final class PacketFlowBridge {
         }
     }
 
-    private func errnoDescription() -> String {
-        String(cString: strerror(errno))
+    private func errnoDescription(_ value: Int32) -> String {
+        String(cString: strerror(value))
     }
 
     private func setNonBlocking(_ fd: Int32) throws {
@@ -394,6 +407,52 @@ final class PacketFlowBridge {
         guard result == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
+    }
+
+    private func configureSocketBuffers(_ fd: Int32, requestedBytes: Int) -> (send: Int, receive: Int) {
+        var sendBuffer = Int32(requestedBytes)
+        let sendResult = setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_SNDBUF,
+            &sendBuffer,
+            socklen_t(MemoryLayout<Int32>.size)
+        )
+        if sendResult != 0 {
+            let setErrno = errno
+            log(
+                "[PacketFlowBridge] failed to set SO_SNDBUF fd=\(fd) " +
+                "requested=\(requestedBytes) errno=\(setErrno) \(errnoDescription(setErrno))"
+            )
+        }
+
+        var receiveBuffer = Int32(requestedBytes)
+        let receiveResult = setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_RCVBUF,
+            &receiveBuffer,
+            socklen_t(MemoryLayout<Int32>.size)
+        )
+        if receiveResult != 0 {
+            let setErrno = errno
+            log(
+                "[PacketFlowBridge] failed to set SO_RCVBUF fd=\(fd) " +
+                "requested=\(requestedBytes) errno=\(setErrno) \(errnoDescription(setErrno))"
+            )
+        }
+
+        return (
+            send: socketBufferSize(fd: fd, option: SO_SNDBUF),
+            receive: socketBufferSize(fd: fd, option: SO_RCVBUF)
+        )
+    }
+
+    private func socketBufferSize(fd: Int32, option: Int32) -> Int {
+        var value: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        let result = getsockopt(fd, SOL_SOCKET, option, &value, &length)
+        return result == 0 ? Int(value) : -1
     }
 
     private func closeIfOpen(_ fd: inout Int32) {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -257,7 +257,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         Cloak_outlineClearGeoRoutingConf()
         Task {
             await teardownForStop(reason: "stopTunnel(\(reason))")
+            logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel teardown complete; calling completionHandler")
             completionHandler()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel completionHandler returned")
         }
     }
 


### PR DESCRIPTION
## Summary

This PR improves iOS tunnel runtime stability diagnostics and removes two misleading signals from the latest failure log.

The latest log (`DobbyVPN_logs_2026-05-02_19-21-33.txt`) does **not** show a tunnel startup failure:

- `setTunnelNetworkSettings` succeeds.
- Dobby's tunnel IP `198.18.0.1` appears on `utun5`.
- `PacketFlowBridge` sees first packets in both directions.
- Outline/tun2socks starts successfully.
- SOCKS dials go through the configured upstream `<...>:443`.
- Health check reports `DIAGNOSIS: ALL OK — connection is working` at `17:20:39`.

The suspicious runtime signal is instead packet-flow backpressure:

```text
[PacketFlowBridge] write packet to Go failed ... errno=55 No buffer space available
```

That means Swift read packets from `NEPacketTunnelFlow`, but the local socketpair feeding Go/tun2socks could not accept them fast enough, so packets were dropped before Go could process them.

The later `tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level` diagnosis happens after the user has already requested stop and the health job has been cancelled. That diagnosis is therefore misleading for the real failure.

## Changes

- Increase iOS `PacketFlowBridge` socket send/receive buffers and log the effective buffer sizes.
- Preserve exact `errno` values for bridge read/write failures instead of reading `errno` after additional calls may have overwritten it.
- Add bridge read/write error counters to periodic stats.
- Make the iOS short health check validate Dobby's exact tunnel IP (`198.18.0.1`) instead of accepting any generic `utun` interface.
- Make the shared health-check manager cancellation-aware so a cancelled tick does not publish/act on stale full-diagnostic results after manual stop.
- Clarify stop logging: app-level stop is a stop request, not proof the OS tunnel has fully torn down.
- Add `stopTunnel` completion markers so the next log shows whether NetworkExtension teardown reached the completion handler.

## Why

The log proves that the startup path fixed by the previous PRs is no longer the primary suspect for this sample. The tunnel comes up and passes data. The next narrowest hypothesis is runtime packet loss/backpressure between `NEPacketTunnelFlow` and Go's fd-backed tun2socks engine.

This PR does not guess at a larger transport rewrite. It makes the known drop point less fragile and makes the next log decisive:

- If `errno=55` disappears, the socket buffer was too small for bursty traffic.
- If drops continue while buffers are large, the bottleneck is likely Go/tun2socks consumption speed or workload/concurrency behind it.
- If stop still hangs, the new stop completion logs show whether the stall is before or after the NetworkExtension completion handler.

## Validation

Passed:

- `git diff --check`

Attempted but blocked locally:

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 GRADLE_USER_HOME=/tmp/dobby-gradle ./gradlew :app:compileKotlinMetadata`
- This Linux checkout does not have `ANDROID_HOME` / Android SDK configured, so Gradle fails while configuring `:awg`.

Not run locally:

- Xcode/iOS NetworkExtension build and real-device VPN test, because this environment is Linux-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced health check resilience with improved handling of connection validation during coroutine cancellation.
  * Improved tunnel IP detection logic for more reliable VPN connectivity verification.
  * Optimized socket buffer configuration and error logging for enhanced packet flow stability.
  * Enhanced diagnostic logging throughout VPN service lifecycle for better troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->