### PR TITLE
Fix iOS Outline proxy liveness

### DIFF
--- a/go_module/ios_exports/outline.go
+++ b/go_module/ios_exports/outline.go
@@ -83,3 +83,15 @@ func OutlineDisconnect() error {
 	log.Infof("OutlineDisconnect() finished")
 	return nil
 }
+
+func OutlineStatus() (string, error) {
+	defer guardExport("OutlineStatus")()
+
+	if client == nil {
+		return "client=false engineStarted=false fd=-1 deviceNil=true localProxyAlive=false reason=client_nil", nil
+	}
+
+	status := client.Status()
+	log.Infof("OutlineStatus: %s", status)
+	return status, nil
+}

--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -142,6 +142,25 @@ func (c *OutlineClient) Disconnect() error {
 	return nil
 }
 
+func (c *OutlineClient) Status() string {
+	if c == nil {
+		return "client=false engineStarted=false fd=-1 deviceNil=true localProxyAlive=false reason=client_nil"
+	}
+	if c.device == nil {
+		return fmt.Sprintf(
+			"client=true engineStarted=%v fd=%d deviceNil=true localProxyAlive=false reason=device_nil",
+			c.engineStarted,
+			c.tunFD,
+		)
+	}
+	return fmt.Sprintf(
+		"client=true engineStarted=%v fd=%d deviceNil=false %s",
+		c.engineStarted,
+		c.tunFD,
+		c.device.Status(750*time.Millisecond),
+	)
+}
+
 func (c *OutlineClient) Refresh() error {
 	return nil
 }

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
@@ -18,6 +20,7 @@ import (
 )
 
 type OutlineDevice struct {
+	mu           sync.RWMutex
 	listener     net.Listener
 	proxyAddr    string
 	svrIP        net.IP
@@ -25,6 +28,11 @@ type OutlineDevice struct {
 	packetDialer transport.PacketDialer
 	useCloak     bool
 	preferTCPDNS bool
+	closed       atomic.Bool
+	startedAt    time.Time
+	serveState   string
+	serveErr     string
+	serveGen     int
 }
 
 type DeviceOptions struct {
@@ -79,10 +87,13 @@ func NewOutlineDeviceWithOptions(transportConfig string, options DeviceOptions) 
 		packetDialer: pd,
 		useCloak:     useCloak,
 		preferTCPDNS: preferTCPDNS,
+		startedAt:    time.Now(),
+		serveState:   "created",
 	}
 
 	server := socks5.NewServer(
 		socks5.WithDial(od.handleDial),
+		socks5.WithLogger(socksLogger{}),
 	)
 
 	lc := net.ListenConfig{}
@@ -95,14 +106,113 @@ func NewOutlineDeviceWithOptions(transportConfig string, options DeviceOptions) 
 	od.listener = listener
 	od.proxyAddr = listener.Addr().String()
 
-	go func() {
-		log.Infof("SOCKS5 started on %s", od.proxyAddr)
-		if err := server.Serve(listener); err != nil {
-			log.Infof("SOCKS5 stopped: %v", err)
+	go od.serveLoop(server)
+
+	return od, nil
+}
+
+type socksLogger struct{}
+
+func (socksLogger) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "client want to used addr") {
+		return
+	}
+	log.Infof("[SOCKS5 internal] %s", msg)
+}
+
+func (d *OutlineDevice) serveLoop(server *socks5.Server) {
+	for {
+		if d.closed.Load() {
+			d.markServeStopped("closed")
+			return
+		}
+
+		d.mu.RLock()
+		listener := d.listener
+		addr := d.proxyAddr
+		d.mu.RUnlock()
+
+		if listener == nil {
+			d.markServeStopped("listener=nil")
+			return
+		}
+
+		d.markServeRunning()
+		err := d.serveOnce(server, listener)
+		if d.closed.Load() {
+			d.markServeStopped("closed")
+			log.Infof("SOCKS5 stopped on %s: closed", addr)
+			return
+		}
+
+		errText := "nil"
+		if err != nil {
+			errText = err.Error()
+		}
+		d.markServeStopped(errText)
+		log.Infof("SOCKS5 stopped unexpectedly on %s: %s", addr, errText)
+
+		for !d.closed.Load() {
+			time.Sleep(250 * time.Millisecond)
+			if err := d.rebindListener(addr); err != nil {
+				log.Infof("SOCKS5 rebind failed on %s: %v", addr, err)
+				time.Sleep(time.Second)
+				continue
+			}
+			log.Infof("SOCKS5 rebound on %s", addr)
+			break
+		}
+	}
+}
+
+func (d *OutlineDevice) serveOnce(server *socks5.Server, listener net.Listener) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
 		}
 	}()
 
