### PR TITLE
fix(ios): expand tunnel diagnostics and status reporting

### DIFF
--- a/go_module/core/client_mobile.go
+++ b/go_module/core/client_mobile.go
@@ -90,6 +90,7 @@ func (c *CoreClient) Connect() error {
 func (c *CoreClient) Disconnect() error {
 	log.Infof("core client disconnect begin engineStarted=%v fd=%d deviceNil=%v", c.engineStarted, c.tunFD, c.device == nil)
 	tunnel.StopEngine()
+	log.Infof("core client disconnect: tun2socks engine stop requested")
 	if !c.engineStarted && c.tunFD >= 0 {
 		if err := unix.Close(c.tunFD); err != nil {
 			log.Infof("failed to close unused tun fd: %v\n", err)
@@ -101,6 +102,7 @@ func (c *CoreClient) Disconnect() error {
 	c.tunFD = -1
 
 	if c.device != nil {
+		log.Infof("core client disconnect: closing protocol device serverIP=%s", c.device.GetServerIP())
 		if err := c.device.Close(); err != nil {
 			log.Infof("failed to close protocol device: %v\n", err)
 		}
@@ -123,12 +125,20 @@ func (c *CoreClient) Status() string {
 			c.tunFD,
 		)
 	}
-	return fmt.Sprintf(
+	status := fmt.Sprintf(
 		"client=true engineStarted=%v fd=%d deviceNil=false serverIP=%s",
 		c.engineStarted,
 		c.tunFD,
 		c.device.GetServerIP().String(),
 	)
+	if statusProvider, ok := c.device.(pkg.StatusProvider); ok {
+		deviceStatus := statusProvider.Status(500 * time.Millisecond)
+		log.Infof("core client status: protocol device status=%s", deviceStatus)
+		status = fmt.Sprintf("%s %s", status, deviceStatus)
+	} else {
+		log.Infof("core client status: protocol device does not implement status provider type=%T", c.device)
+	}
+	return status
 }
 
 func (c *CoreClient) Refresh() error {

--- a/go_module/core/pkg/protocol_device.go
+++ b/go_module/core/pkg/protocol_device.go
@@ -1,6 +1,9 @@
 package pkg
 
-import "net"
+import (
+	"net"
+	"time"
+)
 
 // ProtocolDevice represents any VPN protocol implementation (Xray, Outline, etc.)
 // that provides a local SOCKS5 bridge for tun2socks.
@@ -16,4 +19,10 @@ type ProtocolDevice interface {
 
 	// Close shuts down the engine and releases bound ports.
 	Close() error
+}
+
+// StatusProvider is implemented by protocol devices that can report runtime
+// health details without changing the base ProtocolDevice contract.
+type StatusProvider interface {
+	Status(timeout time.Duration) string
 }

--- a/go_module/healthcheck/address_port_check.go
+++ b/go_module/healthcheck/address_port_check.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"errors"
+	"go_module/log"
 	"net"
 	"strconv"
 	"strings"
@@ -10,6 +11,8 @@ import (
 
 func CheckServerAlive(address string, port int) error {
 	target := net.JoinHostPort(address, strconv.Itoa(port))
+	start := time.Now()
+	log.Infof("[HealthCheck] CheckServerAlive begin target=%s attempts=3 timeout=1s", target)
 
 	d := net.Dialer{
 		Timeout:   1 * time.Second,
@@ -19,19 +22,53 @@ func CheckServerAlive(address string, port int) error {
 	var lastErr error
 
 	for i := 0; i < 3; i++ {
+		attemptStart := time.Now()
+		log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s dial_begin", i+1, target)
 		conn, err := d.Dial("tcp", target)
 		if err != nil {
 			lastErr = err
+			log.Infof(
+				"[HealthCheck] CheckServerAlive attempt=%d target=%s dial_failed elapsedMs=%d err=%v",
+				i+1,
+				target,
+				time.Since(attemptStart).Milliseconds(),
+				err,
+			)
 			if strings.Contains(err.Error(), "refused") {
+				log.Infof("[HealthCheck] CheckServerAlive target=%s refusing immediately err=%v", target, err)
 				return err
 			}
 			continue
 		}
+		log.Infof(
+			"[HealthCheck] CheckServerAlive attempt=%d target=%s dial_ok local=%s remote=%s elapsedMs=%d",
+			i+1,
+			target,
+			conn.LocalAddr(),
+			conn.RemoteAddr(),
+			time.Since(attemptStart).Milliseconds(),
+		)
 
 		func() {
-			defer func() { _ = conn.Close() }()
+			defer func() {
+				if closeErr := conn.Close(); closeErr != nil {
+					log.Infof(
+						"[HealthCheck] CheckServerAlive attempt=%d target=%s close_failed err=%v",
+						i+1,
+						target,
+						closeErr,
+					)
+				} else {
+					log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s close_ok", i+1, target)
+				}
+			}()
 
-			_ = conn.SetDeadline(time.Now().Add(1 * time.Second))
+			if err := conn.SetDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				lastErr = err
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s set_deadline_failed err=%v", i+1, target, err)
+				return
+			}
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_begin bytes=1", i+1, target)
 
 			// We intentionally perform both Write and Read in addition to Dial.
 			//
@@ -53,29 +90,41 @@ func CheckServerAlive(address string, port int) error {
 
 			if _, writeErr := conn.Write([]byte{0x00}); writeErr != nil {
 				lastErr = writeErr
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_failed err=%v", i+1, target, writeErr)
 				return
 			}
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_ok read_probe_begin bytes=1", i+1, target)
 
 			buf := make([]byte, 1)
-			_, readErr := conn.Read(buf)
+			n, readErr := conn.Read(buf)
 			if readErr != nil {
 				var ne net.Error
 				if errors.As(readErr, &ne) && ne.Timeout() {
 					lastErr = nil
+					log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_timeout_treated_alive", i+1, target)
 					return
 				}
 
 				lastErr = readErr
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_failed err=%v", i+1, target, readErr)
 				return
 			}
 
 			lastErr = nil
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_ok bytes=%d", i+1, target, n)
 		}()
 
 		if lastErr == nil {
+			log.Infof(
+				"[HealthCheck] CheckServerAlive OK target=%s attempt=%d totalElapsedMs=%d",
+				target,
+				i+1,
+				time.Since(start).Milliseconds(),
+			)
 			return nil
 		}
 	}
 
+	log.Infof("[HealthCheck] CheckServerAlive failed target=%s totalElapsedMs=%d lastErr=%v", target, time.Since(start).Milliseconds(), lastErr)
 	return lastErr
 }

--- a/go_module/healthcheck/tcp_ping.go
+++ b/go_module/healthcheck/tcp_ping.go
@@ -3,6 +3,7 @@ package healthcheck
 import (
 	"context"
 	"github.com/matsuridayo/libneko/speedtest"
+	"go_module/log"
 	"go_module/tunnel/protected_dialer"
 	"time"
 )
@@ -12,20 +13,37 @@ const (
 )
 
 func TCPPing(address string) (int32, error) {
-	return speedtest.TcpPing(address, pingTimeoutMilliseconds)
+	start := time.Now()
+	log.Infof("[HealthCheck] TCPPing begin address=%s timeoutMs=%d", address, pingTimeoutMilliseconds)
+	ret, err := speedtest.TcpPing(address, pingTimeoutMilliseconds)
+	if err != nil {
+		log.Infof("[HealthCheck] TCPPing failed address=%s elapsedMs=%d err=%v", address, time.Since(start).Milliseconds(), err)
+		return ret, err
+	}
+	log.Infof("[HealthCheck] TCPPing OK address=%s retMs=%d elapsedMs=%d", address, ret, time.Since(start).Milliseconds())
+	return ret, nil
 }
 
 func ProtectedTCPPing(address string) (int32, error) {
 	start := time.Now()
+	log.Infof("[HealthCheck] ProtectedTCPPing begin address=%s timeoutMs=%d", address, pingTimeoutMilliseconds)
 	ctx, cancel := context.WithTimeout(context.Background(), pingTimeoutMilliseconds*time.Millisecond)
 	defer cancel()
 
 	conn, err := protected_dialer.DialContextWithProtect(ctx, "tcp", address)
 	if err != nil {
+		log.Infof("[HealthCheck] ProtectedTCPPing failed address=%s elapsedMs=%d err=%v", address, time.Since(start).Milliseconds(), err)
 		return -1, err
 	}
-	defer conn.Close()
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Infof("[HealthCheck] ProtectedTCPPing close_failed address=%s err=%v", address, closeErr)
+		} else {
+			log.Infof("[HealthCheck] ProtectedTCPPing close_ok address=%s", address)
+		}
+	}()
 
-	return int32(time.Since(start).Milliseconds()), nil
+	elapsed := int32(time.Since(start).Milliseconds())
+	log.Infof("[HealthCheck] ProtectedTCPPing OK address=%s local=%s remote=%s elapsedMs=%d", address, conn.LocalAddr(), conn.RemoteAddr(), elapsed)
+	return elapsed, nil
 }
-

--- a/go_module/healthcheck/urlTest.go
+++ b/go_module/healthcheck/urlTest.go
@@ -1,7 +1,9 @@
 package healthcheck
 
 import (
+	"go_module/log"
 	"net/http"
+	"time"
 
 	"github.com/matsuridayo/libneko/speedtest"
 )
@@ -13,5 +15,13 @@ const (
 var httpClient = &http.Client{}
 
 func URLTest(url string, standard int) (int32, error) {
-	return speedtest.UrlTest(httpClient, url, urlTestTimeoutMilliseconds, standard)
+	start := time.Now()
+	log.Infof("[HealthCheck] URLTest begin url=%s timeoutMs=%d standard=%d", url, urlTestTimeoutMilliseconds, standard)
+	ret, err := speedtest.UrlTest(httpClient, url, urlTestTimeoutMilliseconds, standard)
+	if err != nil {
+		log.Infof("[HealthCheck] URLTest failed url=%s elapsedMs=%d err=%v", url, time.Since(start).Milliseconds(), err)
+		return ret, err
+	}
+	log.Infof("[HealthCheck] URLTest OK url=%s retMs=%d elapsedMs=%d", url, ret, time.Since(start).Milliseconds())
+	return ret, nil
 }

--- a/go_module/ios_exports/cloak.go
+++ b/go_module/ios_exports/cloak.go
@@ -2,12 +2,24 @@ package cloak_outline
 
 import (
 	"go_module/cloak"
+	"go_module/log"
 )
 
-func StartCloakClient(localHost string, localPort string, config string, udp bool) error {
-	return cloak.StartCloakClient(localHost, localPort, config, udp)
+func StartCloakClient(localHost string, localPort string, config string, udp bool) (err error) {
+	defer guardErr("StartCloakClient", &err)()
+	log.Infof("[ios_exports] StartCloakClient begin localHost=%s localPort=%s configLen=%d udp=%v", localHost, localPort, len(config), udp)
+	err = cloak.StartCloakClient(localHost, localPort, config, udp)
+	if err != nil {
+		log.Infof("[ios_exports] StartCloakClient failed localHost=%s localPort=%s err=%v", localHost, localPort, err)
+		return err
+	}
+	log.Infof("[ios_exports] StartCloakClient OK localHost=%s localPort=%s", localHost, localPort)
+	return nil
 }
 
 func StopCloakClient() {
+	defer guard("StopCloakClient")()
+	log.Infof("[ios_exports] StopCloakClient begin")
 	cloak.StopCloakClient()
+	log.Infof("[ios_exports] StopCloakClient returned")
 }

--- a/go_module/ios_exports/dobby_vpn.go
+++ b/go_module/ios_exports/dobby_vpn.go
@@ -12,11 +12,14 @@ import (
 
 var client *core.CoreClient
 
-func guardExport(fnName string) func() {
+func guardExportErr(fnName string, errp *error) func() {
 	return func() {
 		if r := recover(); r != nil {
 			msg := "panic in " + fnName + ": " + unsafeToString(r)
 			log.Infof("%s\n%s", msg, string(debug.Stack()))
+			if errp != nil {
+				*errp = fmt.Errorf("%s", msg)
+			}
 		}
 	}
 }
@@ -31,16 +34,20 @@ func unsafeToString(v any) string {
 }
 
 func NewVpnClient(transportConfig string, protocol string, tunnelFD int, mtu int) (err error) {
-	defer guardExport("NewVpnClient")()
+	defer guardExportErr("NewVpnClient", &err)()
 	log.Infof("NewVpnClient() called protocol=%s fd=%d mtu=%d", protocol, tunnelFD, mtu)
 
 	if client != nil {
+		log.Infof("NewVpnClient(): existing client detected, disconnecting previous client first status=%s", client.Status())
 		if err := VpnDisconnect(); err != nil {
+			log.Infof("NewVpnClient(): previous client disconnect failed: %v", err)
 			return fmt.Errorf("NewVpnClient(): disconnect failed: %w", err)
 		}
+		log.Infof("NewVpnClient(): previous client disconnected")
 	}
 
 	if tunnelFD < 0 {
+		log.Infof("NewVpnClient(): invalid tunnel fd %d", tunnelFD)
 		return fmt.Errorf("NewVpnClient(): invalid tunnel fd %d", tunnelFD)
 	}
 
@@ -52,8 +59,10 @@ func NewVpnClient(transportConfig string, protocol string, tunnelFD int, mtu int
 	// Factory: Create the protocol-specific device
 	switch protocol {
 	case "xray":
+		log.Infof("NewVpnClient(): creating xray device")
 		device, err = xray.NewXrayDevice(transportConfig)
 	case "outline":
+		log.Infof("NewVpnClient(): creating outline device preferTCPDNSForWebSocket=true")
 		device, err = outline.NewOutlineDeviceWithOptions(transportConfig, outline.DeviceOptions{
 			PreferTCPDNSForWebSocket: true,
 		})
@@ -68,51 +77,60 @@ func NewVpnClient(transportConfig string, protocol string, tunnelFD int, mtu int
 	}
 
 	client = core.NewClient(device, tunnelFD, mtu)
+	log.Infof("NewVpnClient(): core client allocated status=%s", client.Status())
 
 	log.Infof("NewVpnClient() finished")
 	return nil
 }
 
-func VpnConnect() error {
-	defer guardExport("VpnConnect")()
+func VpnConnect() (err error) {
+	defer guardExportErr("VpnConnect", &err)()
 	log.Infof("VpnConnect() called")
 
 	if client == nil {
+		log.Infof("VpnConnect() failed: client is nil")
 		return fmt.Errorf("VpnConnect(): client is nil")
 	}
 
+	log.Infof("VpnConnect(): before Connect status=%s", client.Status())
 	if err := client.Connect(); err != nil {
 		log.Infof("VpnConnect() failed: %v", err)
 		return fmt.Errorf("VpnConnect(): %w", err)
 	}
 
-	log.Infof("VpnConnect() finished successfully")
+	log.Infof("VpnConnect() finished successfully status=%s", client.Status())
 	return nil
 }
 
-func VpnDisconnect() error {
-	defer guardExport("VpnDisconnect")()
+func VpnDisconnect() (err error) {
+	defer guardExportErr("VpnDisconnect", &err)()
 	log.Infof("VpnDisconnect() called")
 
 	if client == nil {
+		log.Infof("VpnDisconnect(): client already nil")
 		return nil
 	}
 
-	client.Disconnect()
+	log.Infof("VpnDisconnect(): before Disconnect status=%s", client.Status())
+	if err := client.Disconnect(); err != nil {
+		log.Infof("VpnDisconnect(): client disconnect failed: %v", err)
+		return err
+	}
 	client = nil
 
 	log.Infof("VpnDisconnect() finished")
 	return nil
 }
 
-func VpnStatus() (string, error) {
-	defer guardExport("VpnStatus")()
+func VpnStatus() (status string, err error) {
+	defer guardExportErr("VpnStatus", &err)()
 
 	if client == nil {
+		log.Infof("VpnStatus: client=nil")
 		return "client=false engineStarted=false fd=-1 deviceNil=true reason=client_nil", nil
 	}
 
-	status := client.Status()
+	status = client.Status()
 	log.Infof("VpnStatus: %s", status)
 	return status, nil
 }

--- a/go_module/ios_exports/georouting.go
+++ b/go_module/ios_exports/georouting.go
@@ -1,11 +1,20 @@
 package cloak_outline
 
-import "go_module/tunnel"
+import (
+	"go_module/log"
+	"go_module/tunnel"
+)
 
 func SetGeoRoutingConf(cidrs string) {
+	defer guard("SetGeoRoutingConf")()
+	log.Infof("[ios_exports] SetGeoRoutingConf begin len=%d", len(cidrs))
 	tunnel.SetGeoRoutingConf(cidrs)
+	log.Infof("[ios_exports] SetGeoRoutingConf returned len=%d", len(cidrs))
 }
 
 func ClearGeoRoutingConf() {
+	defer guard("ClearGeoRoutingConf")()
+	log.Infof("[ios_exports] ClearGeoRoutingConf begin")
 	tunnel.ClearGeoRoutingConf()
+	log.Infof("[ios_exports] ClearGeoRoutingConf returned")
 }

--- a/go_module/ios_exports/guard.go
+++ b/go_module/ios_exports/guard.go
@@ -1,6 +1,7 @@
 package cloak_outline
 
 import (
+	"fmt"
 	"go_module/log"
 	"runtime/debug"
 )
@@ -21,6 +22,29 @@ func guard(fn string) func() {
 	return func() {
 		if r := recover(); r != nil {
 			log.Infof("[ios_exports] panic in %s: %v\n%s", fn, r, string(debug.Stack()))
+		}
+	}
+}
+
+func guardErr(fn string, errp *error) func() {
+	return func() {
+		if r := recover(); r != nil {
+			msg := fmt.Sprintf("[ios_exports] panic in %s: %v", fn, r)
+			log.Infof("%s\n%s", msg, string(debug.Stack()))
+			if errp != nil {
+				*errp = fmt.Errorf("%s", msg)
+			}
+		}
+	}
+}
+
+func guardStatus(fn string, statusp *int32) func() {
+	return func() {
+		if r := recover(); r != nil {
+			log.Infof("[ios_exports] panic in %s: %v\n%s", fn, r, string(debug.Stack()))
+			if statusp != nil {
+				*statusp = -1
+			}
 		}
 	}
 }

--- a/go_module/ios_exports/health_check.go
+++ b/go_module/ios_exports/health_check.go
@@ -5,28 +5,52 @@ import (
 	"go_module/log"
 )
 
-func TcpPing(address string) (int32, error) {
-	defer guard("TcpPing")()
-	return healthcheck.TCPPing(address)
+func TcpPing(address string) (ret int32, err error) {
+	defer guardErr("TcpPing", &err)()
+	log.Infof("[ios_exports] TcpPing begin address=%s", address)
+	ret, err = healthcheck.TCPPing(address)
+	if err != nil {
+		log.Infof("[ios_exports] TcpPing failed address=%s err=%v", address, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] TcpPing OK address=%s ms=%d", address, ret)
+	return ret, nil
 }
 
-func ProtectedTcpPing(address string) (int32, error) {
-	defer guard("ProtectedTcpPing")()
-	return healthcheck.ProtectedTCPPing(address)
+func ProtectedTcpPing(address string) (ret int32, err error) {
+	defer guardErr("ProtectedTcpPing", &err)()
+	log.Infof("[ios_exports] ProtectedTcpPing begin address=%s", address)
+	ret, err = healthcheck.ProtectedTCPPing(address)
+	if err != nil {
+		log.Infof("[ios_exports] ProtectedTcpPing failed address=%s err=%v", address, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] ProtectedTcpPing OK address=%s ms=%d", address, ret)
+	return ret, nil
 }
 
-
-func UrlTest(url string, standard int) (int32, error) {
-	defer guard("UrlTest")()
-	return healthcheck.URLTest(url, standard)
+func UrlTest(url string, standard int) (ret int32, err error) {
+	defer guardErr("UrlTest", &err)()
+	log.Infof("[ios_exports] UrlTest begin url=%s standard=%d", url, standard)
+	ret, err = healthcheck.URLTest(url, standard)
+	if err != nil {
+		log.Infof("[ios_exports] UrlTest failed url=%s standard=%d err=%v", url, standard, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] UrlTest OK url=%s standard=%d ms=%d", url, standard, ret)
+	return ret, nil
 }
 
-func CheckServerAlive(address string, port int) int32 {
-	defer guard("CheckServerAlive")()
+func CheckServerAlive(address string, port int) (status int32) {
+	status = -1
+	defer guardStatus("CheckServerAlive", &status)()
+	log.Infof("[ios_exports] CheckServerAlive begin address=%s port=%d", address, port)
 	res := healthcheck.CheckServerAlive(address, port)
 	log.Infof("Health check result: %v", res)
 	if res == nil {
+		log.Infof("[ios_exports] CheckServerAlive OK address=%s port=%d", address, port)
 		return 0
 	}
+	log.Infof("[ios_exports] CheckServerAlive failed address=%s port=%d err=%v", address, port, res)
 	return -1
 }

--- a/go_module/ios_exports/logger.go
+++ b/go_module/ios_exports/logger.go
@@ -6,7 +6,10 @@ import (
 
 func InitLogger(path string) {
 	defer guard("InitLogger")()
+	log.Infof("[ios_exports] InitLogger begin path=%s", path)
 	if err := log.SetPath(path); err != nil {
 		log.Infof("[ios_exports] InitLogger failed: %v", err)
+		return
 	}
+	log.Infof("[ios_exports] InitLogger OK path=%s", path)
 }

--- a/go_module/ios_exports/protector.go
+++ b/go_module/ios_exports/protector.go
@@ -4,20 +4,25 @@
 package cloak_outline
 
 import (
-	"go_module/tunnel/protected_dialer"
 	"go_module/log"
+	"go_module/tunnel/protected_dialer"
 )
 
 // SetDefaultInterfaceIndex sets the default network interface index for socket protection.
 // This is called from Swift when the default interface changes (WiFi/Cellular).
 // On iOS 26+, SO_NO_TC_NETPOLICY no longer works, so we use IP_BOUND_IF instead.
 func SetDefaultInterfaceIndex(index int) {
+	defer guard("SetDefaultInterfaceIndex")()
 	log.Infof("[iOS-Protect] Setting default interface index: %d", index)
 	protected_dialer.SetDefaultInterfaceForIOS(index)
+	log.Infof("[iOS-Protect] SetDefaultInterfaceIndex returned index=%d current=%d", index, protected_dialer.GetDefaultInterfaceForIOS())
 }
 
 // GetDefaultInterfaceIndex returns the current default interface index.
 // Useful for diagnostics from Swift.
-func GetDefaultInterfaceIndex() int {
-	return protected_dialer.GetDefaultInterfaceForIOS()
+func GetDefaultInterfaceIndex() (index int) {
+	defer guard("GetDefaultInterfaceIndex")()
+	index = protected_dialer.GetDefaultInterfaceForIOS()
+	log.Infof("[iOS-Protect] GetDefaultInterfaceIndex returned index=%d", index)
+	return index
 }

--- a/go_module/modules/Cloak/exported_client/protector_ios.go
+++ b/go_module/modules/Cloak/exported_client/protector_ios.go
@@ -19,11 +19,15 @@ const (
 
 func protector(network string, address string, c syscall.RawConn) error {
 	var protectErr error
+	log.Infof("Cloak protect begin network=%s address=%s", network, address)
 	controlErr := c.Control(func(fd uintptr) {
+		log.Infof("Cloak protect control fd=%d network=%s address=%s", fd, network, address)
 		// iOS 26+: Try SO_NO_TC_NETPOLICY (legacy, usually fails on iOS 26+)
 		legacyErr := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
 		if legacyErr != nil {
 			log.Infof("Cloak protect SO_NO_TC_NETPOLICY failed (expected on iOS 26+): fd=%d err=%v", fd, legacyErr)
+		} else {
+			log.Infof("Cloak protect SO_NO_TC_NETPOLICY success: fd=%d", fd)
 		}
 
 		// iOS 26+: Use IP_BOUND_IF with the actual interface index from Swift
@@ -40,6 +44,7 @@ func protector(network string, address string, c syscall.RawConn) error {
 					}
 					return
 				}
+				log.Infof("Cloak IP_BOUND_IF (IPv6) success: fd=%d iface=%d", fd, ifaceIndex)
 			} else {
 				if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, IP_BOUND_IF, ifaceIndex); err != nil {
 					log.Infof("Cloak IP_BOUND_IF (IPv4) failed: fd=%d iface=%d err=%v", fd, ifaceIndex, err)
@@ -48,6 +53,7 @@ func protector(network string, address string, c syscall.RawConn) error {
 					}
 					return
 				}
+				log.Infof("Cloak IP_BOUND_IF (IPv4) success: fd=%d iface=%d", fd, ifaceIndex)
 			}
 
 			log.Infof("Cloak protect success: fd=%d network=%s address=%s iface=%d", fd, network, address, ifaceIndex)
@@ -61,7 +67,13 @@ func protector(network string, address string, c syscall.RawConn) error {
 	})
 
 	if controlErr != nil {
+		log.Infof("Cloak protect raw control failed network=%s address=%s err=%v", network, address, controlErr)
 		return controlErr
+	}
+	if protectErr != nil {
+		log.Infof("Cloak protect finished with error network=%s address=%s err=%v", network, address, protectErr)
+	} else {
+		log.Infof("Cloak protect finished OK network=%s address=%s", network, address)
 	}
 	return protectErr
 }

--- a/go_module/outline/outline_device.go
+++ b/go_module/outline/outline_device.go
@@ -496,6 +496,7 @@ func (d *OutlineDevice) GetProxyAddr() string {
 }
 
 func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, status string) {
+	start := time.Now()
 	d.mu.RLock()
 	addr := d.proxyAddr
 	state := d.serveState
@@ -504,16 +505,29 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 	closed := d.closed.Load()
 	startedAt := d.startedAt
 	d.mu.RUnlock()
+	uptimeMs := outlineUptimeMilliseconds(startedAt)
+
+	log.Infof(
+		"outline local proxy health begin addr=%s state=%s gen=%d closed=%v timeoutMs=%d uptimeMs=%d",
+		addr,
+		state,
+		gen,
+		closed,
+		timeout.Milliseconds(),
+		uptimeMs,
+	)
 
 	if addr == "" {
-		return false, fmt.Sprintf(
+		status := fmt.Sprintf(
 			"localProxyAlive=false proxyAddr= serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
 			state,
 			gen,
 			closed,
 			serveErr,
-			time.Since(startedAt).Milliseconds(),
+			uptimeMs,
 		)
+		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
+		return false, status
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -521,7 +535,7 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
 	if err != nil {
-		return false, fmt.Sprintf(
+		status := fmt.Sprintf(
 			"localProxyAlive=false proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeErr=%q uptimeMs=%d",
 			addr,
 			state,
@@ -529,20 +543,44 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 			closed,
 			serveErr,
 			err.Error(),
-			time.Since(startedAt).Milliseconds(),
+			uptimeMs,
 		)
+		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
+		return false, status
 	}
-	_ = conn.Close()
+	if err := conn.Close(); err != nil {
+		status := fmt.Sprintf(
+			"localProxyAlive=false proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeCloseErr=%q uptimeMs=%d",
+			addr,
+			state,
+			gen,
+			closed,
+			serveErr,
+			err.Error(),
+			uptimeMs,
+		)
+		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
+		return false, status
+	}
 
-	return true, fmt.Sprintf(
+	status = fmt.Sprintf(
 		"localProxyAlive=true proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
 		addr,
 		state,
 		gen,
 		closed,
 		serveErr,
-		time.Since(startedAt).Milliseconds(),
+		uptimeMs,
 	)
+	log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
+	return true, status
+}
+
+func outlineUptimeMilliseconds(startedAt time.Time) int64 {
+	if startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(startedAt).Milliseconds()
 }
 
 func (d *OutlineDevice) Status(timeout time.Duration) string {

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -54,10 +54,11 @@ func listenAddr(network string) string {
 func protectSocket(fd uintptr, realNet, destination string) error {
 	if protector == nil {
 		// iOS 26: Log warning if protector is nil - this could explain connectivity issues
-		log.Infof("[Protect] WARNING: no socket protector registered - traffic may bypass VPN!")
+		log.Infof("[Protect] WARNING: no socket protector registered network=%s destination=%s fd=%d - traffic may bypass VPN!", realNet, destination, fd)
 		return fmt.Errorf("no socket protector registered")
 	}
 
+	log.Infof("[Protect] protect_begin network=%s fd=%d destination=%s", realNet, fd, destination)
 	if err := protector.Protect(fd, realNet); err != nil {
 		// iOS 26: Log detailed error - socket protection failure may cause network issues
 		log.Infof("[Protect] ERROR: %s fd=%d destination=%s protect_failed: %v - may cause iOS network issues", realNet, fd, destination, err)
@@ -103,11 +104,22 @@ func NewProtectedListenConfig(destination string) *net.ListenConfig {
 
 func DialContextWithProtect(ctx context.Context, network, address string) (net.Conn, error) {
 	realNet := normalizeTCP(address)
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"))
+	} else {
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none)", network, realNet, address)
+	}
 
 	if isLoopback(address) {
 		log.Infof("[Protect] TCP BYPASS loopback: %s", address)
 		var d net.Dialer
-		return d.DialContext(ctx, realNet, address)
+		conn, err := d.DialContext(ctx, realNet, address)
+		if err != nil {
+			log.Infof("[Protect] TCP BYPASS loopback failed network=%s dest=%s err=%v", realNet, address, err)
+			return nil, err
+		}
+		log.Infof("[Protect] TCP BYPASS loopback OK network=%s dest=%s local=%s remote=%s", realNet, address, conn.LocalAddr(), conn.RemoteAddr())
+		return conn, nil
 	}
 
 	d := NewProtectedDialer(address)
@@ -131,6 +143,11 @@ func DialContextWithProtect(ctx context.Context, network, address string) (net.C
 
 func DialUDPWithProtect(ctx context.Context, network, address string) (net.PacketConn, error) {
 	realNet := normalizeUDP(address)
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"))
+	} else {
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none)", network, realNet, address)
+	}
 
 	if isLoopback(address) {
 		log.Infof("[Protect] UDP BYPASS loopback: %s", address)
@@ -145,7 +162,9 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 		udpAddr, err := net.ResolveUDPAddr(realNet, address)
 		if err != nil {
-			_ = pc.Close()
+			if closeErr := pc.Close(); closeErr != nil {
+				log.Infof("[Protect] UDP BYPASS loopback close after resolve error failed network=%s destination=%s closeErr=%v", realNet, address, closeErr)
+			}
 			log.Infof("[Protect] UDP BYPASS loopback resolve error network=%s destination=%s: %v", realNet, address, err)
 			return nil, err
 		}
@@ -166,7 +185,9 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 	udpAddr, err := net.ResolveUDPAddr(realNet, address)
 	if err != nil {
-		_ = pc.Close()
+		if closeErr := pc.Close(); closeErr != nil {
+			log.Infof("[Protect] UDP close after resolve error failed network=%s destination=%s closeErr=%v", realNet, address, closeErr)
+		}
 		log.Infof("[Protect] UDP resolve error network=%s destination=%s: %v", realNet, address, err)
 		return nil, err
 	}

--- a/go_module/tunnel/protected_dialer/protect_ios.go
+++ b/go_module/tunnel/protected_dialer/protect_ios.go
@@ -31,7 +31,9 @@ func SetDefaultInterfaceForIOS(index int) {
 	defaultInterfaceMu.Unlock()
 
 	if oldIndex != index {
-		log.Infof("[iOS-Protect] Default interface index changed: %d -> %d", oldIndex, index)
+		log.Infof("[iOS-Protect] Default interface index changed: %d -> %d interfaces=[%s]", oldIndex, index, describeInterfacesForLog())
+	} else {
+		log.Infof("[iOS-Protect] Default interface index unchanged: %d interfaces=[%s]", index, describeInterfacesForLog())
 	}
 }
 
@@ -41,9 +43,11 @@ func GetDefaultInterfaceForIOS() int {
 	idx := defaultInterfaceIndex
 	defaultInterfaceMu.RUnlock()
 	if idx > 0 {
+		log.Infof("[iOS-Protect] using cached default interface index=%d", idx)
 		return idx
 	}
 
+	log.Infof("[iOS-Protect] default interface index not set; scanning interfaces")
 	idx = detectDefaultInterfaceIndex()
 	if idx > 0 {
 		SetDefaultInterfaceForIOS(idx)
@@ -57,6 +61,7 @@ func detectDefaultInterfaceIndex() int {
 		log.Infof("[iOS-Protect] interface scan failed: %v", err)
 		return 0
 	}
+	log.Infof("[iOS-Protect] interface scan candidates=[%s]", formatInterfacesForLog(interfaces))
 
 	preferredNames := []string{"en0", "pdp_ip0"}
 	for _, name := range preferredNames {
@@ -82,14 +87,33 @@ func detectDefaultInterfaceIndex() int {
 	return 0
 }
 
+func describeInterfacesForLog() string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Sprintf("scan_error=%v", err)
+	}
+	return formatInterfacesForLog(interfaces)
+}
+
+func formatInterfacesForLog(interfaces []net.Interface) string {
+	parts := make([]string, 0, len(interfaces))
+	for _, iface := range interfaces {
+		parts = append(parts, fmt.Sprintf("%s(index=%d flags=%s mtu=%d)", iface.Name, iface.Index, iface.Flags.String(), iface.MTU))
+	}
+	return strings.Join(parts, ";")
+}
+
 type iosProtector struct{}
 
 func (i *iosProtector) Protect(fd uintptr, network string) error {
+	log.Infof("[iOS-Protect] Protect begin fd=%d network=%s", fd, network)
 	// iOS 26+: Try SO_NO_TC_NETPOLICY first (legacy approach for older iOS versions)
 	// On iOS 26+, this typically fails with "invalid argument" but doesn't hurt to try.
 	legacyErr := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
 	if legacyErr != nil {
 		log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY failed (expected on iOS 26+): %v", legacyErr)
+	} else {
+		log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY success fd=%d", fd)
 	}
 
 	// iOS 26+: Use IP_BOUND_IF with the actual interface index.
@@ -98,6 +122,7 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 	ifaceIndex := GetDefaultInterfaceForIOS()
 
 	if ifaceIndex > 0 {
+		log.Infof("[iOS-Protect] Protect binding fd=%d network=%s ifaceIndex=%d interfaces=[%s]", fd, network, ifaceIndex, describeInterfacesForLog())
 		// Bind the socket to the default physical interface (WiFi/Cellular)
 		// This ensures encrypted VPN traffic goes outside the VPN tunnel.
 		switch network {
@@ -128,18 +153,20 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 				}
 				return nil
 			}
+			log.Infof("[iOS-Protect] IP_BOUND_IF (fallback IPv4) success: fd=%d bound to interface %d network=%s", fd, ifaceIndex, network)
 		}
 	} else {
 		// No interface index set - this will likely fail on iOS 26+
 		// Log a warning that Swift needs to provide the interface index
-		log.Infof("[iOS-Protect] WARNING: No default interface index set (ifaceIndex=%d). " +
-			"VPN traffic may not bypass tunnel correctly on iOS 26+. " +
+		log.Infof("[iOS-Protect] WARNING: No default interface index set (ifaceIndex=%d). "+
+			"VPN traffic may not bypass tunnel correctly on iOS 26+. "+
 			"Ensure Swift calls SetDefaultInterfaceIndex() with valid interface index from NWPathMonitor.", ifaceIndex)
 		if legacyErr != nil {
 			return fmt.Errorf("no default interface index set and SO_NO_TC_NETPOLICY failed: %w", legacyErr)
 		}
 	}
 
+	log.Infof("[iOS-Protect] Protect finished fd=%d network=%s ifaceIndex=%d legacyErr=%v", fd, network, ifaceIndex, legacyErr)
 	return nil
 }
 

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -3,6 +3,7 @@ import MyLibrary
 import os
 import app
 import Foundation
+import Darwin
 import SystemConfiguration
 import Network
 
@@ -276,6 +277,7 @@ public final class HealthCheckImpl: HealthCheck {
     ) -> Bool {
         for attempt in 1...attempts {
             logs.writeLog(log: "[HC] \(name) attempt \(attempt)")
+            let attemptStart = Date()
             let ok: Bool
             if let timeoutPerAttempt {
                 ok = runWithTimeout(timeout: timeoutPerAttempt, block: block)
@@ -284,8 +286,14 @@ public final class HealthCheckImpl: HealthCheck {
             }
 
             if ok {
+                logs.writeLog(
+                    log: "[HC] \(name) attempt \(attempt) OK in \(elapsedMs(since: attemptStart))ms"
+                )
                 return true
             }
+            logs.writeLog(
+                log: "[HC] \(name) attempt \(attempt) FAILED in \(elapsedMs(since: attemptStart))ms"
+            )
         }
         logs.writeLog(log: "[HC] \(name) FAILED after \(attempts) attempts")
         return false
@@ -309,6 +317,7 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = semaphore.wait(timeout: .now() + timeout)
         if wait == .timedOut {
+            logs.writeLog(log: "[HC] runWithTimeout timed out after \(Int(timeout * 1000))ms")
             return false
         }
         lock.lock()
@@ -321,6 +330,7 @@ public final class HealthCheckImpl: HealthCheck {
         var result: (ok: Bool, message: String)?
         let group = DispatchGroup()
         group.enter()
+        logs.writeLog(log: "[HC] [DNS] \(host) begin timeoutMs=\(Int(timeout * 1000))")
 
         DispatchQueue.global(qos: .userInitiated).async {
             result = self.resolveDNS(host: host)
@@ -338,6 +348,7 @@ public final class HealthCheckImpl: HealthCheck {
     }
 
     private func resolveDNS(host: String) -> (ok: Bool, message: String) {
+        let start = Date()
         var hints = addrinfo(
             ai_flags: AI_PASSIVE,
             ai_family: AF_UNSPEC,
@@ -353,7 +364,7 @@ public final class HealthCheckImpl: HealthCheck {
         let status = getaddrinfo(host, nil, &hints, &infoPointer)
 
         guard status == 0, let first = infoPointer else {
-            return (false, String(cString: gai_strerror(status)))
+            return (false, "\(String(cString: gai_strerror(status))) elapsedMs=\(elapsedMs(since: start))")
         }
 
         defer { freeaddrinfo(infoPointer) }
@@ -370,12 +381,12 @@ public final class HealthCheckImpl: HealthCheck {
                 0,
                 NI_NUMERICHOST
             ) == 0 {
-                return (true, String(cString: buffer))
+                return (true, "\(String(cString: buffer)) elapsedMs=\(elapsedMs(since: start))")
             }
             ptr = current.pointee.ai_next
         }
 
-        return (false, "Can't resolve DNS")
+        return (false, "Can't resolve DNS elapsedMs=\(elapsedMs(since: start))")
     }
 
     private func httpPing(urlString: String) -> Bool {
@@ -453,10 +464,19 @@ public final class HealthCheckImpl: HealthCheck {
 
     private func interfaceName(forIPv4 targetIP: String) -> String? {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return nil }
+        let rc = getifaddrs(&ifaddrPtr)
+        guard rc == 0, let first = ifaddrPtr else {
+            let getErrno = errno
+            logs.writeLog(
+                log: "[HC] [Interfaces] getifaddrs failed rc=\(rc) errno=\(getErrno) " +
+                    "\(String(cString: strerror(getErrno)))"
+            )
+            return nil
+        }
         defer { freeifaddrs(ifaddrPtr) }
 
         var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        var ipv4Interfaces: [String] = []
         while let addr = ptr {
             if addr.pointee.ifa_addr?.pointee.sa_family == UInt8(AF_INET) {
                 var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
@@ -465,13 +485,23 @@ public final class HealthCheckImpl: HealthCheck {
                 }
                 if inet_ntop(AF_INET, &sa, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
                     let ip = String(cString: buffer)
+                    let name = String(cString: addr.pointee.ifa_name)
+                    ipv4Interfaces.append("\(name)=\(ip)")
                     if ip == targetIP {
-                        return String(cString: addr.pointee.ifa_name)
+                        logs.writeLog(log: "[HC] [Interfaces] target \(targetIP) matched \(name); ipv4=[\(ipv4Interfaces.joined(separator: ","))]")
+                        return name
                     }
+                } else {
+                    let ntopErrno = errno
+                    logs.writeLog(
+                        log: "[HC] [Interfaces] inet_ntop failed errno=\(ntopErrno) " +
+                            "\(String(cString: strerror(ntopErrno)))"
+                    )
                 }
             }
             ptr = addr.pointee.ifa_next
         }
+        logs.writeLog(log: "[HC] [Interfaces] target \(targetIP) not found; ipv4=[\(ipv4Interfaces.joined(separator: ","))]")
         return nil
     }
 
@@ -500,6 +530,10 @@ public final class HealthCheckImpl: HealthCheck {
     private func tcpPingWithTimeout(address: String, protected: Bool = false) -> Result<Int32, Error> {
         // The Go ping helper might block longer than desired; enforce a hard wall-clock timeout.
         let semaphore = DispatchSemaphore(value: 0)
+        let start = Date()
+        logs.writeLog(
+            log: "[HC] [tcpPing] begin address=\(address) protected=\(protected) timeoutMs=\(Int(timeout * 1000))"
+        )
         var result: Result<Int32, Error> = .failure(
             NSError(
                 domain: "CloakTcpPing",
@@ -515,6 +549,10 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = semaphore.wait(timeout: .now() + timeout)
         if wait == .timedOut {
+            logs.writeLog(
+                log: "[HC] [tcpPing] timeout address=\(address) protected=\(protected) " +
+                    "elapsedMs=\(elapsedMs(since: start))"
+            )
             return .failure(
                 NSError(
                     domain: "CloakTcpPing",
@@ -523,6 +561,10 @@ public final class HealthCheckImpl: HealthCheck {
                 )
             )
         }
+        logs.writeLog(
+            log: "[HC] [tcpPing] completed address=\(address) protected=\(protected) " +
+                "elapsedMs=\(elapsedMs(since: start))"
+        )
         return result
     }
 
@@ -530,11 +572,16 @@ public final class HealthCheckImpl: HealthCheck {
         var ret: Int32 = 0
         var err: NSError?
         let success: Bool
+        logs.writeLog(log: "[HC] [tcpPingNative] calling protected=\(protected) address=\(address)")
         if protected {
             success = Cloak_outlineProtectedTcpPing(address, &ret, &err)
         } else {
             success = Cloak_outlineTcpPing(address, &ret, &err)
         }
+        logs.writeLog(
+            log: "[HC] [tcpPingNative] returned success=\(success) ret=\(ret) " +
+                "err=\(err?.localizedDescription ?? "nil") protected=\(protected) address=\(address)"
+        )
 
         if success {
             return .success(ret)
@@ -560,20 +607,30 @@ public final class HealthCheckImpl: HealthCheck {
         // iOS 26 fallback: Check for any utun interface if IP check fails
         // This helps identify if the tunnel is at least partially up
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return false }
+        let rc = getifaddrs(&ifaddrPtr)
+        guard rc == 0, let first = ifaddrPtr else {
+            let getErrno = errno
+            logs.writeLog(
+                log: "[HC] [VPNIface] getifaddrs failed rc=\(rc) errno=\(getErrno) " +
+                    "\(String(cString: strerror(getErrno)))"
+            )
+            return false
+        }
         defer { freeifaddrs(ifaddrPtr) }
 
         var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        var utunNames: [String] = []
         while let addr = ptr {
             let name = String(cString: addr.pointee.ifa_name)
             if name.starts(with: "utun") {
+                 utunNames.append(name)
                  logs.writeLog(log: "[HC] [VPNIface] Found utun interface \(name) but it doesn't have IP \(tunnelIPAddress)")
             }
             ptr = addr.pointee.ifa_next
         }
 
         logs.writeLog(
-            log: "[HC] [VPNIface] Dobby tunnel IP \(tunnelIPAddress) not found on any interface"
+            log: "[HC] [VPNIface] Dobby tunnel IP \(tunnelIPAddress) not found on any interface; utuns=[\(utunNames.joined(separator: ","))]"
         )
         return false
     }
@@ -581,6 +638,10 @@ public final class HealthCheckImpl: HealthCheck {
     private func providerMessage(_ message: String, label: String) -> String? {
         var rawResponse: String?
         let semaphore = DispatchSemaphore(value: 0)
+        let start = Date()
+        logs.writeLog(
+            log: "[HC] [\(label)] provider message begin message=\(message) timeoutMs=\(Int(timeout * 1000))"
+        )
 
         NETunnelProviderManager.loadAllFromPreferences { managers, error in
             if let error = error {
@@ -590,6 +651,7 @@ public final class HealthCheckImpl: HealthCheck {
                 semaphore.signal()
                 return
             }
+            self.logs.writeLog(log: "[HC] [\(label)] loadAllFromPreferences managers=\(managers?.count ?? -1)")
             guard
                 let manager = managers?.first(where: {
                     $0.localizedDescription == VpnManagerImpl.dobbyName &&
@@ -615,6 +677,10 @@ public final class HealthCheckImpl: HealthCheck {
                 ) { response in
                     defer { semaphore.signal() }
                     rawResponse = response.flatMap { String(data: $0, encoding: .utf8) }
+                    self.logs.writeLog(
+                        log: "[HC] [\(label)] provider response bytes=\(response?.count ?? -1) " +
+                            "decoded=\(rawResponse ?? "nil")"
+                    )
                 }
             } catch {
                 self.logs.writeLog(
@@ -626,7 +692,9 @@ public final class HealthCheckImpl: HealthCheck {
 
         let wait = semaphore.wait(timeout: .now() + timeout)
         if wait == .timedOut {
-            logs.writeLog(log: "[HC] [\(label)] provider message timed out")
+            logs.writeLog(log: "[HC] [\(label)] provider message timed out elapsedMs=\(elapsedMs(since: start))")
+        } else {
+            logs.writeLog(log: "[HC] [\(label)] provider message finished elapsedMs=\(elapsedMs(since: start))")
         }
         return rawResponse
     }
@@ -644,15 +712,37 @@ public final class HealthCheckImpl: HealthCheck {
         let raw = providerMessage("getOutlineStatus", label: "Outline")
         logs.writeLog(log: "[HC] [Outline] status: \(raw ?? "nil")")
         guard let raw else { return false }
-        return raw.contains("localProxyAlive=true")
+        if raw.contains("localProxyAlive=true") {
+            return true
+        }
+        if raw.contains("localProxyAlive=false") {
+            return false
+        }
+
+        let legacyHealthyStatus = raw.contains("client=true")
+            && raw.contains("engineStarted=true")
+            && raw.contains("deviceNil=false")
+        if legacyHealthyStatus {
+            logs.writeLog(
+                log: "[HC] [Outline] native status lacks localProxyAlive; accepting healthy legacy engine status"
+            )
+        }
+        return legacyHealthyStatus
     }
 
     private func parseMemoryResponse(_ response: String?) -> Double {
         guard let response,
               response.hasPrefix("Memory:")
-        else { return -1 }
+        else {
+            logs.writeLog(log: "[HC] [XPC] parseMemoryResponse invalid response=\(response ?? "nil")")
+            return -1
+        }
         let value = response.replacingOccurrences(of: "Memory:", with: "")
-        return Double(value) ?? -1
+        guard let parsed = Double(value) else {
+            logs.writeLog(log: "[HC] [XPC] parseMemoryResponse failed value=\(value)")
+            return -1
+        }
+        return parsed
     }
 
     public func getTimeToWakeUp() -> Int32 {
@@ -661,5 +751,9 @@ public final class HealthCheckImpl: HealthCheck {
 
     public func checkServerAlive(address: String, port: Int32) -> Bool {
         return pingAddress("\(address):\(port)", name: "ServerAlive")
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -12,15 +12,19 @@ public final class CloakInteractor {
     private var cloakStarted: Bool = false
 
     func startCloak(outlineServerPort: String) throws {
+        let start = Date()
         let localPort = String(configsRepository.getCloakLocalPort())
-        logs.writeLog(log: "startCloakOutline: entering, localPort=\(localPort)")
+        logs.writeLog(log: "startCloakOutline: entering, localPort=\(localPort), outlineServerPort.len=\(outlineServerPort.count)")
 
         if configsRepository.getIsCloakEnabled() {
             let cloakConfig = configsRepository.getCloakConfig()
             if cloakConfig.isEmpty {
                 let host = OutlineInteractor.extractHost(from: outlineServerPort).lowercased()
                 let cloakRequired = (host == "127.0.0.1" || host == "localhost")
-                logs.writeLog(log: "startCloakOutline: enabled but config empty (required=\(cloakRequired), host=\(host))")
+                logs.writeLog(
+                    log: "startCloakOutline: enabled but config empty " +
+                        "(required=\(cloakRequired), host=\(maskStr(value: host)))"
+                )
                 if cloakRequired {
                     throw NSError(
                         domain: "PacketTunnelProvider",
@@ -28,32 +32,45 @@ public final class CloakInteractor {
                         userInfo: [NSLocalizedDescriptionKey: "Cloak enabled but config is empty"]
                     )
                 }
+                logs.writeLog(log: "startCloakOutline: config empty but not required; elapsedMs=\(elapsedMs(since: start))")
                 return
             }
             logs.writeLog(log: "startCloakOutline: starting cloak, config.length=\(cloakConfig.count)")
             var err: NSError?
+            let nativeStart = Date()
             Cloak_outlineStartCloakClient("127.0.0.1", localPort, cloakConfig, false, &err)
             if let error = err {
-                logs.writeLog(log: "startCloakOutline: failed to start cloak: \(error.localizedDescription)")
+                logs.writeLog(
+                    log: "startCloakOutline: failed to start cloak in \(elapsedMs(since: nativeStart))ms: " +
+                        "\(error.localizedDescription)"
+                )
                 throw error
             }
             cloakStarted = true
-            logs.writeLog(log: "startCloakOutline: Cloak_outlineStartCloakClient returned (cloakStarted=true)")
+            logs.writeLog(
+                log: "startCloakOutline: Cloak_outlineStartCloakClient returned " +
+                    "(cloakStarted=true) nativeMs=\(elapsedMs(since: nativeStart)) totalMs=\(elapsedMs(since: start))"
+            )
         } else {
-            logs.writeLog(log: "startCloakOutline: cloak disabled")
+            logs.writeLog(log: "startCloakOutline: cloak disabled elapsedMs=\(elapsedMs(since: start))")
             return
         }
     }
 
     func stopCloak() {
         if cloakStarted {
+            let start = Date()
             logs.writeLog(log: "stopCloak: stopping Cloak client")
             Cloak_outlineStopCloakClient()
             cloakStarted = false
-            logs.writeLog(log: "stopCloak: Cloak client stopped")
+            logs.writeLog(log: "stopCloak: Cloak client stopped elapsedMs=\(elapsedMs(since: start))")
         } else {
             logs.writeLog(log: "[DEBUG] stopCloak: skipped, cloakStarted=false")
         }
         cloakStarted = false
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -16,6 +16,8 @@ public final class OutlineInteractor {
         mtu: Int,
         nativeClientCreated: () -> Void
     ) throws {
+        let start = Date()
+        logs.writeLog(log: "[Outline] startOutline begin fd=\(tunnelFileDescriptor) mtu=\(mtu)")
 
         let methodPassword = configsRepository.getMethodPasswordOutline()
         let serverPort = configsRepository.getServerPort()
@@ -49,48 +51,76 @@ public final class OutlineInteractor {
         )
         logs.writeLog(log: "Outline config built (prefix=\(!prefix.isEmpty), ws=\(websocketEnabled), tcpPath=\(!tcpPath.isEmpty), udpPath=\(!udpPath.isEmpty))")
         if websocketEnabled {
-            logs.writeLog(log: "WebSocket transport requested (wss)")
+            logs.writeLog(
+                log: "WebSocket transport requested (wss) " +
+                    "serverHost=\(maskStr(value: OutlineInteractor.extractHost(from: serverPort)))"
+            )
         }
 
         var err: NSError?
 
         logs.writeLog(log: "[DEBUG][Outline] calling native NewVpnClient protocol=outline fd=\(tunnelFileDescriptor) mtu=\(mtu)")
+        let newClientStart = Date()
         Cloak_outlineNewVpnClient(config, "outline", Int(tunnelFileDescriptor), mtu, &err)
         if let error = err {
-            logs.writeLog(log: "[Outline] NewVpnClient failed: \(error.localizedDescription)")
+            logs.writeLog(
+                log: "[Outline] NewVpnClient failed in \(elapsedMs(since: newClientStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
+        logs.writeLog(log: "[Outline] NewVpnClient succeeded in \(elapsedMs(since: newClientStart))ms")
         nativeClientCreated()
+        logs.writeLog(log: "[Outline] nativeClientCreated callback returned")
 
         logs.writeLog(log: "[DEBUG][Outline] calling native VpnConnect")
+        let connectStart = Date()
         Cloak_outlineVpnConnect(&err)
         if let error = err {
-            logs.writeLog(log: "[Outline] VpnConnect failed: \(error.localizedDescription)")
+            logs.writeLog(
+                log: "[Outline] VpnConnect failed in \(elapsedMs(since: connectStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
-        logs.writeLog(log: "[Outline] VpnConnect succeeded")
+        outlineStarted = true
+        logs.writeLog(
+            log: "[Outline] VpnConnect succeeded in \(elapsedMs(since: connectStart))ms " +
+                "totalStartMs=\(elapsedMs(since: start))"
+        )
     }
 
     func stopOutline() throws {
         var err: NSError?
 
-        logs.writeLog(log: "[DEBUG][Outline] calling native VpnDisconnect")
+        logs.writeLog(log: "[DEBUG][Outline] calling native VpnDisconnect outlineStarted=\(outlineStarted)")
+        let start = Date()
         Cloak_outlineVpnDisconnect(&err)
         if let error = err {
-            logs.writeLog(log: "[Outline] VpnDisconnect failed: \(error.localizedDescription)")
+            logs.writeLog(
+                log: "[Outline] VpnDisconnect failed in \(elapsedMs(since: start))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
-        logs.writeLog(log: "[DEBUG][Outline] VpnDisconnect returned")
+        outlineStarted = false
+        logs.writeLog(log: "[DEBUG][Outline] VpnDisconnect returned in \(elapsedMs(since: start))ms")
     }
 
     func outlineStatus() -> String {
         var err: NSError?
+        let start = Date()
+        logs.writeLog(log: "[Outline] VpnStatus begin outlineStarted=\(outlineStarted)")
         let status = Cloak_outlineVpnStatus(&err)
         if let error = err {
             let message = "client=true localProxyAlive=false statusError=\(error.localizedDescription)"
-            logs.writeLog(log: "[Outline] VpnStatus failed: \(error.localizedDescription)")
+            logs.writeLog(
+                log: "[Outline] VpnStatus failed in \(elapsedMs(since: start))ms: " +
+                    "\(error.localizedDescription)"
+            )
             return message
         }
+        logs.writeLog(log: "[Outline] VpnStatus returned in \(elapsedMs(since: start))ms status=\(status)")
         return status
     }
 
@@ -133,6 +163,10 @@ public final class OutlineInteractor {
         // If WebSocket is enabled, wrap the Shadowsocks URL into WebSocket-over-TLS transport (wss://)
         if websocketEnabled {
             let effectiveHost = extractHost(serverPort).trimmingCharacters(in: .whitespacesAndNewlines)
+            logs.writeLog(
+                log: "[Outline] building WSS config effectiveHost=\(maskStr(value: effectiveHost)) " +
+                    "tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count)"
+            )
 
             var wsParams: [String] = []
             // outline-sdk v0.0.16: ws: does not support the `host=` option ("Unsupported option host")
@@ -166,5 +200,9 @@ public final class OutlineInteractor {
             return String(trimmed[..<lastColon])
         }
         return trimmed
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -12,6 +12,8 @@ final class PacketFlowBridge {
     private let requestedSocketBufferBytes = 1 * 1024 * 1024
     private let maxBatchPackets = 64
     private let maxBatchBytes = 64 * 1024
+    private let maxPacketClassificationSamples = 25
+    private let maxPacketFlowSummaryItems = 12
 
     private var readSource: DispatchSourceRead?
     private var statsTimer: DispatchSourceTimer?
@@ -33,6 +35,8 @@ final class PacketFlowBridge {
     private var goToTunnelDrops = 0
     private var firstTunnelPacketLogged = false
     private var firstGoPacketLogged = false
+    private var tunnelToGoClassification = PacketClassStats()
+    private var goToTunnelClassification = PacketClassStats()
 
     var tunnelFileDescriptor: Int32 {
         lock.lock()
@@ -45,6 +49,10 @@ final class PacketFlowBridge {
         let releasedFD = goFileDescriptor
         goFileDescriptor = -1
         lock.unlock()
+        if releasedFD < 0 {
+            log("[PacketFlowBridge] Go fd ownership release requested but fd was already released")
+            return
+        }
         log("[DEBUG][PacketFlowBridge] Go fd ownership released fd=\(releasedFD)")
     }
 
@@ -59,6 +67,11 @@ final class PacketFlowBridge {
             socketpair(AF_UNIX, SOCK_DGRAM, 0, buffer.baseAddress)
         }
         guard rc == 0 else {
+            let socketErrno = errno
+            log(
+                "[PacketFlowBridge] socketpair failed errno=\(socketErrno) " +
+                "\(errnoDescription(socketErrno))"
+            )
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
 
@@ -78,6 +91,10 @@ final class PacketFlowBridge {
                 "goFD=\(goFileDescriptor) snd=\(goBuffers.send) rcv=\(goBuffers.receive)"
             )
         } catch {
+            log(
+                "[PacketFlowBridge] socket setup failed swiftFD=\(swiftFileDescriptor) " +
+                "goFD=\(goFileDescriptor) error=\(error.localizedDescription)"
+            )
             closeIfOpen(&swiftFileDescriptor)
             closeIfOpen(&goFileDescriptor)
             throw error
@@ -88,8 +105,12 @@ final class PacketFlowBridge {
 
     func start() {
         lock.lock()
-        guard !running, swiftFileDescriptor >= 0, goFileDescriptor >= 0 else {
+        if running || swiftFileDescriptor < 0 || goFileDescriptor < 0 {
+            let isActive = running
+            let swiftFD = swiftFileDescriptor
+            let goFD = goFileDescriptor
             lock.unlock()
+            log("[PacketFlowBridge] start skipped running=\(isActive) swiftFD=\(swiftFD) goFD=\(goFD)")
             return
         }
         running = true
@@ -100,8 +121,18 @@ final class PacketFlowBridge {
         source.setEventHandler { [weak self] in
             self?.drainPacketsFromGo()
         }
+        let closeLog = log
         source.setCancelHandler {
-            close(sourceFD)
+            let rc = Darwin.close(sourceFD)
+            if rc == 0 {
+                closeLog("[PacketFlowBridge] read source cancel closed swiftFD=\(sourceFD)")
+            } else {
+                let closeErrno = errno
+                closeLog(
+                    "[PacketFlowBridge] read source cancel close failed swiftFD=\(sourceFD) " +
+                    "errno=\(closeErrno) \(String(cString: strerror(closeErrno)))"
+                )
+            }
         }
 
         lock.lock()
@@ -118,8 +149,9 @@ final class PacketFlowBridge {
 
     func stop() {
         lock.lock()
-        guard running || swiftFileDescriptor >= 0 || goFileDescriptor >= 0 else {
+        if !running && swiftFileDescriptor < 0 && goFileDescriptor < 0 {
             lock.unlock()
+            log("[PacketFlowBridge] stop skipped; already stopped")
             return
         }
         running = false
@@ -138,10 +170,10 @@ final class PacketFlowBridge {
         timer?.cancel()
         source?.cancel()
         if shouldCloseSwiftFD, swiftFD >= 0 {
-            close(swiftFD)
+            closeFD(swiftFD, label: "swiftFD")
         }
         if unreleasedGoFD >= 0 {
-            close(unreleasedGoFD)
+            closeFD(unreleasedGoFD, label: "unreleasedGoFD")
         }
         log("[PacketFlowBridge] stopped")
     }
@@ -164,6 +196,8 @@ final class PacketFlowBridge {
     private func writePacketToGo(_ packet: Data) {
         let fd = currentSwiftFileDescriptor()
         guard fd >= 0 else {
+            recordTunnelToGoDrop()
+            logWriteError("write packet to Go skipped because swift fd is closed packetBytes=\(packet.count)")
             return
         }
 
@@ -174,6 +208,7 @@ final class PacketFlowBridge {
         let framedPacket = utunFramedPacket(packet)
         let written = framedPacket.withUnsafeBytes { rawBuffer -> Int in
             guard let baseAddress = rawBuffer.baseAddress else {
+                logWriteError("write packet to Go failed: empty raw buffer packetBytes=\(packet.count)")
                 return -1
             }
             return Darwin.write(fd, baseAddress, framedPacket.count)
@@ -188,7 +223,7 @@ final class PacketFlowBridge {
             )
             return
         }
-        recordTunnelToGo(packetBytes: packet.count)
+        recordTunnelToGo(packet: packet)
     }
 
     private func drainPacketsFromGo() {
@@ -256,7 +291,11 @@ final class PacketFlowBridge {
         let count = packets.count
         let bytes = batchBytes
         packetFlow.writePackets(packets, withProtocols: protocols)
-        recordGoToTunnelBatch(packetCount: count, byteCount: bytes)
+        log(
+            "[DEBUG][PacketFlowBridge] wrote batch go->tunnel packets=\(count) bytes=\(bytes) " +
+            "protocols=\(protocols.count)"
+        )
+        recordGoToTunnelBatch(packetCount: count, byteCount: bytes, packets: packets)
         packets.removeAll(keepingCapacity: true)
         protocols.removeAll(keepingCapacity: true)
         batchBytes = 0
@@ -292,31 +331,56 @@ final class PacketFlowBridge {
         }
     }
 
-    private func recordTunnelToGo(packetBytes: Int) {
+    private func recordTunnelToGo(packet: Data) {
+        let classification = classifyPacket(packet)
         lock.lock()
         tunnelToGoPackets += 1
-        tunnelToGoBytes += packetBytes
+        tunnelToGoBytes += packet.count
+        let sample = tunnelToGoClassification.record(
+            classification,
+            sampleLimit: maxPacketClassificationSamples
+        )
         let shouldLogFirst = !firstTunnelPacketLogged
         firstTunnelPacketLogged = true
         lock.unlock()
 
         if shouldLogFirst {
-            log("[DEBUG][PacketFlowBridge] first packet tunnel->go bytes=\(packetBytes)")
+            log("[DEBUG][PacketFlowBridge] first packet tunnel->go \(classification.sampleDescription)")
+        }
+        if let sample {
+            log("[DEBUG][PacketFlowBridge] sample tunnel->go \(sample)")
         }
     }
 
-    private func recordGoToTunnelBatch(packetCount: Int, byteCount: Int) {
+    private func recordGoToTunnelBatch(packetCount: Int, byteCount: Int, packets: [Data]) {
+        let classifications = packets.map { classifyPacket($0) }
         lock.lock()
         goToTunnelPackets += packetCount
         goToTunnelBytes += byteCount
         goToTunnelWriteBatches += 1
         goToTunnelMaxBatchPackets = max(goToTunnelMaxBatchPackets, packetCount)
+        var samples: [String] = []
+        for classification in classifications {
+            if let sample = goToTunnelClassification.record(
+                classification,
+                sampleLimit: maxPacketClassificationSamples
+            ) {
+                samples.append(sample)
+            }
+        }
         let shouldLogFirst = !firstGoPacketLogged
         firstGoPacketLogged = true
         lock.unlock()
 
         if shouldLogFirst {
-            log("[DEBUG][PacketFlowBridge] first batch go->tunnel packets=\(packetCount) bytes=\(byteCount)")
+            let firstPacket = classifications.first?.sampleDescription ?? "no_packet_classification"
+            log(
+                "[DEBUG][PacketFlowBridge] first batch go->tunnel packets=\(packetCount) " +
+                "bytes=\(byteCount) first=\(firstPacket)"
+            )
+        }
+        for sample in samples {
+            log("[DEBUG][PacketFlowBridge] sample go->tunnel \(sample)")
         }
     }
 
@@ -359,6 +423,8 @@ final class PacketFlowBridge {
         let writeErrors = writeErrorCount
         let readErrors = readErrorCount
         let isActive = running
+        let tunnelToGoClassSummary = tunnelToGoClassification.summary(maxItems: maxPacketFlowSummaryItems)
+        let goToTunnelClassSummary = goToTunnelClassification.summary(maxItems: maxPacketFlowSummaryItems)
         lock.unlock()
 
         log(
@@ -370,6 +436,369 @@ final class PacketFlowBridge {
             "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) " +
             "oversized=\(oversized) writeErrors=\(writeErrors) readErrors=\(readErrors)"
         )
+        log("[PacketFlowBridge][classify] tunnel_to_go \(tunnelToGoClassSummary)")
+        log("[PacketFlowBridge][classify] go_to_tunnel \(goToTunnelClassSummary)")
+    }
+
+    private struct PacketClassification {
+        let family: String
+        let transport: String
+        let source: String
+        let destination: String
+        let sourcePort: Int?
+        let destinationPort: Int?
+        let byteCount: Int
+        let parseError: String?
+
+        var isDNS: Bool {
+            sourcePort == 53 || destinationPort == 53
+        }
+
+        var flowKey: String {
+            "\(transport) \(endpoint(source, sourcePort))->\(endpoint(destination, destinationPort))"
+        }
+
+        var sampleKey: String {
+            if let parseError {
+                return "\(family)/\(transport) parseError=\(parseError) bytes=\(byteCount)"
+            }
+            return "\(family)/\(transport) \(endpoint(source, sourcePort))->\(endpoint(destination, destinationPort))"
+        }
+
+        var sampleDescription: String {
+            var parts = [
+                "family=\(family)",
+                "transport=\(transport)",
+                "src=\(endpoint(source, sourcePort))",
+                "dst=\(endpoint(destination, destinationPort))",
+                "bytes=\(byteCount)"
+            ]
+            if isDNS {
+                parts.append("dns=true")
+            }
+            if let parseError {
+                parts.append("parseError=\(parseError)")
+            }
+            return parts.joined(separator: " ")
+        }
+
+        private func endpoint(_ ip: String, _ port: Int?) -> String {
+            guard let port else { return ip }
+            return "\(ip):\(port)"
+        }
+    }
+
+    private struct PacketClassStats {
+        var packets = 0
+        var bytes = 0
+        var parseErrors = 0
+        var dnsPackets = 0
+        var dnsBytes = 0
+        var familyPackets: [String: Int] = [:]
+        var familyBytes: [String: Int] = [:]
+        var transportPackets: [String: Int] = [:]
+        var transportBytes: [String: Int] = [:]
+        var flowPackets: [String: Int] = [:]
+        var flowBytes: [String: Int] = [:]
+        var samples: [String] = []
+        var sampleKeys = Set<String>()
+
+        mutating func record(_ packet: PacketClassification, sampleLimit: Int) -> String? {
+            packets += 1
+            bytes += packet.byteCount
+            familyPackets[packet.family, default: 0] += 1
+            familyBytes[packet.family, default: 0] += packet.byteCount
+            transportPackets[packet.transport, default: 0] += 1
+            transportBytes[packet.transport, default: 0] += packet.byteCount
+            flowPackets[packet.flowKey, default: 0] += 1
+            flowBytes[packet.flowKey, default: 0] += packet.byteCount
+
+            if packet.isDNS {
+                dnsPackets += 1
+                dnsBytes += packet.byteCount
+            }
+            if packet.parseError != nil {
+                parseErrors += 1
+            }
+
+            guard samples.count < sampleLimit, !sampleKeys.contains(packet.sampleKey) else {
+                return nil
+            }
+            sampleKeys.insert(packet.sampleKey)
+            let sample = packet.sampleDescription
+            samples.append(sample)
+            return sample
+        }
+
+        func summary(maxItems: Int) -> String {
+            "packets=\(packets) bytes=\(bytes) " +
+            "families={\(breakdown(familyPackets, familyBytes, maxItems: maxItems))} " +
+            "transports={\(breakdown(transportPackets, transportBytes, maxItems: maxItems))} " +
+            "dns=\(dnsPackets)p/\(dnsBytes)B parseErrors=\(parseErrors) " +
+            "topFlows={\(breakdown(flowPackets, flowBytes, maxItems: maxItems))} " +
+            "samples=[\(samples.joined(separator: "; "))]"
+        }
+
+        private func breakdown(_ packets: [String: Int], _ bytes: [String: Int], maxItems: Int) -> String {
+            guard !packets.isEmpty else { return "none" }
+            return packets
+                .sorted { lhs, rhs in
+                    if lhs.value == rhs.value {
+                        return lhs.key < rhs.key
+                    }
+                    return lhs.value > rhs.value
+                }
+                .prefix(maxItems)
+                .map { key, count in
+                    "\(key)=\(count)p/\(bytes[key] ?? 0)B"
+                }
+                .joined(separator: ",")
+        }
+    }
+
+    private func classifyPacket(_ packet: Data) -> PacketClassification {
+        packet.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            guard let base = bytes.baseAddress, bytes.count > 0 else {
+                return PacketClassification(
+                    family: "unknown",
+                    transport: "unknown",
+                    source: "-",
+                    destination: "-",
+                    sourcePort: nil,
+                    destinationPort: nil,
+                    byteCount: packet.count,
+                    parseError: "empty_packet"
+                )
+            }
+
+            let version = base[0] >> 4
+            switch version {
+            case 4:
+                return classifyIPv4(base: base, count: bytes.count, byteCount: packet.count)
+            case 6:
+                return classifyIPv6(base: base, count: bytes.count, byteCount: packet.count)
+            default:
+                return PacketClassification(
+                    family: "unknown_v\(version)",
+                    transport: "unknown",
+                    source: "-",
+                    destination: "-",
+                    sourcePort: nil,
+                    destinationPort: nil,
+                    byteCount: packet.count,
+                    parseError: "unsupported_ip_version_\(version)"
+                )
+            }
+        }
+    }
+
+    private func classifyIPv4(
+        base: UnsafePointer<UInt8>,
+        count: Int,
+        byteCount: Int
+    ) -> PacketClassification {
+        guard count >= 20 else {
+            return malformedPacket(family: "ipv4", byteCount: byteCount, reason: "short_ipv4_header_\(count)")
+        }
+
+        let headerLength = Int(base[0] & 0x0F) * 4
+        guard headerLength >= 20, count >= headerLength else {
+            return malformedPacket(
+                family: "ipv4",
+                byteCount: byteCount,
+                reason: "invalid_ipv4_header_length_\(headerLength)_count_\(count)"
+            )
+        }
+
+        let protocolNumber = base[9]
+        let source = ipv4String(base.advanced(by: 12))
+        let destination = ipv4String(base.advanced(by: 16))
+        let transport = classifyTransport(
+            base: base,
+            count: count,
+            offset: headerLength,
+            protocolNumber: protocolNumber,
+            family: "ipv4",
+            byteCount: byteCount,
+            source: source,
+            destination: destination
+        )
+        return transport
+    }
+
+    private func classifyIPv6(
+        base: UnsafePointer<UInt8>,
+        count: Int,
+        byteCount: Int
+    ) -> PacketClassification {
+        guard count >= 40 else {
+            return malformedPacket(family: "ipv6", byteCount: byteCount, reason: "short_ipv6_header_\(count)")
+        }
+
+        let source = ipv6String(base.advanced(by: 8))
+        let destination = ipv6String(base.advanced(by: 24))
+        let transportLocation = ipv6TransportLocation(base: base, count: count)
+        if let parseError = transportLocation.parseError {
+            return PacketClassification(
+                family: "ipv6",
+                transport: "proto\(transportLocation.protocolNumber)",
+                source: source,
+                destination: destination,
+                sourcePort: nil,
+                destinationPort: nil,
+                byteCount: byteCount,
+                parseError: parseError
+            )
+        }
+
+        return classifyTransport(
+            base: base,
+            count: count,
+            offset: transportLocation.offset,
+            protocolNumber: transportLocation.protocolNumber,
+            family: "ipv6",
+            byteCount: byteCount,
+            source: source,
+            destination: destination
+        )
+    }
+
+    private func ipv6TransportLocation(
+        base: UnsafePointer<UInt8>,
+        count: Int
+    ) -> (protocolNumber: UInt8, offset: Int, parseError: String?) {
+        var protocolNumber = base[6]
+        var offset = 40
+        var extensionCount = 0
+
+        while isIPv6ExtensionHeader(protocolNumber) {
+            extensionCount += 1
+            if extensionCount > 8 {
+                return (protocolNumber, offset, "too_many_ipv6_extension_headers")
+            }
+            guard count >= offset + 2 else {
+                return (protocolNumber, offset, "short_ipv6_extension_header_offset_\(offset)")
+            }
+
+            let nextHeader = base[offset]
+            let headerLength: Int
+            switch protocolNumber {
+            case 0, 43, 60:
+                headerLength = (Int(base[offset + 1]) + 1) * 8
+            case 44:
+                headerLength = 8
+            case 51:
+                headerLength = (Int(base[offset + 1]) + 2) * 4
+            default:
+                headerLength = 0
+            }
+
+            guard headerLength > 0, count >= offset + headerLength else {
+                return (protocolNumber, offset, "invalid_ipv6_extension_length_\(headerLength)_offset_\(offset)")
+            }
+            offset += headerLength
+            protocolNumber = nextHeader
+        }
+
+        return (protocolNumber, offset, nil)
+    }
+
+    private func isIPv6ExtensionHeader(_ protocolNumber: UInt8) -> Bool {
+        switch protocolNumber {
+        case 0, 43, 44, 51, 60:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func classifyTransport(
+        base: UnsafePointer<UInt8>,
+        count: Int,
+        offset: Int,
+        protocolNumber: UInt8,
+        family: String,
+        byteCount: Int,
+        source: String,
+        destination: String
+    ) -> PacketClassification {
+        let transport = transportName(protocolNumber)
+        var sourcePort: Int?
+        var destinationPort: Int?
+        var parseError: String?
+
+        if protocolNumber == 6 || protocolNumber == 17 {
+            if count >= offset + 4 {
+                sourcePort = readUInt16(base.advanced(by: offset))
+                destinationPort = readUInt16(base.advanced(by: offset + 2))
+            } else {
+                parseError = "short_\(transport)_header_offset_\(offset)_count_\(count)"
+            }
+        }
+
+        return PacketClassification(
+            family: family,
+            transport: transport,
+            source: source,
+            destination: destination,
+            sourcePort: sourcePort,
+            destinationPort: destinationPort,
+            byteCount: byteCount,
+            parseError: parseError
+        )
+    }
+
+    private func transportName(_ protocolNumber: UInt8) -> String {
+        switch protocolNumber {
+        case 6:
+            return "tcp"
+        case 17:
+            return "udp"
+        case 1:
+            return "icmp"
+        case 58:
+            return "icmpv6"
+        default:
+            return "proto\(protocolNumber)"
+        }
+    }
+
+    private func malformedPacket(family: String, byteCount: Int, reason: String) -> PacketClassification {
+        PacketClassification(
+            family: family,
+            transport: "malformed",
+            source: "-",
+            destination: "-",
+            sourcePort: nil,
+            destinationPort: nil,
+            byteCount: byteCount,
+            parseError: reason
+        )
+    }
+
+    private func readUInt16(_ pointer: UnsafePointer<UInt8>) -> Int {
+        (Int(pointer[0]) << 8) | Int(pointer[1])
+    }
+
+    private func ipv4String(_ pointer: UnsafePointer<UInt8>) -> String {
+        var address = in_addr()
+        memcpy(&address, pointer, MemoryLayout<in_addr>.size)
+        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+            return "ipv4_ntop_error"
+        }
+        return String(cString: buffer)
+    }
+
+    private func ipv6String(_ pointer: UnsafePointer<UInt8>) -> String {
+        var address = in6_addr()
+        memcpy(&address, pointer, MemoryLayout<in6_addr>.size)
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+            return "ipv6_ntop_error"
+        }
+        return String(cString: buffer)
     }
 
     private var isRunning: Bool {
@@ -429,11 +858,16 @@ final class PacketFlowBridge {
     private func setNonBlocking(_ fd: Int32) throws {
         let flags = fcntl(fd, F_GETFL, 0)
         guard flags >= 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            let flagErrno = errno
+            log("[PacketFlowBridge] fcntl(F_GETFL) failed fd=\(fd) errno=\(flagErrno) \(errnoDescription(flagErrno))")
+            throw POSIXError(POSIXErrorCode(rawValue: flagErrno) ?? .EIO)
         }
         guard fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            let setErrno = errno
+            log("[PacketFlowBridge] fcntl(F_SETFL O_NONBLOCK) failed fd=\(fd) errno=\(setErrno) \(errnoDescription(setErrno))")
+            throw POSIXError(POSIXErrorCode(rawValue: setErrno) ?? .EIO)
         }
+        log("[DEBUG][PacketFlowBridge] set non-blocking fd=\(fd) oldFlags=\(flags) newFlags=\(flags | O_NONBLOCK)")
     }
 
     private func disableSigpipe(_ fd: Int32) throws {
@@ -446,8 +880,11 @@ final class PacketFlowBridge {
             socklen_t(MemoryLayout<Int32>.size)
         )
         guard result == 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            let sigpipeErrno = errno
+            log("[PacketFlowBridge] setsockopt(SO_NOSIGPIPE) failed fd=\(fd) errno=\(sigpipeErrno) \(errnoDescription(sigpipeErrno))")
+            throw POSIXError(POSIXErrorCode(rawValue: sigpipeErrno) ?? .EIO)
         }
+        log("[DEBUG][PacketFlowBridge] disabled SIGPIPE fd=\(fd)")
     }
 
     private func configureSocketBuffers(_ fd: Int32, requestedBytes: Int) -> (send: Int, receive: Int) {
@@ -493,13 +930,31 @@ final class PacketFlowBridge {
         var value: Int32 = 0
         var length = socklen_t(MemoryLayout<Int32>.size)
         let result = getsockopt(fd, SOL_SOCKET, option, &value, &length)
-        return result == 0 ? Int(value) : -1
+        if result != 0 {
+            let getErrno = errno
+            log("[PacketFlowBridge] getsockopt option=\(option) failed fd=\(fd) errno=\(getErrno) \(errnoDescription(getErrno))")
+            return -1
+        }
+        return Int(value)
     }
 
     private func closeIfOpen(_ fd: inout Int32) {
         if fd >= 0 {
-            close(fd)
+            closeFD(fd, label: "fd")
             fd = -1
+        }
+    }
+
+    private func closeFD(_ fd: Int32, label: String) {
+        let rc = Darwin.close(fd)
+        if rc == 0 {
+            log("[DEBUG][PacketFlowBridge] close OK \(label)=\(fd)")
+        } else {
+            let closeErrno = errno
+            log(
+                "[PacketFlowBridge] close failed \(label)=\(fd) " +
+                "errno=\(closeErrno) \(errnoDescription(closeErrno))"
+            )
         }
     }
 }

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -51,14 +51,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(log: "[Memory] VPN use: \(String(format: "%.2f", usedMB)) MB")
             return usedMB
         }
-        logs.writeLog(log: "[Memory] unable to get info")
+        let message = mach_error_string(result).map { String(cString: $0) } ?? "unknown"
+        logs.writeLog(log: "[Memory] unable to get info result=\(result) error=\(message)")
         return 0.0
     }
 
     func logInterfaces() {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&ifaddrPtr) == 0, ifaddrPtr != nil else {
-            logs.writeLog(log: "[DEBUG][Interfaces] getifaddrs failed")
+        let rc = getifaddrs(&ifaddrPtr)
+        guard rc == 0, ifaddrPtr != nil else {
+            let getErrno = errno
+            logs.writeLog(
+                log: "[DEBUG][Interfaces] getifaddrs failed rc=\(rc) errno=\(getErrno) " +
+                    "\(String(cString: strerror(getErrno)))"
+            )
             return
         }
         defer { freeifaddrs(ifaddrPtr) }
@@ -82,6 +88,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     }
                     if inet_ntop(AF_INET, &ip, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
                         values.append("ipv4=\(String(cString: buffer))")
+                    } else {
+                        let ntopErrno = errno
+                        values.append("ipv4_ntop_error=\(ntopErrno):\(String(cString: strerror(ntopErrno)))")
                     }
                 } else if family == AF_INET6 {
                     values.append("ipv6")
@@ -108,6 +117,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let tid = UInt64(pthread_mach_thread_np(pthread_self()))
         var startupStage = "entered"
         let optionKeys = options?.keys.sorted().joined(separator: ",") ?? "(none)"
+        func enterStage(_ stage: String) {
+            startupStage = stage
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage begin: \(stage)")
+        }
 
         // iOS 26 research: Log iOS version
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
@@ -123,27 +136,32 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_BEFORE_VPN_TUNNEL ==========")
 
         do {
-            startupStage = "go logger init"
+            enterStage("go logger init")
             let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
             logs.writeLog(log: "Start go logger init path = \(path)")
             Cloak_outlineInitLogger(path)
             logs.writeLog(log: "Finish go logger init")
 
             // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
-            startupStage = "pre-start cleanup"
+            enterStage("pre-start cleanup")
             await teardownForStop(reason: "pre-start cleanup")
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: pre-start cleanup")
 
-            startupStage = "path monitor"
+            enterStage("path monitor")
             startPathLogging()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: path monitor")
             
             // iOS 26+: set the physical interface index before any protected sockets are opened.
+            enterStage("initial interface detection")
             setInitialDefaultInterfaceIndexForStartup(timeout: 1.0)
-            startupStage = "geo routing config"
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: initial interface detection")
+            enterStage("geo routing config")
             let geoRoutingConf = configsRepository.getGeoRoutingConf()
             logs.writeLog(log: "[DEBUG][Routing] applying geo routing config length=\(geoRoutingConf.count)")
             Cloak_outlineSetGeoRoutingConf(geoRoutingConf)
+            logs.writeLog(log: "[DEBUG][Routing] geo routing config applied")
 
-            startupStage = "route exclusions"
+            enterStage("route exclusions")
             let cloakConfig = configsRepository.getCloakConfig()
             // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
             // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
@@ -188,20 +206,23 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             } else {
                 logs.writeLog(log: "Excluded IPv4 routes: (none)")
             }
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: route exclusions count=\(excludedRoutes.count)")
 
             // Determine which protocol to use early - needed for Cloak startup
             let vpnInterface = configsRepository.getVpnInterface()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] selected vpnInterface=\(vpnInterface)")
 
             // Cloak must bind/connect before the full-tunnel route is installed; otherwise
             // iOS can route the upstream bootstrap traffic into a tunnel that is not ready yet.
             // Only start Cloak for cloakOutline protocol.
             if vpnInterface == .cloakOutline {
-                startupStage = "cloak startup"
+                enterStage("cloak startup")
                 logs.writeLog(log: "[tunnel:\(tunnelId)] starting Cloak phase")
                 try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPort())
+                logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: cloak startup")
             }
 
-            startupStage = "network settings build"
+            enterStage("network settings build")
             let remoteAddress = "254.1.1.1"
             let localAddress = "198.18.0.1"
             let subnetMask = "255.255.0.0"
@@ -218,6 +239,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             settings.ipv6Settings = nil
             settings.dnsSettings = NEDNSSettings(servers: dnsServers)
             settings.dnsSettings?.matchDomains = [""]
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: network settings build")
 
             logNetworkSettings(
                 localAddress: localAddress,
@@ -227,7 +249,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 dnsServers: dnsServers,
                 excludedRoutes: excludedRoutes
             )
-            startupStage = "setTunnelNetworkSettings"
+            enterStage("setTunnelNetworkSettings")
             let settingsStart = Date()
             logs.writeLog(log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings begin")
             try await self.setTunnelNetworkSettings(settings)
@@ -240,7 +262,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logInterfaces()
             logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_AFTER_VPN_TUNNEL ==========")
 
-            startupStage = "packetFlow bridge"
+            enterStage("packetFlow bridge")
             let bridgeTunnelId = tunnelId
             let bridgeLogs = logs
             logs.writeLog(log: "[tunnel:\(tunnelId)] creating PacketFlowBridge mtu=\(tunnelMTU)")
@@ -254,8 +276,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             )
             packetFlowBridge = bridge
             bridge.start()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: packetFlow bridge fd=\(bridge.tunnelFileDescriptor)")
 
-            startupStage = "protocol startup"
+            enterStage("protocol startup")
             logs.writeLog(log: "[tunnel:\(tunnelId)] starting VPN protocol phase tunnelFD=\(bridge.tunnelFileDescriptor) mtu=\(tunnelMTU)")
 
             switch vpnInterface {
@@ -306,7 +329,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel reason=\(reason.rawValue) (\(reason))")
         configsRepository.setIsUserInitStop(isUserInitStop: true)
+        logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel clearing geo routing config")
         Cloak_outlineClearGeoRoutingConf()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel geo routing clear returned")
 
         // Stop the active protocol based on the VPN interface
         let vpnInterface = configsRepository.getVpnInterface()
@@ -353,15 +378,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
+        logs.writeLog(
+            log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage begin bytes=\(messageData.count) " +
+                "hasCompletion=\(completionHandler != nil)"
+        )
         if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
             logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory")
-            completionHandler?("Memory:\(reportMemoryUsageMB())".data(using: .utf8))
+            let response = "Memory:\(reportMemoryUsageMB())".data(using: .utf8)
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory responseBytes=\(response?.count ?? -1)")
+            completionHandler?(response)
         } else if let msg = String(data: messageData, encoding: .utf8), msg == "getOutlineStatus" {
             let status = outlineInteractor.outlineStatus()
             logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getOutlineStatus \(status)")
-            completionHandler?("OutlineStatus:\(status)".data(using: .utf8))
+            let response = "OutlineStatus:\(status)".data(using: .utf8)
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getOutlineStatus responseBytes=\(response?.count ?? -1)")
+            completionHandler?(response)
         } else {
-            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage echo bytes=\(messageData.count)")
+            if String(data: messageData, encoding: .utf8) == nil {
+                logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage nonUtf8 echo bytes=\(messageData.count)")
+            } else {
+                logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage unknown echo bytes=\(messageData.count)")
+            }
             completionHandler?(messageData)
         }
     }
@@ -371,6 +408,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private func getDefaultInterfaceIndex(from path: Network.NWPath) -> Int {
         // Find the non-VPN, non-loopback interface.
         let physicalInterfaces = path.availableInterfaces.filter { $0.type != .other && $0.type != .loopback }
+        let candidates = path.availableInterfaces
+            .map { "\($0.name):\(interfaceTypeKey($0.type))" }
+            .joined(separator: ",")
+        logs.writeLog(
+            log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] selecting default interface " +
+                "status=\(path.status) candidates=[\(candidates)] physicalCount=\(physicalInterfaces.count)"
+        )
         
         // Prefer WiFi, then cellular, then any other physical interface
         let preferredInterface = physicalInterfaces.first { $0.type == .wifi }
@@ -379,11 +423,24 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             ?? physicalInterfaces.first
         
         guard let iface = preferredInterface else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] no physical interface candidate found")
             return 0
         }
         
         // Convert interface name to index
         let index = iface.name.withCString { Int(if_nametoindex($0)) }
+        if index == 0 {
+            let indexErrno = errno
+            logs.writeLog(
+                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] if_nametoindex failed " +
+                    "name=\(iface.name) type=\(iface.type) errno=\(indexErrno) \(String(cString: strerror(indexErrno)))"
+            )
+        } else {
+            logs.writeLog(
+                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] selected default interface " +
+                    "name=\(iface.name) type=\(iface.type) index=\(index)"
+            )
+        }
         return index
     }
     
@@ -414,7 +471,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             )
         } else {
             logs.writeLog(
-                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] WARNING: Could not determine default interface index!"
+                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] WARNING: Could not determine default interface index! " +
+                    "pathStatus=\(path.status) ifaces=\(path.availableInterfaces.map { "\($0.name):\($0.type)" }.joined(separator: ","))"
             )
         }
     }
@@ -603,6 +661,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             lock.lock()
             if captured {
                 lock.unlock()
+                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP_NETWORK: duplicate path update ignored")
                 return
             }
             captured = true
@@ -633,7 +692,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let ifaceIndex = self.getDefaultInterfaceIndex(from: path)
             if ifaceIndex > 0 {
                 Cloak_outlineSetDefaultInterfaceIndex(ifaceIndex)
-                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP: Set initial interface index: \(ifaceIndex)")
+                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP: Set initial interface index returned: \(ifaceIndex)")
             } else {
                 self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP_WARNING: Could not determine initial interface index")
             }
@@ -649,13 +708,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             semaphore.signal()
         }
 
+        logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: starting temporary NWPathMonitor timeoutMs=\(Int(timeout * 1000))")
         monitor.start(queue: q)
 
         if semaphore.wait(timeout: .now() + timeout) == .timedOut {
             logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_WARNING: Timed out waiting for initial network path")
+        } else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: initial path captured")
         }
 
         monitor.cancel()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: temporary NWPathMonitor cancelled")
     }
 
     @MainActor
@@ -676,6 +739,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] stopping Cloak")
         cloakInteractor.stopCloak()
+
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing geo routing config")
+        Cloak_outlineClearGeoRoutingConf()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] geo routing clear returned")
 
         do {
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing tunnel network settings")
@@ -724,16 +791,34 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     /// Extracts `RemoteHost` from Cloak JSON
     func extractRemoteHost(from cloakConfig: String) -> String? {
-        guard
-            !cloakConfig.isEmpty,
-            let data = cloakConfig.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let remoteHost = json["RemoteHost"] as? String,
-            !remoteHost.isEmpty
-        else {
+        guard !cloakConfig.isEmpty else {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: config empty")
             return nil
         }
-        return remoteHost
+        guard let data = cloakConfig.data(using: .utf8) else {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: config is not UTF-8")
+            return nil
+        }
+        do {
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: JSON root is not object")
+                return nil
+            }
+            guard let remoteHost = json["RemoteHost"] as? String else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: RemoteHost key missing")
+                return nil
+            }
+            let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: RemoteHost empty")
+                return nil
+            }
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extracted host=\(maskStr(value: trimmed))")
+            return trimmed
+        } catch {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Converts host/IP into an excluded /32 route
@@ -783,7 +868,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         var addr = first.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee.sin_addr }
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         let ptr = inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-        guard ptr != nil else { return nil }
+        guard ptr != nil else {
+            let ntopErrno = errno
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) inet_ntop failed " +
+                    "errno=\(ntopErrno) \(String(cString: strerror(ntopErrno))) elapsed=\(elapsedMs(since: start))ms"
+            )
+            return nil
+        }
         let value = String(cString: buffer)
         logs.writeLog(
             log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) ok " +

--- a/swift_module/tunnel/XRayInteractor.swift
+++ b/swift_module/tunnel/XRayInteractor.swift
@@ -15,11 +15,15 @@ public final class XRayInteractor {
         tunnelFileDescriptor: Int32,
         mtu: Int
     ) throws {
+        let start = Date()
+        logs.writeLog(log: "[XRay] startXRay begin fd=\(tunnelFileDescriptor) mtu=\(mtu)")
         if !configsRepository.getIsXrayEnabled() {
+            logs.writeLog(log: "[XRay] startXRay skipped because Xray is disabled")
             return
         }
         
         let xrayConfig = configsRepository.getXrayConfig()
+        logs.writeLog(log: "[XRay] config snapshot length=\(xrayConfig.count)")
 
         // Validate config early (prevents passing empty config into native layer).
         if xrayConfig.isEmpty {
@@ -34,29 +38,55 @@ public final class XRayInteractor {
         
         var err: NSError?
 
+        let newClientStart = Date()
+        logs.writeLog(log: "[XRay] calling native NewVpnClient fd=\(tunnelFileDescriptor) mtu=\(mtu)")
         Cloak_outlineNewVpnClient(xrayConfig, "xray", Int(tunnelFileDescriptor), mtu, &err)
         if let error = err {
             xrayStarted = false
+            logs.writeLog(
+                log: "[XRay] NewVpnClient failed in \(elapsedMs(since: newClientStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
+        logs.writeLog(log: "[XRay] NewVpnClient succeeded in \(elapsedMs(since: newClientStart))ms")
 
+        let connectStart = Date()
+        logs.writeLog(log: "[XRay] calling native VpnConnect")
         Cloak_outlineVpnConnect(&err)
         if let error = err {
             xrayStarted = false
+            logs.writeLog(
+                log: "[XRay] VpnConnect failed in \(elapsedMs(since: connectStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
         xrayStarted = true
+        logs.writeLog(
+            log: "[XRay] VpnConnect succeeded in \(elapsedMs(since: connectStart))ms " +
+                "totalStartMs=\(elapsedMs(since: start))"
+        )
     }
 
     func stopXRay() {
         if !xrayStarted {
+            logs.writeLog(log: "[XRay] stopXRay skipped xrayStarted=false")
             return
         }
         var err: NSError?
+        let start = Date()
+        logs.writeLog(log: "[XRay] calling native VpnDisconnect")
         Cloak_outlineVpnDisconnect(&err)
         if let error = err {
-            logs.writeLog(log: "Stop Xray get error \(error)")
+            logs.writeLog(log: "[XRay] VpnDisconnect failed in \(elapsedMs(since: start))ms: \(error.localizedDescription)")
+        } else {
+            logs.writeLog(log: "[XRay] VpnDisconnect succeeded in \(elapsedMs(since: start))ms")
         }
         xrayStarted = false
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }


### PR DESCRIPTION
## Summary

This PR expands iOS VPN diagnostics and fixes the iOS health-check status blind spot found in the iOS 26 logs.

The app already has extensive logging, but the latest iOS 26 logs showed that the critical failure path was still ambiguous:

- The packet tunnel was created successfully.
- `PacketFlowBridge` was moving packets in both directions.
- Protected upstream sockets were usually bound to the physical interface via `IP_BOUND_IF`.
- HTTP checks sometimes succeeded through `198.18.0.1`.
- The health check still reported `outlineProxy=false` because the Swift check expected `localProxyAlive=true`, while the Go `VpnStatus()` response only exposed `client=true engineStarted=true fd=... deviceNil=false serverIP=...`.

This PR makes the native/runtime status contract explicit and adds packet-level classification so future iOS tunnel failures can be pinned to the exact layer: OS tunnel setup, interface selection, socket protection, packet bridge, DNS, TCP/UDP, local proxy, protocol startup, or upstream reachability.

## Implementation Background

Recent iOS 26 work changed socket protection from the deprecated `SO_NO_TC_NETPOLICY` path toward `IP_BOUND_IF` with a physical interface index from `NWPathMonitor`. The logs show that direction is mostly correct, but the app still produced false-negative health results because the Swift health check did not receive the local Outline proxy liveness field it required.

The important log pattern was:

- Tunnel settings applied and `utun` received `198.18.0.1`.
- `PacketFlowBridge` started and reported non-zero traffic in both directions.
- `VpnConnect()` succeeded.
- `httpPing` could succeed via local tunnel address `198.18.0.1`.
- `getOutlineStatus` returned only `client=true engineStarted=true fd=11 deviceNil=false serverIP=...`.
- Swift then failed `Outline local proxy check` because `localProxyAlive=true` was absent.

Without the extra diagnostics, failures after this point were hard to distinguish from real tunnel/proxy failures.

## Changes

### Native status contract

- Added optional `StatusProvider` for protocol devices.
- Appended `OutlineDevice.Status(500ms)` to mobile `CoreClient.Status()`.
- `VpnStatus()` now exposes `localProxyAlive=true/false`, proxy address, serve state, generation, close state, serve error, probe errors, and uptime.
- Swift health checks still respect `localProxyAlive=false`, accept `localProxyAlive=true`, and retain a legacy fallback for older native binaries that only report a healthy engine/device state.

### iOS tunnel lifecycle logging

- Added explicit `startTunnel stage begin` and stage completion logs.
- Added errno-aware interface logging for `getifaddrs` and `inet_ntop`.
- Added detailed `NWPath` default-interface selection logs, including candidates and `if_nametoindex` failures.
- Logged georouting apply/clear calls from both Swift and gomobile exports.
- Logged provider-message request/response details for `getMemory` and `getOutlineStatus`.

### Packet bridge diagnostics

- Added packet classification on both directions:
  - `tunnel -> go`
  - `go -> tunnel`
- Periodic bridge stats now include:
  - IPv4 / IPv6 packet and byte counters.
  - TCP / UDP / ICMP / ICMPv6 / unknown protocol counters.
  - DNS packet and byte counters based on source/destination port `53`.
  - Top IP:port flows with packet and byte counts.
  - Bounded representative samples.
  - Malformed / parse-error counters.
- Added setup/teardown logging for socketpair, socket buffers, non-blocking mode, SIGPIPE, fd release, and close failures.

### Socket protection diagnostics

- Logged every protected dial/listen begin and result.
- Logged `SO_NO_TC_NETPOLICY` success/failure explicitly.
- Logged `IP_BOUND_IF`/`IPV6_BOUND_IF` bind attempts and interface inventory.
- Logged cached vs fallback interface-index selection.
- Kept critical routing-loop warnings when a protected upstream socket reports local `198.18.x.x`.

### Health checks

- Added timing and pass/fail logs for every retry attempt.
- Added DNS resolution timing.
- Added native TCP/protected TCP ping input/result/error logs.
- Added provider message timeout and response byte logs.
- Added memory response parse-failure logs.
- Added interface scan summaries for tunnel IP detection.

### Gomobile boundary error handling

- Added panic guards that return errors where the function signature allows it.
- Added begin/OK/failed logs for:
  - VPN client creation/connect/disconnect/status.
  - Cloak start/stop.
  - georouting set/clear.
  - logger init.
  - health checks.
  - default interface index set/get.

## Expected Diagnostic Value

With this PR, future logs should distinguish:

- Tunnel never reached `setTunnelNetworkSettings`.
- `utun` exists but does not have `198.18.0.1`.
- App packets never enter `PacketFlowBridge`.
- Packets enter the bridge but Go returns nothing.
- DNS is absent, one-way, or malformed.
- TCP works but UDP does not.
- IPv6 traffic appears despite IPv6 being disabled in tunnel settings.
- Protected upstream sockets still use `198.18.x.x`, indicating a possible routing loop.
- Local Outline SOCKS5 proxy is not listening.
- Native protocol startup failed before tun2socks starts.
- Provider messages fail because the extension/session is unavailable.

## Validation

- `gofmt` on changed Go files.
- `git diff --check` passed.
- `go test ./core ./core/pkg ./outline ./healthcheck ./tunnel/protected_dialer` passed.
- `GOOS=ios GOARCH=arm64 go test ./tunnel/protected_dialer` passed.

## Not Validated Locally

- iOS/Swift build was not run in this Linux workspace.
- `GOOS=ios GOARCH=arm64 go test ./ios_exports` is blocked by existing missing Cloak internal module dependencies:
  - `github.com/cbeuw/Cloak/internal/client`
  - `github.com/cbeuw/Cloak/internal/common`
  - `github.com/cbeuw/Cloak/internal/multiplex`
- `MyLibrary.xcframework` was not rebuilt locally.

## Platform Coverage

- iOS/macOS Swift tunnel and iOS gomobile exports are the primary target of this PR.
- Android/Desktop behavior should be unaffected except for shared Go health/status logging where the same packages are compiled.
- The base protocol interface remains compatible because protocol-specific status is exposed through an optional `StatusProvider`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved error handling in VPN disconnect and health check operations; connection close failures are now properly detected and reported.

* **New Features**
  * Enhanced VPN status reporting with health metrics and device diagnostics.
  * Added comprehensive packet flow statistics including classification by protocol type and traffic patterns.

* **Improvements**
  * Richer logging and diagnostics throughout health checks, connection monitoring, and tunnel operations for better troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->