### PR TITLE
Stabilize iOS WSS DNS and teardown

### DIFF
--- a/go_module/ios_exports/outline.go
+++ b/go_module/ios_exports/outline.go
@@ -44,7 +44,9 @@ func NewOutlineClient(transportConfig string, tunnelFD int, mtu int) (err error)
 	log.Infof("Using tunnel fd=%d mtu=%d", tunnelFD, mtu)
 	log.Infof("Config length=%d", len(transportConfig))
 
-	client = outline.NewClientWithFD(transportConfig, tunnelFD, mtu)
+	client = outline.NewClientWithFDAndOptions(transportConfig, tunnelFD, mtu, outline.ClientOptions{
+		PreferTCPDNSForWebSocket: true,
+	})
 
 	log.Infof("NewOutlineClient() finished")
 	return nil

--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -23,6 +23,11 @@ type OutlineClient struct {
 	engineStarted bool
 	config        string
 	mtu           int
+	options       ClientOptions
+}
+
+type ClientOptions struct {
+	PreferTCPDNSForWebSocket bool
 }
 
 func NewClient(transportConfig string, tun io.ReadWriteCloser) *OutlineClient {
@@ -40,15 +45,26 @@ func NewClientWithMTU(transportConfig string, tun io.ReadWriteCloser, mtu int) *
 }
 
 func NewClientWithFD(transportConfig string, fd int, mtu int) *OutlineClient {
+	return NewClientWithFDAndOptions(transportConfig, fd, mtu, ClientOptions{})
+}
+
+func NewClientWithFDAndOptions(transportConfig string, fd int, mtu int, options ClientOptions) *OutlineClient {
 	if mtu <= 0 {
 		mtu = 1200
 	}
 	c := &OutlineClient{
-		config: transportConfig,
-		tunFD:  fd,
-		mtu:    mtu,
+		config:  transportConfig,
+		tunFD:   fd,
+		mtu:     mtu,
+		options: options,
 	}
-	log.Infof("outline client created (tun2socks version) fd=%d mtu=%d configLen=%d", fd, mtu, len(transportConfig))
+	log.Infof(
+		"outline client created (tun2socks version) fd=%d mtu=%d configLen=%d preferTCPDNSForWebSocket=%v",
+		fd,
+		mtu,
+		len(transportConfig),
+		options.PreferTCPDNSForWebSocket,
+	)
 	common.Client.SetVpnClient(outlineCommon.Name, c)
 	return c
 }
@@ -61,7 +77,9 @@ func (c *OutlineClient) Connect() error {
 			log.Infof("RECOVERED from fail in Connect: %v", r)
 		}
 	}()