-	return od, nil
+	log.Infof("SOCKS5 started on %s", listener.Addr().String())
+	return server.Serve(listener)
+}
+
+func (d *OutlineDevice) rebindListener(addr string) error {
+	if d.closed.Load() {
+		return net.ErrClosed
+	}
+
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(context.Background(), "tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	d.mu.Lock()
+	d.listener = listener
+	d.proxyAddr = listener.Addr().String()
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *OutlineDevice) markServeRunning() {
+	d.mu.Lock()
+	d.serveGen++
+	d.serveState = "running"
+	d.serveErr = ""
+	gen := d.serveGen
+	addr := d.proxyAddr
+	d.mu.Unlock()
+	log.Infof("SOCKS5 serve generation %d running on %s", gen, addr)
+}
+
+func (d *OutlineDevice) markServeStopped(reason string) {
+	d.mu.Lock()
+	d.serveState = "stopped"
+	d.serveErr = reason
+	d.mu.Unlock()
 }
 
 func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -149,21 +259,72 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 }
 
 type truncatedDNSConn struct {
-	req []byte
+	responses chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
+	remote    net.Addr
 }
 
 func newTruncatedDNSConn(host string, port int) net.Conn {
-	return &truncatedDNSConn{}
+	return &truncatedDNSConn{
+		responses: make(chan []byte, 16),
+		done:      make(chan struct{}),
+		remote:    &net.UDPAddr{IP: net.ParseIP(host), Port: port},
+	}
 }
 
 func (c *truncatedDNSConn) Read(b []byte) (int, error) {
+	select {
+	case resp := <-c.responses:
+		n := copy(b, resp)
+		return n, nil
+	case <-c.done:
+		return 0, net.ErrClosed
+	}
+}
 
