### PR TITLE
Add iOS 26 diagnostic logging for VPN connectivity issues

### DIFF
--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -52,10 +52,13 @@ func listenAddr(network string) string {
 
 func protectSocket(fd uintptr, realNet string, destination string) error {
 	if protector == nil {
+		// iOS 26: Log warning if protector is nil - this could explain connectivity issues
+		log.Infof("[Protect] WARNING: no socket protector registered - traffic may bypass VPN!")
 		return fmt.Errorf("no socket protector registered")
 	}
 	if err := protector.Protect(fd, realNet); err != nil {
-		log.Infof("[Protect] %s fd=%d destination=%s failed: %v", realNet, fd, destination, err)
+		// iOS 26: Log detailed error - socket protection failure may cause network issues
+		log.Infof("[Protect] ERROR: %s fd=%d destination=%s failed: %v - THIS MAY CAUSE CONNECTIVITY ISSUES ON iOS 26", realNet, fd, destination, err)
 		return err
 	}
 	log.Infof("[Protect] %s fd=%d destination=%s OK", realNet, fd, destination)

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -110,6 +110,10 @@ type DobbyProxy struct {
 }
 
 func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net.Conn, error) {
+	// iOS 26 diagnostic: log connection attempt details
+	destAddr := metadata.DestinationAddress()
+	log.Infof("[Router] TCP dial attempt to %s proto=%s", destAddr, metadata.Network)
+
 	if IsBypass(metadata) {
 		conn, err := p.direct.DialContext(ctx, metadata)
 		if err != nil {
@@ -132,6 +136,7 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 	conn, err := p.vpn.DialContext(ctx, metadata)
 	if err != nil {
 		p.activeTCP.Add(-1)
+		// iOS 26: log more detail on proxy errors
 		log.Infof("[Router] PROXY TCP dial error %s: %v", metadata.DestinationAddress(), err)
 		return nil, err
 	}
@@ -152,6 +157,10 @@ func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 		log.Infof("[DEBUG][Router] BYPASS UDP dial OK %s local=%s", metadata.DestinationAddress(), conn.LocalAddr())
 		return conn, nil
 	}
+
+	// iOS 26 diagnostic: log UDP connection details
+	destAddr := metadata.DestinationAddress()
+	log.Infof("[Router] UDP dial attempt to %s proto=%s", destAddr, metadata.Network)
 
 	active := p.activeUDP.Add(1)
 	if active > maxActiveUDPConns {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -113,6 +113,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
             startupStage = "path monitor"
             startPathLogging()
+            
+            // iOS 26+ diagnostic: capture network state at tunnel start
+            captureNetworkStateAtStartup(logs: logs, tunnelId: tunnelId)
 
             startupStage = "go logger init"
             let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
@@ -303,22 +306,128 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
-            let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
+            
+            // iOS 26+ diagnostic: capture all path properties
+            let ifaces = path.availableInterfaces.map { iface -> String in
+                let name = iface.name
+                let type = iface.type
+                let typeStr = "\(type)"
+                let supportsIPV4 = path.supportsIPv4
+                let supportsIPV6 = path.supportsIPv6
+                let isCellular = iface.type == .cellular
+                return "\(name):\(typeStr) ipv4=\(supportsIPV4) ipv6=\(supportsIPV6)"
+            }.joined(separator: ",")
+            
             let expensive = path.isExpensive
             let constrained = path.isConstrained
+            let status = path.status
+            
+            // iOS 26+ detection of problematic scenarios
+            var pathDesc = "status=\(status) ifaces=[\(ifaces)] expensive=\(expensive) constrained=\(constrained)"
+            
+            if #available(iOS 26.0, *) {
+                if expensive {
+                    pathDesc += " [EXPENSIVE_NETWORK]"
+                }
+                if constrained {
+                    pathDesc += " [CONSTRAINED - data saver/low data mode or carrier restriction]"
+                }
+                switch status {
+                case .satisfied:
+                    pathDesc += " [OK]"
+                case .unsatisfied:
+                    pathDesc += " [LOST]"
+                case .requiresConnection:
+                    pathDesc += " [NEEDS_CONNECT]"
+                @unknown default:
+                    pathDesc += " [UNKNOWN]"
+                }
+            }
+            
             let fingerprint = "status=\(path.status)|ifaces=\(ifaces)|expensive=\(expensive)|constrained=\(constrained)"
             if self.lastPathFingerprint != fingerprint {
                 self.lastPathFingerprint = fingerprint
                 self.logs.writeLog(
-                    log: "[tunnel:\(self.tunnelId)] pathUpdate " +
-                        "status=\(path.status) ifaces=[\(ifaces)] " +
-                        "expensive=\(expensive) constrained=\(constrained)"
+                    log: "[tunnel:\(self.tunnelId)] PATH_UPDATE: " + pathDesc
                 )
+                
+                // iOS 26: Log warning for problematic network conditions
+                if constrained && expensive {
+                    self.logs.writeLog(
+                        log: "[tunnel:\(self.tunnelId)] WARNING: Network is BOTH expensive AND constrained - expect connection issues!"
+                    )
+                }
+                
+                // Log each interface's capability
+                for iface in path.availableInterfaces {
+                    self.logs.writeLog(
+                        log: "[tunnel:\(self.tunnelId)] Interface: \(iface.name) type=\(iface.type) isCellular=\(iface.type == .cellular)"
+                    )
+                }
+                
+                // CRITICAL: Log when WiFi->Cellular transition happens (this is when tunnel issues start)
+                let wasUsingWiFi = self.lastPathFingerprint?.contains("wifi") == true
+                let isNowUsingWiFi = ifaces.contains("wifi")
+                let isNowUsingCellular = ifaces.contains("cellular")
+                
+                if wasUsingWiFi && isNowUsingCellular && !isNowUsingWiFi {
+                    self.logs.writeLog(
+                        log: "[tunnel:\(self.tunnelId)] CRITICAL: Network transitioned WiFi -> Cellular! Tunnel instability expected!"
+                    )
+                }
             }
         }
 
         monitor.start(queue: q)
         logs.writeLog(log: "[tunnel:\(tunnelId)] NWPathMonitor started")
+    }
+    
+    /// Capture network state at tunnel startup for diagnostic purposes
+    private func captureNetworkStateAtStartup(logs: Any, tunnelId: String) {
+        // Note: This is a best-effort capture; the monitor may not have populated yet
+        let monitor = Network.NWPathMonitor()
+        let q = DispatchQueue(label: "vpn.dobby.app.tunnel.startup-path")
+        var captured = false
+        
+        monitor.pathUpdateHandler = { path in
+            guard !captured else { return }
+            captured = true
+            
+            // Capture interface details
+            var ifaceDetails: [String] = []
+            for iface in path.availableInterfaces {
+                let detail = "\(iface.name):\(iface.type) cellular=\(iface.type == .cellular) wifi=\(iface.type == .wifi)"
+                ifaceDetails.append(detail)
+            }
+            let ifacesStr = ifaceDetails.joined(separator: ", ")
+            
+            let expensive = path.isExpensive
+            let constrained = path.isConstrained
+            let status = path.status
+            let supportsIPv4 = path.supportsIPv4
+            let supportsIPv6 = path.supportsIPv6
+            
+            // Log all network state
+            let log = "[tunnel:\(tunnelId)] STARTUP_NETWORK: status=\(status) ifaces=[\(ifacesStr)] " +
+                      "expensive=\(expensive) constrained=\(constrained) " +
+                      "ipv4=\(supportsIPv4) ipv6=\(supportsIPv6)"
+            logs.writeLog(log: log)
+            
+            // iOS 26-specific warnings
+            if expensive && constrained {
+                logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_WARNING: Cellular with BOTH expensive AND constrained=true - expect instability!")
+            }
+            if path.status == .unsatisfied {
+                logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_ERROR: Network path unsatisfied at tunnel start!")
+            }
+        }
+        
+        monitor.start(queue: q)
+        
+        // Give it a moment to capture, then stop
+        q.asyncAfter(deadline: .now() + 1.0) {
+            monitor.cancel()
+        }
     }
 
     @MainActor

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -308,14 +308,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             guard let self else { return }
             
             // iOS 26+ diagnostic: capture all path properties
+            let supportsIPV4 = path.supportsIPv4
+            let supportsIPV6 = path.supportsIPv6
             let ifaces = path.availableInterfaces.map { iface -> String in
-                let name = iface.name
-                let type = iface.type
-                let typeStr = "\(type)"
-                let supportsIPV4 = path.supportsIPv4
-                let supportsIPV6 = path.supportsIPv6
-                let isCellular = iface.type == .cellular
-                return "\(name):\(typeStr) ipv4=\(supportsIPV4) ipv6=\(supportsIPV6)"
+                return "\(iface.name):\(iface.type) ipv4=\(supportsIPV4) ipv6=\(supportsIPV6)"
             }.joined(separator: ",")
             
             let expensive = path.isExpensive
@@ -346,27 +342,28 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             
             let fingerprint = "status=\(path.status)|ifaces=\(ifaces)|expensive=\(expensive)|constrained=\(constrained)"
             if self.lastPathFingerprint != fingerprint {
+                let previousFingerprint = self.lastPathFingerprint
                 self.lastPathFingerprint = fingerprint
                 self.logs.writeLog(
                     log: "[tunnel:\(self.tunnelId)] PATH_UPDATE: " + pathDesc
                 )
-                
+
                 // iOS 26: Log warning for problematic network conditions
                 if constrained && expensive {
                     self.logs.writeLog(
                         log: "[tunnel:\(self.tunnelId)] WARNING: Network is BOTH expensive AND constrained - expect connection issues!"
                     )
                 }
-                
+
                 // Log each interface's capability
                 for iface in path.availableInterfaces {
                     self.logs.writeLog(
                         log: "[tunnel:\(self.tunnelId)] Interface: \(iface.name) type=\(iface.type) isCellular=\(iface.type == .cellular)"
                     )
                 }
-                
+
                 // CRITICAL: Log when WiFi->Cellular transition happens (this is when tunnel issues start)
-                let wasUsingWiFi = self.lastPathFingerprint?.contains("wifi") == true
+                let wasUsingWiFi = previousFingerprint?.contains("wifi") == true
                 let isNowUsingWiFi = ifaces.contains("wifi")
                 let isNowUsingCellular = ifaces.contains("cellular")
                 
@@ -383,7 +380,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
     
     /// Capture network state at tunnel startup for diagnostic purposes
-    private func captureNetworkStateAtStartup(logs: Any, tunnelId: String) {
+    private func captureNetworkStateAtStartup(logs: AppLogsRepository, tunnelId: String) {
         // Note: This is a best-effort capture; the monitor may not have populated yet
         let monitor = Network.NWPathMonitor()
         let q = DispatchQueue(label: "vpn.dobby.app.tunnel.startup-path")

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -380,7 +380,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
     
     /// Capture network state at tunnel startup for diagnostic purposes
-    private func captureNetworkStateAtStartup(logs: AppLogsRepository, tunnelId: String) {
+    private func captureNetworkStateAtStartup(logs: LogsRepository, tunnelId: String) {
         // Note: This is a best-effort capture; the monitor may not have populated yet
         let monitor = Network.NWPathMonitor()
         let q = DispatchQueue(label: "vpn.dobby.app.tunnel.startup-path")


### PR DESCRIPTION
- Enhanced Swift PacketTunnelProvider with:
  - Detailed network path logging (expensive/constrained flags)
  - Network state capture at startup
  - WiFi->Cellular transition detection

- Enhanced Go tunnel with:
  - TCP/UDP dial attempt logging
  - Socket protection failure warnings
  - More detailed proxy error logging

Purpose: Diagnose cellular (expensive+constrained) and WiFi (chacha20poly1305 authentication) failures on iOS 26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for socket protection, including explicit warnings when protection is unavailable and platform-specific connectivity notes.
  * Expanded network state diagnostics at startup with richer interface and capability details and explicit iOS-26+ warnings for problematic states.
  * Added detection/logging for Wi‑Fi → cellular transitions.
  * Added extra diagnostic logs for proxy TCP/UDP dial attempts and protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->