### PR TITLE
fix(ios): expose native build info and Outline UDP stats

### DIFF
--- a/go_module/ios_exports/build_info.go
+++ b/go_module/ios_exports/build_info.go
@@ -1,0 +1,38 @@
+package cloak_outline
+
+import (
+	"go_module/log"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+const nativeFeatureBuild = "ios-native/2026-05-05.2 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo"
+
+func NativeBuildInfo() string {
+	parts := []string{nativeFeatureBuild, "go=" + runtime.Version()}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			parts = append(parts, "mainVersion="+info.Main.Version)
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if setting.Value != "" {
+					parts = append(parts, "vcsRevision="+setting.Value)
+				}
+			case "vcs.modified":
+				if setting.Value != "" {
+					parts = append(parts, "vcsModified="+setting.Value)
+				}
+			}
+		}
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func logNativeBuildInfo(context string) {
+	log.Infof("%s nativeBuildInfo=%s", context, NativeBuildInfo())
+}

--- a/go_module/ios_exports/build_info.go
+++ b/go_module/ios_exports/build_info.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const nativeFeatureBuild = "ios-native/2026-05-05.2 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo"
+const nativeFeatureBuild = "ios-native/2026-05-05.3 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo,protectionDiagnostics,routedUDPHealth"
 
 func NativeBuildInfo() string {
 	parts := []string{nativeFeatureBuild, "go=" + runtime.Version()}

--- a/go_module/ios_exports/dobby_vpn.go
+++ b/go_module/ios_exports/dobby_vpn.go
@@ -36,6 +36,7 @@ func unsafeToString(v any) string {
 func NewVpnClient(transportConfig string, protocol string, tunnelFD int, mtu int) (err error) {
 	defer guardExportErr("NewVpnClient", &err)()
 	log.Infof("NewVpnClient() called protocol=%s fd=%d mtu=%d", protocol, tunnelFD, mtu)
+	logNativeBuildInfo("NewVpnClient()")
 
 	if client != nil {
 		log.Infof("NewVpnClient(): existing client detected, disconnecting previous client first status=%s", client.Status())
@@ -65,7 +66,7 @@ func NewVpnClient(transportConfig string, protocol string, tunnelFD int, mtu int
 		log.Infof("NewVpnClient(): creating outline device preferTCPDNSForWebSocket=true disableNonDNSUDP=true")
 		device, err = outline.NewOutlineDeviceWithOptions(transportConfig, outline.DeviceOptions{
 			PreferTCPDNSForWebSocket: true,
-			DisableNonDNSUDP:        true,
+			DisableNonDNSUDP:         true,
 		})
 	default:
 		log.Infof("NewVpnClient() failed: unsupported protocol")

--- a/go_module/ios_exports/logger.go
+++ b/go_module/ios_exports/logger.go
@@ -12,4 +12,5 @@ func InitLogger(path string) {
 		return
 	}
 	log.Infof("[ios_exports] InitLogger OK path=%s", path)
+	logNativeBuildInfo("[ios_exports] InitLogger")
 }

--- a/go_module/ios_exports/protector.go
+++ b/go_module/ios_exports/protector.go
@@ -26,3 +26,13 @@ func GetDefaultInterfaceIndex() (index int) {
 	log.Infof("[iOS-Protect] GetDefaultInterfaceIndex returned index=%d", index)
 	return index
 }
+
+// ProtectionDiagnostics returns the current Go-side socket protection state.
+// Swift logs this at every critical tunnel stage so stale native artifacts and
+// interface-index propagation failures are visible in the device log.
+func ProtectionDiagnostics() (diagnostics string) {
+	defer guard("ProtectionDiagnostics")()
+	diagnostics = protected_dialer.ProtectionDiagnosticsForIOS()
+	log.Infof("[iOS-Protect] ProtectionDiagnostics returned %s", diagnostics)
+	return diagnostics
+}

--- a/go_module/outline/outline_device.go
+++ b/go_module/outline/outline_device.go
@@ -29,6 +29,9 @@ type OutlineDevice struct {
 	svrIP            net.IP
 	streamDialer     transport.StreamDialer
 	packetDialer     transport.PacketDialer
+	websocket        bool
+	hasTCPPath       bool
+	hasUDPPath       bool
 	useCloak         bool
 	preferTCPDNS     bool
 	disableNonDNSUDP bool
@@ -40,14 +43,23 @@ type OutlineDevice struct {
 	ctx              context.Context
 	socksUser        string
 	socksPass        string
+	tcpDialAttempt   atomic.Uint64
+	tcpDialOK        atomic.Uint64
+	tcpDialErr       atomic.Uint64
+	udpDialAttempt   atomic.Uint64
+	udpDialOK        atomic.Uint64
+	udpDialErr       atomic.Uint64
+	udpDNSTruncated  atomic.Uint64
+	udpNonDNSReject  atomic.Uint64
+	unsupportedDial  atomic.Uint64
 }
 
 type DeviceOptions struct {
 	PreferTCPDNSForWebSocket bool
 	// DisableNonDNSUDP rejects non-DNS UDP dials immediately.
-	// Use this when the transport is WebSocket without a dedicated UDP path:
-	// Shadowsocks AEAD UDP over WebSocket fails AEAD decryption under concurrency,
-	// causing QUIC retry storms. Refusing UDP makes iOS/apps fall back to TCP instantly.
+	// Use this when the transport is WebSocket: current iOS 26 logs show
+	// Shadowsocks AEAD UDP over WebSocket failing decryption under concurrency
+	// even when udp_path is configured. Refusing UDP makes apps fall back to TCP.
 	DisableNonDNSUDP bool
 }
 
@@ -111,6 +123,9 @@ func NewOutlineDeviceWithOptions(transportConfig string, options DeviceOptions) 
 		svrIP:            ip,
 		streamDialer:     sd,
 		packetDialer:     pd,
+		websocket:        isWebSocket,
+		hasTCPPath:       hasTCPPath,
+		hasUDPPath:       hasUDPPath,
 		useCloak:         useCloak,
 		preferTCPDNS:     preferTCPDNS,
 		disableNonDNSUDP: disableNonDNSUDP,
@@ -266,7 +281,15 @@ func (d *OutlineDevice) markServeStopped(reason string) {
 }
 
 func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (net.Conn, error) {
-	log.Infof("[SOCKS5] dial %s %s", network, addr)
+	log.Infof(
+		"[SOCKS5] dial network=%s addr=%s websocket=%v preferTCPDNS=%v disableNonDNSUDP=%v useCloak=%v",
+		network,
+		addr,
+		d.websocket,
+		d.preferTCPDNS,
+		d.disableNonDNSUDP,
+		d.useCloak,
+	)
 	start := time.Now()
 
 	host, portStr, _ := net.SplitHostPort(addr)
@@ -275,29 +298,34 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 	switch network {
 
 	case "tcp":
+		d.tcpDialAttempt.Add(1)
 		conn, err := d.streamDialer.DialStream(ctx, addr)
 		elapsed := time.Since(start).Milliseconds()
 		if err != nil {
+			d.tcpDialErr.Add(1)
 			log.Infof("[SOCKS5 TCP ERROR] %s in %dms: %v", addr, elapsed, err)
 			return nil, err
 		}
+		d.tcpDialOK.Add(1)
 		log.Infof("[SOCKS5 TCP OK] %s in %dms", addr, elapsed)
 		log.Infof("[DEBUG][SOCKS5 TCP] %s local=%s remote=%s", addr, conn.LocalAddr(), conn.RemoteAddr())
 		return conn, nil
 
 	case "udp":
+		d.udpDialAttempt.Add(1)
 
 		// Force DNS-over-TCP fallback when UDP is known to be unreliable for this transport.
 		if port == 53 && (d.useCloak || d.preferTCPDNS) {
+			d.udpDNSTruncated.Add(1)
 			log.Infof("[SOCKS5 DNS] returning truncated DNS (useCloak=%v preferTCPDNS=%v)", d.useCloak, d.preferTCPDNS)
 			return newTruncatedDNSConn(host, port), nil
 		}
 
-		// When using WebSocket transport without a dedicated UDP path, Shadowsocks AEAD UDP
-		// frames are multiplexed over the TCP WebSocket stream. Under concurrency this produces
-		// chacha20poly1305 AEAD failures on every response, causing QUIC retry storms.
+		// WebSocket UDP is unreliable in current iOS 26 logs: under concurrency it produces
+		// chacha20poly1305 AEAD failures and websocket handshakes start failing.
 		// Reject non-DNS UDP immediately so the OS falls back to TCP without burning ~1s per attempt.
 		if d.disableNonDNSUDP && port != 53 {
+			d.udpNonDNSReject.Add(1)
 			log.Infof("[SOCKS5 UDP] rejected (disableNonDNSUDP) addr=%s", addr)
 			return nil, fmt.Errorf("non-DNS UDP disabled for this transport")
 		}
@@ -305,14 +333,17 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 		conn, err := d.packetDialer.DialPacket(ctx, addr)
 		elapsed := time.Since(start).Milliseconds()
 		if err != nil {
+			d.udpDialErr.Add(1)
 			log.Infof("[SOCKS5 UDP ERROR] %s in %dms: %v", addr, elapsed, err)
 			return nil, err
 		}
+		d.udpDialOK.Add(1)
 		log.Infof("[SOCKS5 UDP OK] %s in %dms", addr, elapsed)
 		log.Infof("[DEBUG][SOCKS5 UDP] %s local=%s", addr, conn.LocalAddr())
 		return conn, nil
 	}
 
+	d.unsupportedDial.Add(1)
 	return nil, fmt.Errorf("unsupported network %s", network)
 }
 
@@ -526,12 +557,13 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 	startedAt := d.startedAt
 	d.mu.RUnlock()
 	uptimeMs := outlineUptimeMilliseconds(startedAt)
+	runtimeStatus := d.runtimeStatus()
 	if listenAddr == "" {
 		listenAddr = listenAddressFromProxyAddr(proxyAddr)
 	}
 
 	log.Infof(
-		"outline local proxy health begin listenAddr=%s proxyAddr=%s state=%s gen=%d closed=%v timeoutMs=%d uptimeMs=%d",
+		"outline local proxy health begin listenAddr=%s proxyAddr=%s state=%s gen=%d closed=%v timeoutMs=%d uptimeMs=%d %s",
 		listenAddr,
 		proxyAddr,
 		state,
@@ -539,17 +571,19 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 		closed,
 		timeout.Milliseconds(),
 		uptimeMs,
+		runtimeStatus,
 	)
 
 	if listenAddr == "" {
 		status := fmt.Sprintf(
-			"localProxyAlive=false listenAddr= proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
+			"localProxyAlive=false listenAddr= proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d %s",
 			proxyAddr,
 			state,
 			gen,
 			closed,
 			serveErr,
 			uptimeMs,
+			runtimeStatus,
 		)
 		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
 		return false, status
@@ -561,7 +595,7 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", listenAddr)
 	if err != nil {
 		status := fmt.Sprintf(
-			"localProxyAlive=false listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeErr=%q uptimeMs=%d",
+			"localProxyAlive=false listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeErr=%q uptimeMs=%d %s",
 			listenAddr,
 			proxyAddr,
 			state,
@@ -570,13 +604,14 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 			serveErr,
 			err.Error(),
 			uptimeMs,
+			runtimeStatus,
 		)
 		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
 		return false, status
 	}
 	if err := conn.Close(); err != nil {
 		status := fmt.Sprintf(
-			"localProxyAlive=true listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeCloseErr=%q uptimeMs=%d",
+			"localProxyAlive=true listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q probeCloseErr=%q uptimeMs=%d %s",
 			listenAddr,
 			proxyAddr,
 			state,
@@ -585,13 +620,14 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 			serveErr,
 			err.Error(),
 			uptimeMs,
+			runtimeStatus,
 		)
 		log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
 		return true, status
 	}
 
 	status = fmt.Sprintf(
-		"localProxyAlive=true listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d",
+		"localProxyAlive=true listenAddr=%s proxyAddr=%s serveState=%s serveGen=%d closed=%v serveErr=%q uptimeMs=%d %s",
 		listenAddr,
 		proxyAddr,
 		state,
@@ -599,9 +635,30 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 		closed,
 		serveErr,
 		uptimeMs,
+		runtimeStatus,
 	)
 	log.Infof("outline local proxy health result=%s elapsedMs=%d", status, time.Since(start).Milliseconds())
 	return true, status
+}
+
+func (d *OutlineDevice) runtimeStatus() string {
+	return fmt.Sprintf(
+		"transport(websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v disableNonDNSUDP=%v) dialStats(tcpAttempt=%d tcpOK=%d tcpErr=%d udpAttempt=%d udpOK=%d udpErr=%d udpDNSTruncated=%d udpNonDNSRejected=%d unsupported=%d)",
+		d.websocket,
+		d.hasTCPPath,
+		d.hasUDPPath,
+		d.preferTCPDNS,
+		d.disableNonDNSUDP,
+		d.tcpDialAttempt.Load(),
+		d.tcpDialOK.Load(),
+		d.tcpDialErr.Load(),
+		d.udpDialAttempt.Load(),
+		d.udpDialOK.Load(),
+		d.udpDialErr.Load(),
+		d.udpDNSTruncated.Load(),
+		d.udpNonDNSReject.Load(),
+		d.unsupportedDial.Load(),
+	)
 }
 
 func listenAddressFromProxyAddr(proxyAddr string) string {

--- a/go_module/outline/outline_device_test.go
+++ b/go_module/outline/outline_device_test.go
@@ -24,13 +24,25 @@ func TestLocalProxyAliveUsesListenerAddressWithoutCredentials(t *testing.T) {
 	}()
 
 	device := &OutlineDevice{
-		listener:   listener,
-		listenAddr: listener.Addr().String(),
-		proxyAddr:  "user:pass@" + listener.Addr().String(),
-		startedAt:  time.Now(),
-		serveState: "running",
-		serveGen:   1,
+		listener:         listener,
+		listenAddr:       listener.Addr().String(),
+		proxyAddr:        "user:pass@" + listener.Addr().String(),
+		websocket:        true,
+		hasTCPPath:       true,
+		hasUDPPath:       true,
+		preferTCPDNS:     true,
+		disableNonDNSUDP: true,
+		startedAt:        time.Now(),
+		serveState:       "running",
+		serveGen:         1,
 	}
+	device.tcpDialAttempt.Add(2)
+	device.tcpDialOK.Add(1)
+	device.tcpDialErr.Add(1)
+	device.udpDialAttempt.Add(3)
+	device.udpDialErr.Add(1)
+	device.udpDNSTruncated.Add(1)
+	device.udpNonDNSReject.Add(1)
 
 	alive, status := device.LocalProxyAlive(500 * time.Millisecond)
 	if !alive {
@@ -41,6 +53,12 @@ func TestLocalProxyAliveUsesListenerAddressWithoutCredentials(t *testing.T) {
 	}
 	if strings.Contains(status, "too many colons") {
 		t.Fatalf("status shows credentialed proxy address was dialed: %s", status)
+	}
+	if !strings.Contains(status, "transport(websocket=true tcpPath=true udpPath=true preferTCPDNS=true disableNonDNSUDP=true)") {
+		t.Fatalf("status does not include transport flags: %s", status)
+	}
+	if !strings.Contains(status, "dialStats(tcpAttempt=2 tcpOK=1 tcpErr=1 udpAttempt=3 udpOK=0 udpErr=1 udpDNSTruncated=1 udpNonDNSRejected=1 unsupported=0)") {
+		t.Fatalf("status does not include dial counters: %s", status)
 	}
 
 	select {

--- a/go_module/tunnel/protected_dialer/protect_ios.go
+++ b/go_module/tunnel/protected_dialer/protect_ios.go
@@ -54,6 +54,24 @@ func GetDefaultInterfaceForIOS() int {
 	return idx
 }
 
+// GetConfiguredDefaultInterfaceForIOS returns the last interface index supplied by Swift.
+// Unlike GetDefaultInterfaceForIOS, it does not perform fallback detection; this is useful
+// for diagnostics that must distinguish "Swift never supplied an index" from "Go guessed one".
+func GetConfiguredDefaultInterfaceForIOS() int {
+	defaultInterfaceMu.RLock()
+	idx := defaultInterfaceIndex
+	defaultInterfaceMu.RUnlock()
+	return idx
+}
+
+func ProtectionDiagnosticsForIOS() string {
+	return fmt.Sprintf(
+		"configuredDefaultInterfaceIndex=%d interfaces=[%s]",
+		GetConfiguredDefaultInterfaceForIOS(),
+		describeInterfacesForLog(),
+	)
+}
+
 func detectDefaultInterfaceIndex() int {
 	interfaces, err := net.Interfaces()
 	if err != nil {
@@ -108,6 +126,11 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 	// iOS 26+: Try SO_NO_TC_NETPOLICY first (legacy approach for older iOS versions).
 	// On iOS 26+, this fails with "invalid argument" — expected and handled below.
 	legacyErr := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
+	if legacyErr != nil {
+		log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY failed fd=%d network=%s err=%v", fd, network, legacyErr)
+	} else {
+		log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY success fd=%d network=%s", fd, network)
+	}
 
 	// iOS 26+: Use IP_BOUND_IF with the actual interface index.
 	// This is the primary method for socket protection on iOS 26+.
@@ -128,6 +151,9 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 				return nil
 			}
 			log.Infof("[iOS-Protect] IP_BOUND_IF (IPv4) success: fd=%d bound to interface %d", fd, ifaceIndex)
+			if err := verifyBoundInterface(fd, syscall.IPPROTO_IP, IP_BOUND_IF, ifaceIndex, "IP_BOUND_IF", network); err != nil {
+				return err
+			}
 		case "tcp6", "udp6":
 			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, IPV6_BOUND_IF, ifaceIndex); err != nil {
 				log.Infof("[iOS-Protect] IP_BOUND_IF (IPv6) failed for fd=%d iface=%d: %v", fd, ifaceIndex, err)
@@ -137,6 +163,9 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 				return nil
 			}
 			log.Infof("[iOS-Protect] IP_BOUND_IF (IPv6) success: fd=%d bound to interface %d", fd, ifaceIndex)
+			if err := verifyBoundInterface(fd, syscall.IPPROTO_IPV6, IPV6_BOUND_IF, ifaceIndex, "IPV6_BOUND_IF", network); err != nil {
+				return err
+			}
 		default:
 			// For unknown network types, try IPv4
 			if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, IP_BOUND_IF, ifaceIndex); err != nil {
@@ -147,6 +176,9 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 				return nil
 			}
 			log.Infof("[iOS-Protect] IP_BOUND_IF (fallback IPv4) success: fd=%d bound to interface %d network=%s", fd, ifaceIndex, network)
+			if err := verifyBoundInterface(fd, syscall.IPPROTO_IP, IP_BOUND_IF, ifaceIndex, "IP_BOUND_IF fallback", network); err != nil {
+				return err
+			}
 		}
 	} else {
 		// No interface index set - log with full interface list to aid debugging
@@ -157,6 +189,21 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 		}
 	}
 
+	return nil
+}
+
+func verifyBoundInterface(fd uintptr, level int, option int, expected int, label string, network string) error {
+	actual, err := syscall.GetsockoptInt(int(fd), level, option)
+	if err != nil {
+		log.Infof("[iOS-Protect] %s verify skipped fd=%d network=%s expectedIface=%d getErr=%v", label, fd, network, expected, err)
+		return nil
+	}
+	if actual != expected {
+		err := fmt.Errorf("%s verification mismatch fd=%d network=%s expectedIface=%d actualIface=%d", label, fd, network, expected, actual)
+		log.Infof("[iOS-Protect] %v", err)
+		return err
+	}
+	log.Infof("[iOS-Protect] %s verify OK fd=%d network=%s iface=%d", label, fd, network, actual)
 	return nil
 }
 

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -70,7 +70,10 @@ public final class HealthCheckImpl: HealthCheck {
 
     public func shortConnectionCheckUp() -> Bool {
         let checkId = nextCheckId(prefix: "short")
-        logs.writeLog(log: "[HC] Start shortConnectionCheckUp id=\(checkId)")
+        logs.writeLog(
+            log: "[HC] Start shortConnectionCheckUp id=\(checkId) " +
+                "userStopRequested=\(isUserStopRequested())"
+        )
 
         let checks: [(String, () -> Bool)] = [
             ("HTTP https://google.com/gen_204", {
@@ -116,17 +119,28 @@ public final class HealthCheckImpl: HealthCheck {
         }
 
         let result = vpnOk && networkOk && heartbeatOk && outlineProxyOk && serverAliveProtected
+        let userStopAtEnd = isUserStopRequested()
         logs.writeLog(
             log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) " +
             "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk), " +
-            "outlineProxy=\(outlineProxyOk), serverAlive=\(serverAliveProtected))"
+            "outlineProxy=\(outlineProxyOk), serverAlive=\(serverAliveProtected), " +
+            "userStopRequested=\(userStopAtEnd))"
         )
+        if !result && userStopAtEnd {
+            logs.writeLog(
+                log: "[HC] id=\(checkId) false result is stop-related; " +
+                    "user stop was requested before the check completed"
+            )
+        }
         return result
     }
 
     public func fullConnectionCheckUp() -> Bool {
         let checkId = nextCheckId(prefix: "full")
-        logs.writeLog(log: "[HC] Start fullConnectionCheckUp id=\(checkId)")
+        logs.writeLog(
+            log: "[HC] Start fullConnectionCheckUp id=\(checkId) " +
+                "userStopRequested=\(isUserStopRequested())"
+        )
 
         // --- Standard check groups ---
         // On iOS, net.Dial based TCP probes can complete against the local
@@ -211,6 +225,12 @@ public final class HealthCheckImpl: HealthCheck {
             )
         }
         logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result)")
+        if !result && isUserStopRequested() {
+            logs.writeLog(
+                log: "[HC] RESULT id=\(checkId) is stop-related; " +
+                    "user stop was requested before the check completed"
+            )
+        }
 
         // --- DIAGNOSIS — single line with actionable verdict ---
         let tcpProxyOk = groupResults["TCP Ping diagnostics"] ?? true
@@ -235,6 +255,10 @@ public final class HealthCheckImpl: HealthCheck {
         let value = checkSequence
         checkSequenceLock.unlock()
         return "\(prefix)-\(value)"
+    }
+
+    private func isUserStopRequested() -> Bool {
+        DobbyConfigsRepositoryImpl.shared.getIsUserInitStop()
     }
 
     private func logDiagnosis(

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -132,6 +132,9 @@ public final class HealthCheckImpl: HealthCheck {
                     "user stop was requested before the check completed"
             )
         }
+        if !result && !userStopAtEnd {
+            logTunnelDiagnostics(checkId: checkId, reason: "shortConnectionCheckUp=false")
+        }
         return result
     }
 
@@ -216,6 +219,26 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(log: "[HC] [diag] tunnel_ip_assigned=\(tunnelIPOk)")
         logs.writeLog(log: "[HC] [diag] outline_proxy_alive=\(lastOutlineProxyOk)")
 
+        let udpDNSOk = runWithRetry(name: "Routed UDP DNS diagnostic", attempts: 1, timeoutPerAttempt: 6.0) {
+            self.udpDNSProbe()
+        }
+        logs.writeLog(log: "[HC] [diag] routed_udp_dns=\(udpDNSOk)")
+
+        let nonDNSUDPOk = runWithRetry(name: "Routed non-DNS UDP diagnostic", attempts: 1, timeoutPerAttempt: 6.0) {
+            self.udpSTUNProbe()
+        }
+        logs.writeLog(log: "[HC] [diag] routed_non_dns_udp=\(nonDNSUDPOk)")
+        groupResults["Routed non-DNS UDP group"] = nonDNSUDPOk
+        if !nonDNSUDPOk {
+            logs.writeLog(
+                log: "[HC] Group FAILED: Routed non-DNS UDP group " +
+                    "(Speedtest/QUIC/real app UDP traffic is not working)"
+            )
+            failedGroups.append("Routed non-DNS UDP group")
+        } else {
+            logs.writeLog(log: "[HC] Group OK: Routed non-DNS UDP group")
+        }
+
         // --- Result ---
         let result = failedGroups.isEmpty
         if !result {
@@ -225,11 +248,15 @@ public final class HealthCheckImpl: HealthCheck {
             )
         }
         logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result)")
-        if !result && isUserStopRequested() {
+        let userStopAtResult = isUserStopRequested()
+        if !result && userStopAtResult {
             logs.writeLog(
                 log: "[HC] RESULT id=\(checkId) is stop-related; " +
                     "user stop was requested before the check completed"
             )
+        }
+        if !result && !userStopAtResult {
+            logTunnelDiagnostics(checkId: checkId, reason: "fullConnectionCheckUp=false")
         }
 
         // --- DIAGNOSIS — single line with actionable verdict ---
@@ -243,7 +270,8 @@ public final class HealthCheckImpl: HealthCheck {
             dns: dnsOk,
             tcp443: tcp443Ok,
             outlineProxy: lastOutlineProxyOk,
-            https: httpsOk
+            https: httpsOk,
+            nonDNSUDP: nonDNSUDPOk
         )
 
         return result
@@ -267,28 +295,31 @@ public final class HealthCheckImpl: HealthCheck {
         dns: Bool,
         tcp443: Bool,
         outlineProxy: Bool,
-        https: Bool
+        https: Bool,
+        nonDNSUDP: Bool
     ) {
         let diagnosis: String
-        switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https) {
-        case (false, _, _, _, _, _):
+        switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https, nonDNSUDP) {
+        case (false, _, _, _, _, _, _):
             diagnosis = "SIDE: CLIENT | REASON: tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level"
-        case (true, _, _, _, false, _):
+        case (true, _, _, _, false, _, _):
             diagnosis = "SIDE: CLIENT | REASON: local Outline SOCKS5 proxy is unavailable — tun2socks has no working upstream proxy"
-        case (true, _, false, _, _, _):
+        case (true, _, false, _, _, _, _):
             diagnosis = "SIDE: CLIENT OR SERVER | REASON: DNS not resolving — DNS-over-tunnel is failing or blocked"
-        case (true, _, true, _, true, false):
+        case (true, _, true, _, true, false, _):
             // Check metrics[win] in logs: proto=h3+total=- → QUIC/UDP not proxied (no udpPath? pool full?);
             // proto=h2+high total → server is slow or blocking TLS
             diagnosis = "SIDE: CLIENT OR SERVER | REASON: Outline proxy is alive but HTTPS checks fail — check [win] metrics for h3/h2 timing and server behavior"
-        case (true, false, true, _, true, _):
+        case (true, false, true, _, true, _, _):
             diagnosis = "SIDE: CLIENT | REASON: TCP diagnostic failed after DNS/HTTP checks — possible tun2socks forwarding issue"
-        case (true, true, true, false, true, _):
+        case (true, true, true, false, true, _, _):
             diagnosis = "SIDE: SERVER (likely) | REASON: TCP diagnostic to :443 failed — server blocks HTTPS port or intermediate node filters it"
-        case (true, true, true, true, true, true):
+        case (true, true, true, true, true, true, false):
+            diagnosis = "SIDE: CLIENT OR TRANSPORT | REASON: TCP/DNS/HTTPS passed but routed non-DNS UDP failed — Speedtest/QUIC apps can freeze; check PacketFlowBridge flow stats and Outline dialStats udpNonDNSRejected/udpErr"
+        case (true, true, true, true, true, true, true):
             diagnosis = "ALL OK — connection is working"
         default:
-            diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) outlineProxy=\(outlineProxy) https=\(https)"
+            diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) outlineProxy=\(outlineProxy) https=\(https) nonDNSUDP=\(nonDNSUDP)"
         }
         logs.writeLog(log: "[HC] DIAGNOSIS: \(diagnosis)")
     }
@@ -473,6 +504,200 @@ public final class HealthCheckImpl: HealthCheck {
             session.invalidateAndCancel()
         }
         return success
+    }
+
+    private func udpDNSProbe() -> Bool {
+        let query = dnsQueryPayload(id: 0xD0BB, host: "example.com")
+        return routedUDPProbe(
+            name: "udp-dns",
+            host: "1.1.1.1",
+            port: 53,
+            payload: query,
+            timeoutSeconds: 6.0
+        ) { response in
+            let bytes = [UInt8](response)
+            return bytes.count >= 12 &&
+                bytes[0] == 0xD0 &&
+                bytes[1] == 0xBB &&
+                (bytes[2] & 0x80) != 0
+        }
+    }
+
+    private func udpSTUNProbe() -> Bool {
+        let request = stunBindingRequestPayload()
+        return routedUDPProbe(
+            name: "udp-stun-non-dns",
+            host: "stun.l.google.com",
+            port: 19302,
+            payload: request,
+            timeoutSeconds: 6.0
+        ) { response in
+            let bytes = [UInt8](response)
+            guard bytes.count >= 20 else { return false }
+            let hasMagicCookie = bytes[4] == 0x21 &&
+                bytes[5] == 0x12 &&
+                bytes[6] == 0xA4 &&
+                bytes[7] == 0x42
+            let transactionMatches = Array(bytes[8..<20]) == Array([UInt8](request)[8..<20])
+            return hasMagicCookie && transactionMatches
+        }
+    }
+
+    private func routedUDPProbe(
+        name: String,
+        host: String,
+        port: UInt16,
+        payload: Data,
+        timeoutSeconds: TimeInterval,
+        validate: @escaping (Data) -> Bool
+    ) -> Bool {
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            logs.writeLog(log: "[HC] [udpProbe \(name)] invalid port=\(port)")
+            return false
+        }
+
+        let start = Date()
+        let endpoint = "\(host):\(port)"
+        let queue = DispatchQueue(label: "vpn.dobby.app.health.udp.\(name)")
+        let connection = NWConnection(
+            host: NWEndpoint.Host(host),
+            port: nwPort,
+            using: .udp
+        )
+        let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var completed = false
+        var success = false
+        var finishReason = "not_finished"
+        var lastState = "created"
+
+        func finish(ok: Bool, reason: String) {
+            lock.lock()
+            if completed {
+                lock.unlock()
+                return
+            }
+            completed = true
+            success = ok
+            finishReason = reason
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        logs.writeLog(
+            log: "[HC] [udpProbe \(name)] begin endpoint=\(endpoint) " +
+                "payloadBytes=\(payload.count) timeoutMs=\(Int(timeoutSeconds * 1000))"
+        )
+
+        connection.stateUpdateHandler = { [weak self] state in
+            let stateText = "\(state)"
+            lock.lock()
+            lastState = stateText
+            lock.unlock()
+            self?.logs.writeLog(log: "[HC] [udpProbe \(name)] state=\(stateText) endpoint=\(endpoint)")
+
+            switch state {
+            case .failed(let error):
+                finish(ok: false, reason: "state_failed=\(error.localizedDescription)")
+            case .cancelled:
+                lock.lock()
+                let wasCompleted = completed
+                lock.unlock()
+                if !wasCompleted {
+                    finish(ok: false, reason: "state_cancelled")
+                }
+            default:
+                break
+            }
+        }
+
+        connection.start(queue: queue)
+        connection.receiveMessage { [weak self] data, _, isComplete, error in
+            if let error {
+                self?.logs.writeLog(
+                    log: "[HC] [udpProbe \(name)] receive error endpoint=\(endpoint) " +
+                        "error=\(error.localizedDescription)"
+                )
+                finish(ok: false, reason: "receive_error=\(error.localizedDescription)")
+                return
+            }
+            guard let data, !data.isEmpty else {
+                self?.logs.writeLog(
+                    log: "[HC] [udpProbe \(name)] receive empty endpoint=\(endpoint) " +
+                        "isComplete=\(isComplete)"
+                )
+                finish(ok: false, reason: "empty_response")
+                return
+            }
+            let valid = validate(data)
+            self?.logs.writeLog(
+                log: "[HC] [udpProbe \(name)] receive response endpoint=\(endpoint) " +
+                    "bytes=\(data.count) isComplete=\(isComplete) valid=\(valid)"
+            )
+            finish(ok: valid, reason: valid ? "valid_response_bytes=\(data.count)" : "invalid_response_bytes=\(data.count)")
+        }
+        connection.send(content: payload, completion: .contentProcessed { [weak self] error in
+            if let error {
+                self?.logs.writeLog(
+                    log: "[HC] [udpProbe \(name)] send failed endpoint=\(endpoint) " +
+                        "error=\(error.localizedDescription)"
+                )
+                finish(ok: false, reason: "send_error=\(error.localizedDescription)")
+                return
+            }
+            self?.logs.writeLog(log: "[HC] [udpProbe \(name)] send ok endpoint=\(endpoint)")
+        })
+
+        let wait = semaphore.wait(timeout: .now() + timeoutSeconds)
+        if wait == .timedOut {
+            lock.lock()
+            let stateAtTimeout = lastState
+            lock.unlock()
+            logs.writeLog(
+                log: "[HC] [udpProbe \(name)] TIMEOUT endpoint=\(endpoint) " +
+                    "elapsedMs=\(elapsedMs(since: start)) lastState=\(stateAtTimeout)"
+            )
+            connection.cancel()
+            return false
+        }
+
+        connection.cancel()
+        logs.writeLog(
+            log: "[HC] [udpProbe \(name)] end endpoint=\(endpoint) " +
+                "success=\(success) reason=\(finishReason) elapsedMs=\(elapsedMs(since: start))"
+        )
+        return success
+    }
+
+    private func dnsQueryPayload(id: UInt16, host: String) -> Data {
+        var bytes: [UInt8] = [
+            UInt8(id >> 8),
+            UInt8(id & 0xFF),
+            0x01, 0x00,
+            0x00, 0x01,
+            0x00, 0x00,
+            0x00, 0x00,
+            0x00, 0x00
+        ]
+        for label in host.split(separator: ".") {
+            let labelBytes = [UInt8](label.utf8)
+            bytes.append(UInt8(labelBytes.count))
+            bytes.append(contentsOf: labelBytes)
+        }
+        bytes.append(0x00)
+        bytes.append(contentsOf: [0x00, 0x01, 0x00, 0x01])
+        return Data(bytes)
+    }
+
+    private func stunBindingRequestPayload() -> Data {
+        Data([
+            0x00, 0x01,
+            0x00, 0x00,
+            0x21, 0x12, 0xA4, 0x42,
+            0x44, 0x4F, 0x42, 0x42,
+            0x59, 0x56, 0x50, 0x4E,
+            0x49, 0x4F, 0x53, 0x32
+        ])
     }
 
     // Checks if Dobby's configured tunnel IP is assigned to at least one interface.