-	if len(c.req) < 12 {
-		return 0, errors.New("invalid dns packet")
+func (c *truncatedDNSConn) Write(b []byte) (int, error) {
+	select {
+	case <-c.done:
+		return 0, net.ErrClosed
+	default:
 	}
 
-	resp := make([]byte, len(c.req))
-	copy(resp, c.req)
+	resp, err := truncatedDNSResponse(b)
+	if err != nil {
+		log.Infof("[SOCKS5 DNS] invalid DNS packet for TCP fallback: %v", err)
+		return len(b), nil
+	}
+
+	select {
+	case c.responses <- resp:
+	case <-c.done:
+		return 0, net.ErrClosed
+	default:
+		// Keep SOCKS5 UDP associate from blocking forever if a resolver floods
+		// DNS requests faster than the client-side UDP relay can read replies.
+		select {
+		case <-c.responses:
+		default:
+		}
+		select {
+		case c.responses <- resp:
+		case <-c.done:
+			return 0, net.ErrClosed
+		default:
+		}
+	}
+
+	return len(b), nil
+}
+
+func truncatedDNSResponse(req []byte) ([]byte, error) {
+	if len(req) < 12 {
+		return nil, errors.New("invalid dns packet")
+	}
+
+	resp := make([]byte, len(req))
+	copy(resp, req)
 
 	// response
 	resp[2] |= 0x80
@@ -180,19 +341,18 @@ func (c *truncatedDNSConn) Read(b []byte) (int, error) {
 	resp[10] = 0
 	resp[11] = 0
 
-	n := copy(b, resp)
-	return n, nil
+	return resp, nil
 }
 
-func (c *truncatedDNSConn) Write(b []byte) (int, error) {
-	c.req = make([]byte, len(b))
-	copy(c.req, b)
-	return len(b), nil
+func (c *truncatedDNSConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
+	return nil
 }
 
-func (c *truncatedDNSConn) Close() error                       { return nil }
-func (c *truncatedDNSConn) LocalAddr() net.Addr                { return nil }
-func (c *truncatedDNSConn) RemoteAddr() net.Addr               { return nil }
+func (c *truncatedDNSConn) LocalAddr() net.Addr                { return &net.UDPAddr{IP: net.IPv4zero, Port: 0} }
+func (c *truncatedDNSConn) RemoteAddr() net.Addr               { return c.remote }
 func (c *truncatedDNSConn) SetDeadline(t time.Time) error      { return nil }
 func (c *truncatedDNSConn) SetReadDeadline(t time.Time) error  { return nil }
 func (c *truncatedDNSConn) SetWriteDeadline(t time.Time) error { return nil }
@@ -291,12 +451,76 @@ func (d *OutlineDevice) GetServerIP() net.IP {
 }
 
 func (d *OutlineDevice) GetProxyAddr() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	return d.proxyAddr
 }
 
+func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (bool, string) {
+	d.mu.RLock()
+	addr := d.proxyAddr
+	state := d.serveState
+	serveErr := d.serveErr
+	gen := d.serveGen
+	closed := d.closed.Load()
+	startedAt := d.startedAt
+	d.mu.RUnlock()
+
+	if addr == "" {
+		return false, fmt.Sprintf(
+			"localProxyAlive=false proxyAddr= serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
+			state,
+			gen,
+			closed,
+			serveErr,
+			time.Since(startedAt).Milliseconds(),
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false, fmt.Sprintf(
+			"localProxyAlive=false proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeErr=%q uptimeMs=%d",
+			addr,
+			state,
+			gen,
+			closed,
+			serveErr,
+			err.Error(),
+			time.Since(startedAt).Milliseconds(),
+		)
+	}
+	_ = conn.Close()
+
+	return true, fmt.Sprintf(
+		"localProxyAlive=true proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
+		addr,
+		state,
+		gen,
+		closed,
+		serveErr,
+		time.Since(startedAt).Milliseconds(),
+	)
+}
+
+func (d *OutlineDevice) Status(timeout time.Duration) string {
+	_, status := d.LocalProxyAlive(timeout)
+	return status
+}
+
 func (d *OutlineDevice) Close() error {
-	if d.listener != nil {
-		return d.listener.Close()
+	d.closed.Store(true)
+	d.mu.RLock()
+	listener := d.listener
+	addr := d.proxyAddr
+	d.mu.RUnlock()
+
+	if listener != nil {
+		log.Infof("SOCKS5 close requested on %s", addr)
+		return listener.Close()
 	}
 	return nil
 }

--- a/go_module/outline/internal/outline_device_test.go
+++ b/go_module/outline/internal/outline_device_test.go
@@ -1,0 +1,101 @@
+package internal
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTruncatedDNSResponsePreservesQuestionAndSetsTC(t *testing.T) {
+	query := []byte{
+		0x12, 0x34, // ID
+		0x01, 0x00, // recursion desired
+		0x00, 0x01, // QDCOUNT
+		0x00, 0x01, // ANCOUNT in malformed input; response must clear it
+		0x00, 0x01, // NSCOUNT
+		0x00, 0x01, // ARCOUNT
+		0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		0x03, 'c', 'o', 'm',
+		0x00,
+		0x00, 0x01, // A
+		0x00, 0x01, // IN
+	}
+
+	resp, err := truncatedDNSResponse(query)
+	if err != nil {
+		t.Fatalf("truncatedDNSResponse returned error: %v", err)
+	}
+
+	if resp[0] != query[0] || resp[1] != query[1] {
+		t.Fatalf("DNS transaction ID changed: got %x %x", resp[0], resp[1])
+	}
+	if resp[2]&0x80 == 0 {
+		t.Fatal("DNS response bit is not set")
+	}
+	if resp[2]&0x02 == 0 {
+		t.Fatal("DNS truncated bit is not set")
+	}
+	if resp[4] != 0 || resp[5] != 1 {
+		t.Fatalf("QDCOUNT not preserved: got %d.%d", resp[4], resp[5])
+	}
+	for i := 6; i <= 11; i++ {
+		if resp[i] != 0 {
+			t.Fatalf("record count byte %d was not cleared: %d", i, resp[i])
+		}
+	}
+	if string(resp[12:]) != string(query[12:]) {
+		t.Fatal("DNS question payload changed")
+	}
+}
+
+func TestTruncatedDNSConnDoesNotRepeatSameResponse(t *testing.T) {
+	conn := newTruncatedDNSConn("1.1.1.1", 53)
+	defer conn.Close()
+
+	query := []byte{
+		0xab, 0xcd,
+		0x01, 0x00,
+		0x00, 0x01,
+		0x00, 0x00,
+		0x00, 0x00,
+		0x00, 0x00,
+		0x00,
+		0x00, 0x01,
+		0x00, 0x01,
+	}
+
+	if _, err := conn.Write(query); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	buf := make([]byte, 512)
+	if n, err := conn.Read(buf); err != nil || n == 0 {
+		t.Fatalf("first Read = %d, %v", n, err)
+	}
+
+	readAgain := make(chan error, 1)
+	go func() {
+		_, err := conn.Read(buf)
+		readAgain <- err
+	}()
+
+	select {
+	case err := <-readAgain:
+		t.Fatalf("Read repeated without another Write: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	select {
+	case err := <-readAgain:
+		if !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("Read after Close error = %v, want net.ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read did not unblock after Close")
+	}
+}

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -63,6 +63,7 @@ public final class HealthCheckImpl: HealthCheck {
 
     public private(set) var currentMemmoryUsageMb = 0.0
     private var lastMemoryMB: Double = 0
+    private var lastOutlineProxyOk = false
     private var checkSequence: Int = 0
     private let checkSequenceLock = NSLock()
 
@@ -93,6 +94,11 @@ public final class HealthCheckImpl: HealthCheck {
             return mem >= 0
         }
 
+        let outlineProxyOk = runWithRetry(name: "Outline local proxy check", attempts: 1) {
+            self.isOutlineProxyAliveViaXPC()
+        }
+        lastOutlineProxyOk = outlineProxyOk
+
         if currentMemmoryUsageMb >= 0 {
             let delta = currentMemmoryUsageMb - lastMemoryMB
             let deltaStr = lastMemoryMB == 0 ? "" : " (\(delta >= 0 ? "+" : "")\(String(format: "%.1f", delta))MB)"
@@ -102,10 +108,10 @@ public final class HealthCheckImpl: HealthCheck {
             logs.writeLog(log: "[HC] Memory: unknown (XPC no response)")
         }
 
-        let result = vpnOk && networkOk && heartbeatOk
+        let result = vpnOk && networkOk && heartbeatOk && outlineProxyOk
         logs.writeLog(
             log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) " +
-            "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk))"
+            "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk), outlineProxy=\(outlineProxyOk))"
         )
         return result
     }
@@ -117,19 +123,20 @@ public final class HealthCheckImpl: HealthCheck {
         // --- Standard check groups ---
         // On iOS, net.Dial based TCP probes can complete against the local
         // virtual TCP stack before the upstream proxy dial has succeeded.
-        // Run DNS/HTTP first; only run TCP probes as diagnostics if required checks fail.
+        // Treat real HTTP and local Outline proxy liveness as required; run
+        // TCP probes only as diagnostics.
         let requiredCheckGroups: [(String, [(String, () -> Bool)])] = [
             ("DNS Resolve group", [
                 ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") }),
                 ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") })
-            ]),
-            ("DNS Ping group", [
-                ("Ping google.com (DNS)", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
-                ("Ping one.one.one.one (DNS)", { self.pingAddress("one.one.one.one:80", name: "OnesDNS") })
             ])
         ]
 
         let diagnosticCheckGroups: [(String, [(String, () -> Bool)])] = [
+            ("Hostname TCP diagnostics", [
+                ("Ping google.com:80", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
+                ("Ping one.one.one.one:80", { self.pingAddress("one.one.one.one:80", name: "OnesDNS") })
+            ]),
             ("TCP Ping diagnostics", [
                 ("Ping 8.8.8.8", { self.pingAddress("8.8.8.8:53", name: "Google") }),
                 ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
@@ -185,12 +192,13 @@ public final class HealthCheckImpl: HealthCheck {
         // Check if tunnel IP is assigned — confirms the tunnel exists at OS level
         let tunnelIPOk = isTunnelIPAssigned()
         logs.writeLog(log: "[HC] [diag] tunnel_ip_assigned=\(tunnelIPOk)")
+        logs.writeLog(log: "[HC] [diag] outline_proxy_alive=\(lastOutlineProxyOk)")
 
         // --- Result ---
-        let result = failedGroups.count <= 1
+        let result = failedGroups.isEmpty
         if !result {
             logs.writeLog(
-                log: "[HC] Too many failed groups (\(failedGroups.count)): " +
+                log: "[HC] Required check groups failed (\(failedGroups.count)): " +
                      failedGroups.joined(separator: ", ")
             )
         }
@@ -206,6 +214,7 @@ public final class HealthCheckImpl: HealthCheck {
             tcpProxy: tcpProxyOk,
             dns: dnsOk,
             tcp443: tcp443Ok,
+            outlineProxy: lastOutlineProxyOk,
             https: httpsOk
         )
 
@@ -225,26 +234,29 @@ public final class HealthCheckImpl: HealthCheck {
         tcpProxy: Bool,
         dns: Bool,
         tcp443: Bool,
+        outlineProxy: Bool,
         https: Bool
     ) {
         let diagnosis: String
-        switch (tunnelIP, tcpProxy, dns, tcp443, https) {
-        case (false, _, _, _, _):
+        switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https) {
+        case (false, _, _, _, _, _):
             diagnosis = "SIDE: CLIENT | REASON: tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level"
-        case (true, _, false, _, _):
+        case (true, _, _, _, false, _):
+            diagnosis = "SIDE: CLIENT | REASON: local Outline SOCKS5 proxy is unavailable — tun2socks has no working upstream proxy"
+        case (true, _, false, _, _, _):
             diagnosis = "SIDE: CLIENT OR SERVER | REASON: DNS not resolving — DNS-over-tunnel is failing or blocked"
-        case (true, _, true, _, false):
+        case (true, _, true, _, true, false):
             // Check metrics[win] in logs: proto=h3+total=- → QUIC/UDP not proxied (no udpPath? pool full?);
             // proto=h2+high total → server is slow or blocking TLS
-            diagnosis = "SIDE: CLIENT OR SERVER | REASON: TCP :443 OK but HTTPS failing — check [win] in metrics: h3+total=- → UDP not proxied; h2+total=NNNms → slow/blocking server"
-        case (true, false, true, _, _):
+            diagnosis = "SIDE: CLIENT OR SERVER | REASON: Outline proxy is alive but HTTPS checks fail — check [win] metrics for h3/h2 timing and server behavior"
+        case (true, false, true, _, true, _):
             diagnosis = "SIDE: CLIENT | REASON: TCP diagnostic failed after DNS/HTTP checks — possible tun2socks forwarding issue"
-        case (true, true, true, false, _):
+        case (true, true, true, false, true, _):
             diagnosis = "SIDE: SERVER (likely) | REASON: TCP diagnostic to :443 failed — server blocks HTTPS port or intermediate node filters it"
-        case (true, true, true, true, true):
+        case (true, true, true, true, true, true):
             diagnosis = "ALL OK — connection is working"
         default:
-            diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) https=\(https)"
+            diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) outlineProxy=\(outlineProxy) https=\(https)"
         }
         logs.writeLog(log: "[HC] DIAGNOSIS: \(diagnosis)")
     }
@@ -528,14 +540,14 @@ public final class HealthCheckImpl: HealthCheck {
         return false
     }
 
-    private func isTunnelAliveViaXPC() -> Double {
-        var memory: Double = -1
+    private func providerMessage(_ message: String, label: String) -> String? {
+        var rawResponse: String?
         let semaphore = DispatchSemaphore(value: 0)
 
         NETunnelProviderManager.loadAllFromPreferences { managers, error in
             if let error = error {
                 self.logs.writeLog(
-                    log: "[HC] [XPC] loadAllFromPreferences error: \(error.localizedDescription)"
+                    log: "[HC] [\(label)] loadAllFromPreferences error: \(error.localizedDescription)"
                 )
                 semaphore.signal()
                 return
@@ -549,32 +561,26 @@ public final class HealthCheckImpl: HealthCheck {
                 let session = manager.connection as? NETunnelProviderSession
             else {
                 self.logs.writeLog(
-                    log: "[HC] [XPC] manager not found (managers count: \(managers?.count ?? -1))"
+                    log: "[HC] [\(label)] manager not found (managers count: \(managers?.count ?? -1))"
                 )
                 semaphore.signal()
                 return
             }
 
             self.logs.writeLog(
-                log: "[HC] [XPC] session status: \(session.status.rawValue)"
+                log: "[HC] [\(label)] session status: \(session.status.rawValue)"
             )
 
             do {
                 try session.sendProviderMessage(
-                    Data("getMemory".utf8)
+                    Data(message.utf8)
                 ) { response in
                     defer { semaphore.signal() }
-                    memory = self.parseMemoryResponse(response)
-                    if memory < 0 {
-                        let raw = response.flatMap { String(data: $0, encoding: .utf8) } ?? "nil"
-                        self.logs.writeLog(
-                            log: "[HC] [XPC] unexpected response: \(raw)"
-                        )
-                    }
+                    rawResponse = response.flatMap { String(data: $0, encoding: .utf8) }
                 }
             } catch {
                 self.logs.writeLog(
-                    log: "[HC] [XPC] sendProviderMessage error: \(error.localizedDescription)"
+                    log: "[HC] [\(label)] sendProviderMessage error: \(error.localizedDescription)"
                 )
                 semaphore.signal()
             }
@@ -582,17 +588,32 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = semaphore.wait(timeout: .now() + timeout)
         if wait == .timedOut {
-            logs.writeLog(log: "[HC] [XPC] heartbeat timed out")
+            logs.writeLog(log: "[HC] [\(label)] provider message timed out")
+        }
+        return rawResponse
+    }
+
+    private func isTunnelAliveViaXPC() -> Double {
+        let raw = providerMessage("getMemory", label: "XPC")
+        let memory = parseMemoryResponse(raw)
+        if memory < 0 {
+            logs.writeLog(log: "[HC] [XPC] unexpected response: \(raw ?? "nil")")
         }
         return memory
     }
 
-    private func parseMemoryResponse(_ response: Data?) -> Double {
+    private func isOutlineProxyAliveViaXPC() -> Bool {
+        let raw = providerMessage("getOutlineStatus", label: "Outline")
+        logs.writeLog(log: "[HC] [Outline] status: \(raw ?? "nil")")
+        guard let raw else { return false }
+        return raw.contains("localProxyAlive=true")
+    }
+
+    private func parseMemoryResponse(_ response: String?) -> Double {
         guard let response,
-              let str = String(data: response, encoding: .utf8),
-              str.hasPrefix("Memory:")
+              response.hasPrefix("Memory:")
         else { return -1 }
-        let value = str.replacingOccurrences(of: "Memory:", with: "")
+        let value = response.replacingOccurrences(of: "Memory:", with: "")
         return Double(value) ?? -1
     }
 

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -81,6 +81,17 @@ public final class OutlineInteractor {
         }
         logs.writeLog(log: "[DEBUG][Outline] OutlineDisconnect returned")
     }
+
+    func outlineStatus() -> String {
+        var err: NSError?
+        let status = Cloak_outlineOutlineStatus(&err)
+        if let error = err {
+            let message = "client=true localProxyAlive=false statusError=\(error.localizedDescription)"
+            logs.writeLog(log: "[Outline] OutlineStatus failed: \(error.localizedDescription)")
+            return message
+        }
+        return status
+    }
     
     func buildOutlineConfig(
         methodPassword: String,

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -285,6 +285,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
             logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory")
             completionHandler?("Memory:\(reportMemoryUsageMB())".data(using: .utf8))
+        } else if let msg = String(data: messageData, encoding: .utf8), msg == "getOutlineStatus" {
+            let status = outlineInteractor.outlineStatus()
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getOutlineStatus \(status)")
+            completionHandler?("OutlineStatus:\(status)".data(using: .utf8))
         } else {
             logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage echo bytes=\(messageData.count)")
             completionHandler?(messageData)


### PR DESCRIPTION
## Summary

This PR targets the latest iOS failure shown in `DobbyVPN_logs_2026-05-02_23-01-12.txt`.

The tunnel no longer fails at `setTunnelNetworkSettings` or `PacketFlowBridge`: the log shows the bridge starts, first packets flow both directions, and periodic bridge stats have zero drops/read/write errors. The failure appears later:

- `SOCKS5 started on 127.0.0.1:63778`
- `OutlineConnect succeeded`
- DNS UDP fallback is active: `preferTCPDNS=true` and `[SOCKS5 DNS] returning truncated DNS`
- then traffic fails with `connect to 127.0.0.1:63778: connection refused`
- health checks still report connected because TCP probes can return success through iOS/tun2socks before the upstream SOCKS dial has actually succeeded

The immediate root cause is that tun2socks still has a tunnel and routes packets, but its configured local Outline SOCKS5 bridge is unavailable. The most likely trigger in the current code is the fake truncated-DNS `net.Conn`: it returned the same DNS response repeatedly on every `Read`, which can create a tight UDP response loop inside the SOCKS5 UDP-associate reader. That can destabilize the local SOCKS5 bridge and explains why the local proxy later refuses connections while the packet bridge remains healthy.

## Changes

- Make the truncated DNS fallback behave like a real request/response connection:
  - each `Write` enqueues one truncated DNS response
  - `Read` returns one response and then blocks until the next query
  - `Close` unblocks readers with `net.ErrClosed`
  - added tests to prove the DNS response preserves the question, sets TC, clears record counts, and does not repeat the same response
- Add lifecycle supervision and diagnostics for the embedded Outline SOCKS5 bridge:
  - logs serve generation, unexpected stop, close, and rebind attempts
  - recovers panics in the serve loop
  - attempts to rebind the same local proxy address if the listener exits unexpectedly, so tun2socks can continue using the same upstream address
- Add iOS Outline status reporting:
  - Go exports `OutlineStatus`
  - tunnel provider handles `getOutlineStatus`
  - health check asks the provider whether the local Outline proxy is alive
- Make health checks stricter and less misleading:
  - local Outline proxy liveness is now required
  - real HTTP check failure is no longer accepted as connected because only one group failed
  - TCP ping checks are diagnostic only because the latest logs show they can produce false positives while the proxy dial logs `connection refused`

## Validation

- `go test -mod=readonly ./outline ./outline/internal ./tunnel ./tunnel/platform_engine`
- `git diff --check`

Known local limitation:

- `go test -mod=readonly ./ios_exports` still fails because the existing module state wants `go mod tidy`; I did not run tidy to avoid unrelated module churn.
- iOS Swift/Xcode build was not run in this Linux workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Outline client status reporting capability to display current operational state of the client, device, and proxy components.

* **Improvements**
  * Enhanced connection health checks to include verification of Outline proxy liveness and availability.
  * Improved proxy server lifecycle management with automatic recovery and rebinding on unexpected termination.

* **Tests**
  * Added comprehensive tests for DNS truncation response handling and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->