-	od, err := internal.NewOutlineDevice(c.config)
+	od, err := internal.NewOutlineDeviceWithOptions(c.config, internal.DeviceOptions{
+		PreferTCPDNSForWebSocket: c.options.PreferTCPDNSForWebSocket,
+	})
 	if err != nil {
 		log.Infof("failed to create outline device: %v\n", err)
 		return err

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -24,9 +24,18 @@ type OutlineDevice struct {
 	streamDialer transport.StreamDialer
 	packetDialer transport.PacketDialer
 	useCloak     bool
+	preferTCPDNS bool
+}
+
+type DeviceOptions struct {
+	PreferTCPDNSForWebSocket bool
 }
 
 func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
+	return NewOutlineDeviceWithOptions(transportConfig, DeviceOptions{})
+}
+
+func NewOutlineDeviceWithOptions(transportConfig string, options DeviceOptions) (*OutlineDevice, error) {
 	ip, err := ResolveServerIPFromConfig(transportConfig)
 	if err != nil {
 		return nil, err
@@ -48,12 +57,14 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	hasUDPPath := strings.Contains(transportConfig, "udp_path=")
 	hasTCPPath := strings.Contains(transportConfig, "tcp_path=")
 	isWebSocket := strings.Contains(transportConfig, "ws:")
+	preferTCPDNS := options.PreferTCPDNSForWebSocket && isWebSocket
 	log.Infof(
-		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v streamDialer=%T packetDialer=%T",
+		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v streamDialer=%T packetDialer=%T",
 		len(transportConfig),
 		isWebSocket,
 		hasTCPPath,
 		hasUDPPath,
+		preferTCPDNS,
 		sd,
 		pd,
 	)
@@ -67,6 +78,7 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 		streamDialer: sd,
 		packetDialer: pd,
 		useCloak:     useCloak,
+		preferTCPDNS: preferTCPDNS,
 	}
 
 	server := socks5.NewServer(
@@ -116,9 +128,9 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 
 	case "udp":
 
-		// DNS fallback for Cloak
-		if d.useCloak && port == 53 {
-			log.Infof("[SOCKS5 DNS] returning truncated DNS (cloak mode)")
+		// Force DNS-over-TCP fallback when UDP is known to be unreliable for this transport.
+		if port == 53 && (d.useCloak || d.preferTCPDNS) {
+			log.Infof("[SOCKS5 DNS] returning truncated DNS (useCloak=%v preferTCPDNS=%v)", d.useCloak, d.preferTCPDNS)
 			return newTruncatedDNSConn(host, port), nil
 		}
 
@@ -159,8 +171,14 @@ func (c *truncatedDNSConn) Read(b []byte) (int, error) {
 	// truncated
 	resp[2] |= 0x02
 
+	// Preserve the original question but return no records. The TC bit is the
+	// signal that the resolver should retry the same question over TCP.
 	resp[6] = 0
 	resp[7] = 0
+	resp[8] = 0
+	resp[9] = 0
+	resp[10] = 0
+	resp[11] = 0
 
 	n := copy(b, resp)
 	return n, nil

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -58,7 +58,7 @@ public final class HealthCheckImpl: HealthCheck {
     public static let shared = HealthCheckImpl()
 
     private let logs = NativeModuleHolder.logsRepository
-    private let timeout: TimeInterval = 4.0
+    private let timeout: TimeInterval = 8.0
     private let tunnelIPAddress = "198.18.0.1"
 
     public private(set) var currentMemmoryUsageMb = 0.0
@@ -115,11 +115,10 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(log: "[HC] Start fullConnectionCheckUp id=\(checkId)")
 
         // --- Standard check groups ---
-        let groups: [(String, [(String, () -> Bool)])] = [
-            ("TCP Ping group", [
-                ("Ping 8.8.8.8", { self.pingAddress("8.8.8.8:53", name: "Google") }),
-                ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
-            ]),
+        // On iOS, net.Dial based TCP probes can complete against the local
+        // virtual TCP stack before the upstream proxy dial has succeeded.
+        // Run DNS/HTTP first; only run TCP probes as diagnostics if required checks fail.
+        let requiredCheckGroups: [(String, [(String, () -> Bool)])] = [
             ("DNS Resolve group", [
                 ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") }),
                 ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") })
@@ -127,10 +126,15 @@ public final class HealthCheckImpl: HealthCheck {
             ("DNS Ping group", [
                 ("Ping google.com (DNS)", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
                 ("Ping one.one.one.one (DNS)", { self.pingAddress("one.one.one.one:80", name: "OnesDNS") })
+            ])
+        ]
+
+        let diagnosticCheckGroups: [(String, [(String, () -> Bool)])] = [
+            ("TCP Ping diagnostics", [
+                ("Ping 8.8.8.8", { self.pingAddress("8.8.8.8:53", name: "Google") }),
+                ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
             ]),
-            // TCP to 443 — verifies HTTPS traffic flows at TCP level through the proxy.
-            // If TCP ping :53 is OK but :443 fails — server blocks 443 or routing is broken.
-            ("TCP :443 group", [
+            ("TCP :443 diagnostics", [
                 ("Ping 8.8.8.8:443", { self.pingAddress("8.8.8.8:443", name: "TCP443-8888") }),
                 ("Ping 1.1.1.1:443", { self.pingAddress("1.1.1.1:443", name: "TCP443-1111") })
             ])
@@ -139,7 +143,7 @@ public final class HealthCheckImpl: HealthCheck {
         var failedGroups: [String] = []
         var groupResults: [String: Bool] = [:]
 
-        for (groupName, checks) in groups {
+        for (groupName, checks) in requiredCheckGroups {
             logs.writeLog(log: "[HC] Checking group: \(groupName)")
             let groupOk = checks.contains { name, check in
                 self.runWithRetry(name: name, block: check)
@@ -163,6 +167,18 @@ public final class HealthCheckImpl: HealthCheck {
             logs.writeLog(log: "[HC] Group OK: Short health check group")
         }
 
+        if !failedGroups.isEmpty {
+            logs.writeLog(log: "[HC] Required checks failed → running TCP diagnostic groups")
+            for (groupName, checks) in diagnosticCheckGroups {
+                logs.writeLog(log: "[HC] Checking group: \(groupName)")
+                let groupOk = checks.contains { name, check in
+                    self.runWithRetry(name: name, block: check)
+                }
+                groupResults[groupName] = groupOk
+                logs.writeLog(log: "[HC] Group \(groupOk ? "OK" : "DIAGNOSTIC FAILED"): \(groupName)")
+            }
+        }
+
         // --- Additional diagnostic tests (do not affect the result) ---
         logs.writeLog(log: "[HC] [diag] === Diagnostic checks ===")
 
@@ -181,9 +197,9 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result)")
 
         // --- DIAGNOSIS — single line with actionable verdict ---
-        let tcpProxyOk = groupResults["TCP Ping group"] ?? false
+        let tcpProxyOk = groupResults["TCP Ping diagnostics"] ?? true
         let dnsOk = groupResults["DNS Resolve group"] ?? false
-        let tcp443Ok = groupResults["TCP :443 group"] ?? false
+        let tcp443Ok = groupResults["TCP :443 diagnostics"] ?? true
         let httpsOk = shortOk
         logDiagnosis(
             tunnelIP: tunnelIPOk,
@@ -215,16 +231,16 @@ public final class HealthCheckImpl: HealthCheck {
         switch (tunnelIP, tcpProxy, dns, tcp443, https) {
         case (false, _, _, _, _):
             diagnosis = "SIDE: CLIENT | REASON: tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level"
-        case (true, false, _, _, _):
-            diagnosis = "SIDE: CLIENT | REASON: TCP via SOCKS5 proxy not working — tun2socks not forwarding traffic or Go engine crashed"
-        case (true, true, false, _, _):
-            diagnosis = "SIDE: CLIENT | REASON: DNS not resolving — wrong DNS servers in tunnel or their traffic is blocked"
-        case (true, true, true, false, _):
-            diagnosis = "SIDE: SERVER (likely) | REASON: TCP :53 OK but TCP :443 failing — server blocks HTTPS port or intermediate node filters it"
-        case (true, true, true, true, false):
+        case (true, _, false, _, _):
+            diagnosis = "SIDE: CLIENT OR SERVER | REASON: DNS not resolving — DNS-over-tunnel is failing or blocked"
+        case (true, _, true, _, false):
             // Check metrics[win] in logs: proto=h3+total=- → QUIC/UDP not proxied (no udpPath? pool full?);
             // proto=h2+high total → server is slow or blocking TLS
             diagnosis = "SIDE: CLIENT OR SERVER | REASON: TCP :443 OK but HTTPS failing — check [win] in metrics: h3+total=- → UDP not proxied; h2+total=NNNms → slow/blocking server"
+        case (true, false, true, _, _):
+            diagnosis = "SIDE: CLIENT | REASON: TCP diagnostic failed after DNS/HTTP checks — possible tun2socks forwarding issue"
+        case (true, true, true, false, _):
+            diagnosis = "SIDE: SERVER (likely) | REASON: TCP diagnostic to :443 failed — server blocks HTTPS port or intermediate node filters it"
         case (true, true, true, true, true):
             diagnosis = "ALL OK — connection is working"
         default:

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -321,6 +321,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private func teardownForStop(reason: String) async {
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason))")
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping PacketFlowBridge")
+        packetFlowBridge?.stop()
+        packetFlowBridge = nil
+
         do {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Outline")
             try outlineInteractor.stopOutline()
@@ -328,10 +332,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         } catch {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
         }
-
-        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping PacketFlowBridge")
-        packetFlowBridge?.stop()
-        packetFlowBridge = nil
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Cloak")
         cloakInteractor.stopCloak()


### PR DESCRIPTION
## Summary

This PR targets the latest iOS failure log from `2026-05-02 20:32` after the runtime diagnostics PR was merged.

The new log shows that iOS is no longer failing at tunnel setup:

- `setTunnelNetworkSettings` succeeds.
- `utun5` gets `198.18.0.1`.
- `PacketFlowBridge` starts and passes packets in both directions.
- `OutlineConnect succeeded` and the app reports `VPN connected`.
- `PacketFlowBridge` stats show zero tunnel/go drops, zero oversized packets, and zero read/write errors.

The dominant failure in the log is instead DNS over UDP through the WebSocket transport:

- repeated `SOCKS5 UDP ERROR ... 1.1.1.1:53 ... websocket: bad handshake`
- repeated `SOCKS5 UDP ERROR ... 8.8.8.8:53 ... websocket: bad handshake`
- `activeUDP` rises quickly up to `25/150`
- the run is on constrained cellular: `expensive=true constrained=true`

The stop path also still looks suspicious: the log reaches `[Engine] stopping tun2socks engine` but never logs engine stopped / `OutlineDisconnect returned` / teardown completion.

## Changes

- Add mobile Outline client options and enable `PreferTCPDNSForWebSocket` only for the iOS export path.
- For iOS WebSocket configs, return a truncated DNS response for UDP port 53 so resolvers retry DNS over TCP instead of opening many failing UDP-over-WebSocket sessions.
- Keep the existing Cloak DNS fallback behavior.
- Log whether WebSocket DNS TCP fallback is enabled in the Go transport summary.
- Treat iOS TCP health probes as diagnostics rather than primary success signals, because `net.Dial` can complete against the local NetworkExtension/TUN path before the upstream proxy dial has actually succeeded.
- Increase iOS health-check timeout from 4s to 8s to match the 4-6s WebSocket failures seen in the log.
- Stop `PacketFlowBridge` before stopping Outline during teardown so the fd-backed Go engine is not left waiting on the Swift-side socketpair while shutting down.

## Reasoning

The latest log does not point to packet bridge loss or OS tunnel setup failure. It points to WSS UDP/DNS instability and misleading health-check interpretation:

- UDP DNS failures are the repeated actionable error.
- TCP/WebSocket sometimes works, so forcing DNS to TCP is a narrower and safer iOS-specific mitigation than changing the whole transport.
- Existing TCP ping checks can produce false confidence on iOS NetworkExtension, so DNS/HTTP are better primary health signals and TCP probes should be diagnostic only.
- Teardown currently starts by stopping Outline, then the log ends inside Go engine shutdown while UDP sessions are still closing; stopping the bridge first should unblock the fd path earlier.

## Validation

- `go test -mod=readonly ./outline ./outline/internal`
- `git diff --check`

Known limitation:

- `go test -mod=readonly ./ios_exports` is still blocked by the existing module state: `go: updates to go.mod needed, disabled by -mod=readonly`. I did not run `go mod tidy` because that would introduce unrelated module churn.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP DNS preference option for WebSocket-based connections to improve DNS resolution reliability
  * Enhanced network health checks with improved two-phase verification system

* **Bug Fixes**
  * Optimized packet tunnel shutdown sequence for better resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->