@@ -752,6 +977,12 @@ public final class HealthCheckImpl: HealthCheck {
             )
         }
         return legacyHealthyStatus
+    }
+
+    private func logTunnelDiagnostics(checkId: String, reason: String) {
+        logs.writeLog(log: "[HC] [diag] requesting tunnel diagnostics id=\(checkId) reason=\(reason)")
+        let raw = providerMessage("getTunnelDiagnostics", label: "TunnelDiagnostics")
+        logs.writeLog(log: "[HC] [diag] tunnel diagnostics id=\(checkId): \(raw ?? "nil")")
     }
 
     private func parseMemoryResponse(_ response: String?) -> Double {

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -24,6 +24,7 @@ public class VpnManagerImpl: VpnManager {
         logs.writeLog(log: "Start go logger init path = \(path)")
         Cloak_outlineInitLogger(path)
         logs.writeLog(log: "Finish go logger init")
+        logs.writeLog(log: "[Native] Go build info: \(Cloak_outlineNativeBuildInfo())")
 
 //        VpnManagerImpl.startSentry()
         self.connectionRepository = connectionRepository

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -18,6 +18,7 @@ public final class OutlineInteractor {
     ) throws {
         let start = Date()
         logs.writeLog(log: "[Outline] startOutline begin fd=\(tunnelFileDescriptor) mtu=\(mtu)")
+        logs.writeLog(log: "[Outline] native build info: \(Cloak_outlineNativeBuildInfo())")
 
         let methodPassword = configsRepository.getMethodPasswordOutline()
         let serverPort = configsRepository.getServerPort()

--- a/swift_module/tunnel/PacketFlowBridge.swift
+++ b/swift_module/tunnel/PacketFlowBridge.swift
@@ -33,6 +33,9 @@ final class PacketFlowBridge {
     private var goToTunnelMaxBatchPackets = 0
     private var tunnelToGoDrops = 0
     private var goToTunnelDrops = 0
+    private var lastTunnelToGoPacketAt: Date?
+    private var lastGoToTunnelPacketAt: Date?
+    private var previousStatsSnapshot: TrafficSnapshot?
     private var firstTunnelPacketLogged = false
     private var firstGoPacketLogged = false
     private var tunnelToGoClassification = PacketClassStats()
@@ -176,6 +179,47 @@ final class PacketFlowBridge {
             closeFD(unreleasedGoFD, label: "unreleasedGoFD")
         }
         log("[PacketFlowBridge] stopped")
+    }
+
+    func diagnosticsSnapshot() -> String {
+        let now = Date()
+        lock.lock()
+        let snapshot = TrafficSnapshot(
+            tunnelToGoPackets: tunnelToGoPackets,
+            tunnelToGoBytes: tunnelToGoBytes,
+            goToTunnelPackets: goToTunnelPackets,
+            goToTunnelBytes: goToTunnelBytes,
+            tunnelToGoDrops: tunnelToGoDrops,
+            goToTunnelDrops: goToTunnelDrops,
+            writeErrors: writeErrorCount,
+            readErrors: readErrorCount
+        )
+        let isActive = running
+        let swiftFD = swiftFileDescriptor
+        let goFD = goFileDescriptor
+        let batches = tunnelReadBatches
+        let emptyBatches = tunnelReadEmptyBatches
+        let g2tBatches = goToTunnelWriteBatches
+        let g2tMaxBatch = goToTunnelMaxBatchPackets
+        let oversized = oversizedPacketCount
+        let lastTunnelToGo = lastTunnelToGoPacketAt
+        let lastGoToTunnel = lastGoToTunnelPacketAt
+        let tunnelToGoClassSummary = tunnelToGoClassification.summary(maxItems: maxPacketFlowSummaryItems)
+        let goToTunnelClassSummary = goToTunnelClassification.summary(maxItems: maxPacketFlowSummaryItems)
+        lock.unlock()
+
+        return "running=\(isActive) swiftFD=\(swiftFD) goFD=\(goFD) mtu=\(mtu) " +
+            "batches=\(batches) emptyBatches=\(emptyBatches) " +
+            "tunnel_to_go=\(snapshot.tunnelToGoPackets)p/\(snapshot.tunnelToGoBytes)B " +
+            "go_to_tunnel=\(snapshot.goToTunnelPackets)p/\(snapshot.goToTunnelBytes)B " +
+            "go_to_tunnel_batches=\(g2tBatches) max_batch=\(g2tMaxBatch) " +
+            "drops_tunnel_to_go=\(snapshot.tunnelToGoDrops) drops_go_to_tunnel=\(snapshot.goToTunnelDrops) " +
+            "oversized=\(oversized) writeErrors=\(snapshot.writeErrors) readErrors=\(snapshot.readErrors) " +
+            "lastPacketAge(tunnel_to_go=\(ageDescription(lastTunnelToGo, now: now))," +
+            "go_to_tunnel=\(ageDescription(lastGoToTunnel, now: now))) " +
+            "diagnosis=\(flowDiagnosis(running: isActive, snapshot: snapshot)) " +
+            "classify_tunnel_to_go=[\(tunnelToGoClassSummary)] " +
+            "classify_go_to_tunnel=[\(goToTunnelClassSummary)]"
     }
 
     private func readPacketsFromTunnel() {
@@ -336,6 +380,7 @@ final class PacketFlowBridge {
         lock.lock()
         tunnelToGoPackets += 1
         tunnelToGoBytes += packet.count
+        lastTunnelToGoPacketAt = Date()
         let sample = tunnelToGoClassification.record(
             classification,
             sampleLimit: maxPacketClassificationSamples
@@ -357,6 +402,7 @@ final class PacketFlowBridge {
         lock.lock()
         goToTunnelPackets += packetCount
         goToTunnelBytes += byteCount
+        lastGoToTunnelPacketAt = Date()
         goToTunnelWriteBatches += 1
         goToTunnelMaxBatchPackets = max(goToTunnelMaxBatchPackets, packetCount)
         var samples: [String] = []
@@ -408,6 +454,7 @@ final class PacketFlowBridge {
     }
 
     private func logStats(reason: String) {
+        let now = Date()
         lock.lock()
         let batches = tunnelReadBatches
         let emptyBatches = tunnelReadEmptyBatches
@@ -423,8 +470,22 @@ final class PacketFlowBridge {
         let writeErrors = writeErrorCount
         let readErrors = readErrorCount
         let isActive = running
+        let lastTunnelToGo = lastTunnelToGoPacketAt
+        let lastGoToTunnel = lastGoToTunnelPacketAt
         let tunnelToGoClassSummary = tunnelToGoClassification.summary(maxItems: maxPacketFlowSummaryItems)
         let goToTunnelClassSummary = goToTunnelClassification.summary(maxItems: maxPacketFlowSummaryItems)
+        let snapshot = TrafficSnapshot(
+            tunnelToGoPackets: t2gPackets,
+            tunnelToGoBytes: t2gBytes,
+            goToTunnelPackets: g2tPackets,
+            goToTunnelBytes: g2tBytes,
+            tunnelToGoDrops: t2gDrops,
+            goToTunnelDrops: g2tDrops,
+            writeErrors: writeErrors,
+            readErrors: readErrors
+        )
+        let previousSnapshot = previousStatsSnapshot
+        previousStatsSnapshot = snapshot
         lock.unlock()
 
         log(
@@ -432,12 +493,65 @@ final class PacketFlowBridge {
             "batches=\(batches) emptyBatches=\(emptyBatches) " +
             "tunnel_to_go=\(t2gPackets)p/\(t2gBytes)B " +
             "go_to_tunnel=\(g2tPackets)p/\(g2tBytes)B " +
+            "delta=\(snapshot.deltaDescription(from: previousSnapshot)) " +
+            "lastPacketAge(tunnel_to_go=\(ageDescription(lastTunnelToGo, now: now))," +
+            "go_to_tunnel=\(ageDescription(lastGoToTunnel, now: now))) " +
             "go_to_tunnel_batches=\(g2tBatches) max_batch=\(g2tMaxBatch) " +
             "drops_tunnel_to_go=\(t2gDrops) drops_go_to_tunnel=\(g2tDrops) " +
-            "oversized=\(oversized) writeErrors=\(writeErrors) readErrors=\(readErrors)"
+            "oversized=\(oversized) writeErrors=\(writeErrors) readErrors=\(readErrors) " +
+            "diagnosis=\(flowDiagnosis(running: isActive, snapshot: snapshot))"
         )
         log("[PacketFlowBridge][classify] tunnel_to_go \(tunnelToGoClassSummary)")
         log("[PacketFlowBridge][classify] go_to_tunnel \(goToTunnelClassSummary)")
+    }
+
+    private struct TrafficSnapshot {
+        let tunnelToGoPackets: Int
+        let tunnelToGoBytes: Int
+        let goToTunnelPackets: Int
+        let goToTunnelBytes: Int
+        let tunnelToGoDrops: Int
+        let goToTunnelDrops: Int
+        let writeErrors: Int
+        let readErrors: Int
+
+        func deltaDescription(from previous: TrafficSnapshot?) -> String {
+            guard let previous else {
+                return "first"
+            }
+            return "tunnel_to_go=+\(tunnelToGoPackets - previous.tunnelToGoPackets)p/" +
+                "+\(tunnelToGoBytes - previous.tunnelToGoBytes)B " +
+                "go_to_tunnel=+\(goToTunnelPackets - previous.goToTunnelPackets)p/" +
+                "+\(goToTunnelBytes - previous.goToTunnelBytes)B " +
+                "drops=+\(tunnelToGoDrops - previous.tunnelToGoDrops)/" +
+                "+\(goToTunnelDrops - previous.goToTunnelDrops) " +
+                "errors=+\(writeErrors - previous.writeErrors)/+\(readErrors - previous.readErrors)"
+        }
+    }
+
+    private func ageDescription(_ date: Date?, now: Date) -> String {
+        guard let date else { return "never" }
+        return "\(Int(now.timeIntervalSince(date) * 1000))ms"
+    }
+
+    private func flowDiagnosis(running: Bool, snapshot: TrafficSnapshot) -> String {
+        var flags: [String] = []
+        if running && snapshot.tunnelToGoPackets == 0 && snapshot.goToTunnelPackets == 0 {
+            flags.append("NO_TRAFFIC_YET")
+        }
+        if snapshot.tunnelToGoPackets > 0 && snapshot.goToTunnelPackets == 0 {
+            flags.append("ONE_WAY_APP_TO_GO")
+        }
+        if snapshot.goToTunnelPackets > 0 && snapshot.tunnelToGoPackets == 0 {
+            flags.append("ONE_WAY_GO_TO_APP")
+        }
+        if snapshot.tunnelToGoDrops > 0 || snapshot.goToTunnelDrops > 0 {
+            flags.append("DROPS_PRESENT")
+        }
+        if snapshot.writeErrors > 0 || snapshot.readErrors > 0 {
+            flags.append("SOCKET_ERRORS_PRESENT")
+        }
+        return flags.isEmpty ? "OK_OR_IDLE" : flags.joined(separator: ",")
     }
 
     private struct PacketClassification {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -81,7 +81,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let family = Int32(addr.pointee.sa_family)
             var values = interfaces[name] ?? []
             if values.isEmpty {
-                let index = Int(if_nametoindex(rawName))
+                let index = Int(if_nametoindex(name))
                 let flags = ptr?.pointee.ifa_flags ?? 0
                 values.append("index=\(index)")
                 values.append("flags=0x\(String(flags, radix: 16))")

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -78,32 +78,51 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 continue
             }
             let name = String(cString: rawName)
-            if name.starts(with: "utun") {
-                let family = Int32(addr.pointee.sa_family)
-                var values = interfaces[name] ?? []
-                if family == AF_INET {
-                    var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-                    var ip = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
-                        $0.pointee.sin_addr
-                    }
-                    if inet_ntop(AF_INET, &ip, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
-                        values.append("ipv4=\(String(cString: buffer))")
-                    } else {
-                        let ntopErrno = errno
-                        values.append("ipv4_ntop_error=\(ntopErrno):\(String(cString: strerror(ntopErrno)))")
-                    }
-                } else if family == AF_INET6 {
-                    values.append("ipv6")
-                } else {
-                    values.append("family=\(family)")
+            let family = Int32(addr.pointee.sa_family)
+            var values = interfaces[name] ?? []
+            if values.isEmpty {
+                let index = Int(if_nametoindex(rawName))
+                let flags = ptr?.pointee.ifa_flags ?? 0
+                values.append("index=\(index)")
+                values.append("flags=0x\(String(flags, radix: 16))")
+                if name.starts(with: "utun") {
+                    values.append("vpnTunnel=true")
                 }
-                interfaces[name] = values
+                if name == "en0" || name.starts(with: "pdp_ip") || name.starts(with: "en") {
+                    values.append("physicalCandidate=true")
+                }
             }
+            if family == AF_INET {
+                var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                var ip = addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                    $0.pointee.sin_addr
+                }
+                if inet_ntop(AF_INET, &ip, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil {
+                    values.append("ipv4=\(String(cString: buffer))")
+                } else {
+                    let ntopErrno = errno
+                    values.append("ipv4_ntop_error=\(ntopErrno):\(String(cString: strerror(ntopErrno)))")
+                }
+            } else if family == AF_INET6 {
+                var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+                var ip = addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) {
+                    $0.pointee.sin6_addr
+                }
+                if inet_ntop(AF_INET6, &ip, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil {
+                    values.append("ipv6=\(String(cString: buffer))")
+                } else {
+                    let ntopErrno = errno
+                    values.append("ipv6_ntop_error=\(ntopErrno):\(String(cString: strerror(ntopErrno)))")
+                }
+            } else {
+                values.append("family=\(family)")
+            }
+            interfaces[name] = values
             ptr = ptr?.pointee.ifa_next
         }
 
         if interfaces.isEmpty {
-            logs.writeLog(log: "[DEBUG][Interfaces] no utun interfaces visible")
+            logs.writeLog(log: "[DEBUG][Interfaces] no interfaces visible")
             return
         }
 
@@ -141,6 +160,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(log: "Start go logger init path = \(path)")
             Cloak_outlineInitLogger(path)
             logs.writeLog(log: "Finish go logger init")
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [Native] Go build info: \(Cloak_outlineNativeBuildInfo())")
+            logGoProtectionDiagnostics(label: "after logger init")
 
             // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
             enterStage("pre-start cleanup")
@@ -154,6 +175,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // iOS 26+: set the physical interface index before any protected sockets are opened.
             enterStage("initial interface detection")
             setInitialDefaultInterfaceIndexForStartup(timeout: 1.0)
+            logGoProtectionDiagnostics(label: "after initial interface detection")
             logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: initial interface detection")
             enterStage("geo routing config")
             let geoRoutingConf = configsRepository.getGeoRoutingConf()
@@ -256,6 +278,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(
                 log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings applied in \(elapsedMs(since: settingsStart))ms"
             )
+            logGoProtectionDiagnostics(label: "after setTunnelNetworkSettings")
 
             // iOS 26 research: Log network interfaces AFTER tunnel starts
             logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: AFTER_VPN_TUNNEL ==========")
@@ -313,6 +336,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
 
             logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
+            logGoProtectionDiagnostics(label: "after protocol startup")
+            logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: AFTER_PROTOCOL_STARTUP ==========")
+            logInterfaces()
+            logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_AFTER_PROTOCOL_STARTUP ==========")
 
             logs.writeLog(log: "startTunnel: all packet loops started")
         } catch {
@@ -396,6 +423,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let response = "OutlineStatus:\(status)".data(using: .utf8)
             logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getOutlineStatus responseBytes=\(response?.count ?? -1)")
             completionHandler?(response)
+        } else if let msg = String(data: messageData, encoding: .utf8), msg == "getTunnelDiagnostics" {
+            let diagnostics = tunnelDiagnosticsSnapshot()
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getTunnelDiagnostics \(diagnostics)")
+            let response = "TunnelDiagnostics:\(diagnostics)".data(using: .utf8)
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getTunnelDiagnostics responseBytes=\(response?.count ?? -1)")
+            completionHandler?(response)
         } else {
             if String(data: messageData, encoding: .utf8) == nil {
                 logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage nonUtf8 echo bytes=\(messageData.count)")
@@ -404,6 +437,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
             completionHandler?(messageData)
         }
+    }
+
+    private func tunnelDiagnosticsSnapshot() -> String {
+        let outlineStatus = outlineInteractor.outlineStatus()
+        let bridgeStatus = packetFlowBridge?.diagnosticsSnapshot() ?? "packetFlowBridge=nil"
+        let protection = Cloak_outlineProtectionDiagnostics()
+        logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: XPC_TUNNEL_DIAGNOSTICS ==========")
+        logInterfaces()
+        logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_XPC_TUNNEL_DIAGNOSTICS ==========")
+        return "nativeBuildInfo=\(Cloak_outlineNativeBuildInfo()) " +
+            "protection={\(protection)} " +
+            "outline={\(outlineStatus)} " +
+            "bridge={\(bridgeStatus)}"
     }
 
     /// Get the default (primary) interface index for socket binding.
@@ -468,10 +514,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             
             // Call Go function to set the interface index
             Cloak_outlineSetDefaultInterfaceIndex(index)
+            let goIndex = Cloak_outlineGetDefaultInterfaceIndex()
+            let diagnostics = Cloak_outlineProtectionDiagnostics()
             
             logs.writeLog(
-                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] Set default interface index: \(index) (\(ifaceName)/\(ifaceType))"
+                log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] Set default interface index: " +
+                    "\(index) (\(ifaceName)/\(ifaceType)) goIndex=\(goIndex) diagnostics=\(diagnostics)"
             )
+            if goIndex != index {
+                logs.writeLog(
+                    log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] ERROR: Go default interface index mismatch " +
+                        "swiftSet=\(index) goReturned=\(goIndex)"
+                )
+            }
         } else {
             logs.writeLog(
                 log: "[tunnel:\(tunnelId)] [iOS26-RESEARCH] WARNING: Could not determine default interface index! " +
@@ -695,7 +750,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let ifaceIndex = self.getDefaultInterfaceIndex(from: path)
             if ifaceIndex > 0 {
                 Cloak_outlineSetDefaultInterfaceIndex(ifaceIndex)
-                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP: Set initial interface index returned: \(ifaceIndex)")
+                let goIndex = Cloak_outlineGetDefaultInterfaceIndex()
+                let diagnostics = Cloak_outlineProtectionDiagnostics()
+                self.logs.writeLog(
+                    log: "[tunnel:\(self.tunnelId)] STARTUP: Set initial interface index " +
+                        "swiftSet=\(ifaceIndex) goIndex=\(goIndex) diagnostics=\(diagnostics)"
+                )
+                if goIndex != ifaceIndex {
+                    self.logs.writeLog(
+                        log: "[tunnel:\(self.tunnelId)] STARTUP_ERROR: Go default interface index mismatch " +
+                            "swiftSet=\(ifaceIndex) goReturned=\(goIndex)"
+                    )
+                }
             } else {
                 self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP_WARNING: Could not determine initial interface index")
             }
@@ -761,6 +827,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         lastPathFingerprint = nil
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
+    }
+
+    private func logGoProtectionDiagnostics(label: String) {
+        logs.writeLog(
+            log: "[tunnel:\(tunnelId)] [iOS-Protect] \(label): " +
+                "\(Cloak_outlineProtectionDiagnostics())"
+        )
     }
 
     private func logNetworkSettings(


### PR DESCRIPTION
## Background
- PR #161 is merged and this branch is based directly on current `origin/main` (`398f6b5a`).
- Latest log `/home/alex/ai/dobbyvpn-client/DobbyVPN_logs_2026-05-05_16-22-59.txt` was not produced by the current native Go source: it logs `NewVpnClient(): creating outline device preferTCPDNSForWebSocket=true` and the transport summary lacks `disableNonDNSUDP`.
- Current `main` expects `disableNonDNSUDP=true` for iOS Outline WebSocket, so that device run appears to have used a stale `MyLibrary.xcframework` or a pre-`398f6b5a` native artifact.
- The same log shows the user-visible failure class: routed app traffic later becomes unhealthy while the local Outline proxy still reports alive. Around `14:22:46-14:22:49`, HTTPS health checks time out or return `NSURLErrorDomain -1009`, while the packet bridge shows heavy UDP `:443` traffic and Go logs repeated `websocket: bad handshake`.
- This means the earlier “local proxy alive”/initial health success was not sufficient. Speedtest freezing is consistent with routed non-DNS UDP / QUIC traffic failing over WebSocket transport.

## Fix / Diagnostics
- Export Go `NativeBuildInfo()` and log it from Swift app startup plus Outline tunnel startup. The expected marker is now `ios-native/2026-05-05.3`.
- Force stale native artifacts to fail visibly: Swift calls new Go exports, so an old `MyLibrary.xcframework` without these symbols should not compile.
- Add Go-side socket protection diagnostics exposed through `ProtectionDiagnostics()`, including configured default interface index and full interface list.
- Verify/log `SO_NO_TC_NETPOLICY`, `IP_BOUND_IF` / `IPV6_BOUND_IF`, and bound-interface checks for protected iOS sockets.
- Expand iOS interface logs from only `utun*` to all visible interfaces with index, flags, IPv4/IPv6 addresses, and physical/VPN candidate markers.
- Add packet-flow bridge live snapshots: packet/byte counters, deltas, last packet ages, drop/error counters, one-way/no-traffic diagnoses, and top classified flows.
- Add `getTunnelDiagnostics` XPC message so failed health checks can pull live tunnel diagnostics immediately, not just wait for periodic logs.
- Add routed UDP health probes:
  - UDP DNS probe to `1.1.1.1:53` as a diagnostic.
  - Non-DNS UDP/STUN probe to `stun.l.google.com:19302` as a required full-health signal, because this matches Speedtest/QUIC-style failures.
- Full health diagnosis no longer reports `ALL OK` unless routed non-DNS UDP also works. If TCP/DNS/HTTPS pass but UDP fails, it now says: `TCP/DNS/HTTPS passed but routed non-DNS UDP failed`.
- Keep Outline transport flags and dial counters in `VpnStatus`, including `udpNonDNSRejected`, `udpErr`, DNS truncation, TCP/UDP attempt/OK/error counts.

## What To Check In The Next iOS Log
- Must contain `ios-native/2026-05-05.3`. If not, the app is still running a stale native artifact.
- Must contain `disableNonDNSUDP=true` in the Outline transport summary/status.
- Must contain `[iOS-Protect] ... diagnostics=... goIndex=...` after interface selection.
- If Speedtest still freezes, look for:
  - `[HC] [diag] routed_non_dns_udp=false`
  - `[HC] DIAGNOSIS: ... routed non-DNS UDP failed`
  - `PacketFlowBridge ... diagnosis=ONE_WAY_*`, `DROPS_PRESENT`, or `SOCKET_ERRORS_PRESENT`
  - `OutlineStatus ... dialStats(... udpNonDNSRejected=... udpErr=...)`
  - `[SOCKS5 UDP ERROR] ... websocket: bad handshake`

## Validation
- `gofmt` on changed Go files.
- `go test ./outline ./core ./core/pkg ./tunnel/protected_dialer` from `go_module`.
- `git diff --check`.

## Not Tested Locally
- iOS gomobile/XCFramework rebuild, because this Linux checkout does not have the macOS/iOS toolchain and the workflow vendors `Cloak/internal` before building `ios_exports`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tunnel diagnostics snapshot reporting, accessible via diagnostics request.
  * Enhanced routed UDP health checks with DNS probe and STUN probe capabilities.
  * Added protection diagnostics functionality for improved network binding visibility.

* **Improvements**
  * Enhanced native build information tracking with new feature flags.
  * Improved interface binding verification for more reliable socket protection.
  * Extended health check diagnostics with detailed packet flow monitoring and classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->