### PR TITLE
Improve iOS protected bypass diagnostics

### DIFF
--- a/go_module/core/pkg/protected_providers.go
+++ b/go_module/core/pkg/protected_providers.go
@@ -36,6 +36,5 @@ func NewProtectedPacketDialer(destination string) *ProtectedPacketDialer {
 }
 
 func (d *ProtectedPacketDialer) DialPacket(ctx context.Context, address string) (net.Conn, error) {
-	dialer := protected_dialer.NewProtectedDialer(address)
-	return dialer.DialContext(ctx, "udp", address)
+	return protected_dialer.DialPacketWithProtect(ctx, "udp", address)
 }

--- a/go_module/ios_exports/build_info.go
+++ b/go_module/ios_exports/build_info.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const nativeFeatureBuild = "ios-native/2026-05-05.3 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo,protectionDiagnostics,routedUDPHealth"
+const nativeFeatureBuild = "ios-native/2026-05-05.4 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo,protectionDiagnostics,routedUDPHealth,effectiveBypassValidation"
 
 func NativeBuildInfo() string {
 	parts := []string{nativeFeatureBuild, "go=" + runtime.Version()}

--- a/go_module/outline/outline_device.go
+++ b/go_module/outline/outline_device.go
@@ -101,13 +101,14 @@ func NewOutlineDeviceWithOptions(transportConfig string, options DeviceOptions) 
 	// concurrency. For plain Shadowsocks (no WebSocket) UDP works correctly.
 	disableNonDNSUDP := options.DisableNonDNSUDP && isWebSocket
 	log.Infof(
-		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v disableNonDNSUDP=%v streamDialer=%T packetDialer=%T",
+		"outline client: transport summary len=%d websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v disableNonDNSUDP=%v udpPolicy=%s streamDialer=%T packetDialer=%T",
 		len(transportConfig),
 		isWebSocket,
 		hasTCPPath,
 		hasUDPPath,
 		preferTCPDNS,
 		disableNonDNSUDP,
+		udpPolicyForLog(disableNonDNSUDP),
 		sd,
 		pd,
 	)
@@ -326,7 +327,7 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 		// Reject non-DNS UDP immediately so the OS falls back to TCP without burning ~1s per attempt.
 		if d.disableNonDNSUDP && port != 53 {
 			d.udpNonDNSReject.Add(1)
-			log.Infof("[SOCKS5 UDP] rejected (disableNonDNSUDP) addr=%s", addr)
+			log.Infof("[SOCKS5 UDP] rejected disabledByConfig=true addr=%s reason=non-DNS UDP disabled for WebSocket transport; Speedtest/QUIC traffic will fail or fall back to TCP if the app supports fallback", addr)
 			return nil, fmt.Errorf("non-DNS UDP disabled for this transport")
 		}
 
@@ -643,12 +644,13 @@ func (d *OutlineDevice) LocalProxyAlive(timeout time.Duration) (alive bool, stat
 
 func (d *OutlineDevice) runtimeStatus() string {
 	return fmt.Sprintf(
-		"transport(websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v disableNonDNSUDP=%v) dialStats(tcpAttempt=%d tcpOK=%d tcpErr=%d udpAttempt=%d udpOK=%d udpErr=%d udpDNSTruncated=%d udpNonDNSRejected=%d unsupported=%d)",
+		"transport(websocket=%v tcpPath=%v udpPath=%v preferTCPDNS=%v disableNonDNSUDP=%v udpPolicy=%s) dialStats(tcpAttempt=%d tcpOK=%d tcpErr=%d udpAttempt=%d udpOK=%d udpErr=%d udpDNSTruncated=%d udpNonDNSRejected=%d unsupported=%d)",
 		d.websocket,
 		d.hasTCPPath,
 		d.hasUDPPath,
 		d.preferTCPDNS,
 		d.disableNonDNSUDP,
+		udpPolicyForLog(d.disableNonDNSUDP),
 		d.tcpDialAttempt.Load(),
 		d.tcpDialOK.Load(),
 		d.tcpDialErr.Load(),
@@ -676,6 +678,13 @@ func outlineUptimeMilliseconds(startedAt time.Time) int64 {
 		return 0
 	}
 	return time.Since(startedAt).Milliseconds()
+}
+
+func udpPolicyForLog(disabled bool) string {
+	if disabled {
+		return "non_dns_udp_disabled_by_config"
+	}
+	return "non_dns_udp_enabled"
 }
 
 func (d *OutlineDevice) Status(timeout time.Duration) string {

--- a/go_module/outline/outline_device_test.go
+++ b/go_module/outline/outline_device_test.go
@@ -54,7 +54,7 @@ func TestLocalProxyAliveUsesListenerAddressWithoutCredentials(t *testing.T) {
 	if strings.Contains(status, "too many colons") {
 		t.Fatalf("status shows credentialed proxy address was dialed: %s", status)
 	}
-	if !strings.Contains(status, "transport(websocket=true tcpPath=true udpPath=true preferTCPDNS=true disableNonDNSUDP=true)") {
+	if !strings.Contains(status, "transport(websocket=true tcpPath=true udpPath=true preferTCPDNS=true disableNonDNSUDP=true udpPolicy=non_dns_udp_disabled_by_config)") {
 		t.Fatalf("status does not include transport flags: %s", status)
 	}
 	if !strings.Contains(status, "dialStats(tcpAttempt=2 tcpOK=1 tcpErr=1 udpAttempt=3 udpOK=0 udpErr=1 udpDNSTruncated=1 udpNonDNSRejected=1 unsupported=0)") {

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"syscall"
+	"time"
 
 	M "github.com/xjasonlyu/tun2socks/v2/metadata"
 	"github.com/xjasonlyu/tun2socks/v2/proxy"
@@ -102,12 +103,155 @@ func NewProtectedListenConfig(destination string) *net.ListenConfig {
 	}
 }
 
+type diagnosticProtector interface {
+	Diagnostics() string
+}
+
+func protectionDiagnosticsForLog() string {
+	if protector == nil {
+		return "protector=nil"
+	}
+	if diagnostic, ok := protector.(diagnosticProtector); ok {
+		return diagnostic.Diagnostics()
+	}
+	return fmt.Sprintf("protector=%T diagnostics=unavailable", protector)
+}
+
+func splitAddrHost(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	return host
+}
+
+func destinationPartsForLog(address string) (host string, port string, hostType string) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address, "", "invalid_hostport"
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.To4() != nil {
+			return host, port, "ipv4"
+		}
+		return host, port, "ipv6"
+	}
+	return host, port, "hostname"
+}
+
+func interfaceNamesForIP(host string) string {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "ip_parse_failed"
+	}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Sprintf("scan_error=%v", err)
+	}
+
+	var matches []string
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			matches = append(matches, fmt.Sprintf("%s(index=%d addr_scan_error=%v)", iface.Name, iface.Index, err))
+			continue
+		}
+		for _, addr := range addrs {
+			var addrIP net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				addrIP = v.IP
+			case *net.IPAddr:
+				addrIP = v.IP
+			default:
+				continue
+			}
+			if addrIP.Equal(ip) {
+				matches = append(matches, fmt.Sprintf("%s(index=%d flags=%s mtu=%d)", iface.Name, iface.Index, iface.Flags.String(), iface.MTU))
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return "none"
+	}
+	return strings.Join(matches, ";")
+}
+
+func isTunnelSourceHost(host string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	ip4 := ip.To4()
+	return ip4 != nil && ip4[0] == 198 && (ip4[1] == 18 || ip4[1] == 19)
+}
+
+func isUnspecifiedSourceHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
+}
+
+func validateProtectedAddrs(kind string, localAddr net.Addr, remoteAddr net.Addr, requestedNetwork string, realNetwork string, address string, started time.Time) error {
+	localHost := splitAddrHost(localAddr)
+	remoteHost := splitAddrHost(remoteAddr)
+	destHost, destPort, hostType := destinationPartsForLog(address)
+	localInterfaces := interfaceNamesForIP(localHost)
+	remoteInterfaces := interfaceNamesForIP(remoteHost)
+	protectionDiagnostics := protectionDiagnosticsForLog()
+	elapsedMs := time.Since(started).Milliseconds()
+
+	verdict := "BYPASS_OK"
+	if isTunnelSourceHost(localHost) {
+		verdict = "BYPASS_FAILED_TUNNEL_SOURCE"
+	} else if isUnspecifiedSourceHost(localHost) {
+		verdict = "BYPASS_SOURCE_UNSPECIFIED"
+	}
+
+	log.Infof(
+		"[Protect] %s effective_bypass verdict=%s requestedNetwork=%s realNetwork=%s dest=%s destHost=%s destPort=%s destHostType=%s resolvedRemote=%s local=%s localHost=%s localInterfaces=[%s] remote=%s remoteHost=%s remoteInterfaces=[%s] elapsedMs=%d protection={%s}",
+		kind,
+		verdict,
+		requestedNetwork,
+		realNetwork,
+		address,
+		destHost,
+		destPort,
+		hostType,
+		remoteHost,
+		localAddr,
+		localHost,
+		localInterfaces,
+		remoteAddr,
+		remoteHost,
+		remoteInterfaces,
+		elapsedMs,
+		protectionDiagnostics,
+	)
+
+	if verdict == "BYPASS_FAILED_TUNNEL_SOURCE" {
+		err := fmt.Errorf("protected %s upstream routed through tunnel source local=%s remote=%s dest=%s", strings.ToLower(kind), localAddr, remoteAddr, address)
+		log.Infof("[Protect] %s effective_bypass hard_fail err=%v", kind, err)
+		return err
+	}
+	return nil
+}
+
+func validateProtectedConn(kind string, conn net.Conn, requestedNetwork string, realNetwork string, address string, started time.Time) error {
+	return validateProtectedAddrs(kind, conn.LocalAddr(), conn.RemoteAddr(), requestedNetwork, realNetwork, address, started)
+}
+
 func DialContextWithProtect(ctx context.Context, network, address string) (net.Conn, error) {
 	realNet := normalizeTCP(address)
+	start := time.Now()
 	if deadline, ok := ctx.Deadline(); ok {
-		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"))
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s protection={%s}", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"), protectionDiagnosticsForLog())
 	} else {
-		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none)", network, realNet, address)
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none) protection={%s}", network, realNet, address, protectionDiagnosticsForLog())
 	}
 
 	if isLoopback(address) {
@@ -132,21 +276,62 @@ func DialContextWithProtect(ctx context.Context, network, address string) (net.C
 
 	// Protected upstream sockets must bypass the packet tunnel. If they use the
 	// tunnel address, Outline/Cloak traffic can loop back into tun2socks.
-	localAddr := conn.LocalAddr().String()
-	log.Infof("[Protect] TCP dial OK: dest=%s local=%s remote=%s", address, localAddr, conn.RemoteAddr())
+	log.Infof("[Protect] TCP dial OK: dest=%s local=%s remote=%s", address, conn.LocalAddr(), conn.RemoteAddr())
 
-	if strings.HasPrefix(localAddr, "198.18.") {
-		log.Infof("[Protect] *** CRITICAL *** Protected upstream TCP connection is using VPN tunnel address local=%s - routing loop risk", localAddr)
+	if err := validateProtectedConn("TCP", conn, network, realNet, address, start); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Infof("[Protect] TCP close after bypass validation failure failed dest=%s closeErr=%v", address, closeErr)
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+func DialPacketWithProtect(ctx context.Context, network, address string) (net.Conn, error) {
+	realNet := normalizeUDP(address)
+	start := time.Now()
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Infof("[Protect] UDP conn dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s protection={%s}", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"), protectionDiagnosticsForLog())
+	} else {
+		log.Infof("[Protect] UDP conn dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none) protection={%s}", network, realNet, address, protectionDiagnosticsForLog())
+	}
+
+	if isLoopback(address) {
+		log.Infof("[Protect] UDP conn BYPASS loopback: %s", address)
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, realNet, address)
+		if err != nil {
+			log.Infof("[Protect] UDP conn BYPASS loopback failed network=%s dest=%s err=%v", realNet, address, err)
+			return nil, err
+		}
+		log.Infof("[Protect] UDP conn BYPASS loopback OK network=%s dest=%s local=%s remote=%s", realNet, address, conn.LocalAddr(), conn.RemoteAddr())
+		return conn, nil
+	}
+
+	d := NewProtectedDialer(address)
+	conn, err := d.DialContext(ctx, realNet, address)
+	if err != nil {
+		log.Infof("[Protect] UDP conn dial FAILED: dest=%s err=%v", address, err)
+		return nil, err
+	}
+	log.Infof("[Protect] UDP conn dial OK: dest=%s local=%s remote=%s", address, conn.LocalAddr(), conn.RemoteAddr())
+
+	if err := validateProtectedConn("UDP", conn, network, realNet, address, start); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Infof("[Protect] UDP conn close after bypass validation failure failed dest=%s closeErr=%v", address, closeErr)
+		}
+		return nil, err
 	}
 	return conn, nil
 }
 
 func DialUDPWithProtect(ctx context.Context, network, address string) (net.PacketConn, error) {
 	realNet := normalizeUDP(address)
+	start := time.Now()
 	if deadline, ok := ctx.Deadline(); ok {
-		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"))
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s protection={%s}", network, realNet, address, deadline.Format("2006-01-02T15:04:05.000Z07:00"), protectionDiagnosticsForLog())
 	} else {
-		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none)", network, realNet, address)
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none) protection={%s}", network, realNet, address, protectionDiagnosticsForLog())
 	}
 
 	if isLoopback(address) {
@@ -195,8 +380,11 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 	localAddr := pc.LocalAddr().String()
 	log.Infof("[DEBUG][Protect] UDP dial ready network=%s destination=%s local=%s remote=%s", realNet, address, localAddr, udpAddr)
 
-	if strings.HasPrefix(localAddr, "198.18.") {
-		log.Infof("[Protect] *** CRITICAL *** Protected upstream UDP socket is using VPN tunnel address local=%s - routing loop risk", localAddr)
+	if err := validateProtectedAddrs("UDP_PACKET", pc.LocalAddr(), udpAddr, network, realNet, address, start); err != nil {
+		if closeErr := pc.Close(); closeErr != nil {
+			log.Infof("[Protect] UDP close after bypass validation failure failed dest=%s closeErr=%v", address, closeErr)
+		}
+		return nil, err
 	}
 	return &connectedUDPConn{
 		PacketConn: pc,

--- a/go_module/tunnel/protected_dialer/protect_ios.go
+++ b/go_module/tunnel/protected_dialer/protect_ios.go
@@ -65,9 +65,11 @@ func GetConfiguredDefaultInterfaceForIOS() int {
 }
 
 func ProtectionDiagnosticsForIOS() string {
+	configuredIndex := GetConfiguredDefaultInterfaceForIOS()
 	return fmt.Sprintf(
-		"configuredDefaultInterfaceIndex=%d interfaces=[%s]",
-		GetConfiguredDefaultInterfaceForIOS(),
+		"configuredDefaultInterfaceIndex=%d configuredDefaultInterfaceName=%s interfaces=[%s]",
+		configuredIndex,
+		interfaceNameByIndex(configuredIndex),
 		describeInterfacesForLog(),
 	)
 }
@@ -120,7 +122,22 @@ func formatInterfacesForLog(interfaces []net.Interface) string {
 	return strings.Join(parts, ";")
 }
 
+func interfaceNameByIndex(index int) string {
+	if index <= 0 {
+		return "unset"
+	}
+	iface, err := net.InterfaceByIndex(index)
+	if err != nil {
+		return fmt.Sprintf("lookup_error=%v", err)
+	}
+	return iface.Name
+}
+
 type iosProtector struct{}
+
+func (i *iosProtector) Diagnostics() string {
+	return ProtectionDiagnosticsForIOS()
+}
 
 func (i *iosProtector) Protect(fd uintptr, network string) error {
 	// iOS 26+: Try SO_NO_TC_NETPOLICY first (legacy approach for older iOS versions).
@@ -138,7 +155,7 @@ func (i *iosProtector) Protect(fd uintptr, network string) error {
 	ifaceIndex := GetDefaultInterfaceForIOS()
 
 	if ifaceIndex > 0 {
-		log.Infof("[iOS-Protect] Protect binding fd=%d network=%s ifaceIndex=%d", fd, network, ifaceIndex)
+		log.Infof("[iOS-Protect] Protect binding fd=%d network=%s ifaceIndex=%d ifaceName=%s", fd, network, ifaceIndex, interfaceNameByIndex(ifaceIndex))
 		// Bind the socket to the default physical interface (WiFi/Cellular)
 		// This ensures encrypted VPN traffic goes outside the VPN tunnel.
 		switch network {

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -65,6 +65,9 @@ public final class HealthCheckImpl: HealthCheck {
     public private(set) var currentMemmoryUsageMb = 0.0
     private var lastMemoryMB: Double = 0
     private var lastOutlineProxyOk = false
+    private var lastOutlineStatus = ""
+    private var lastProtectedServerOk = false
+    private var lastProtectedServerAddress = "(none)"
     private var checkSequence: Int = 0
     private let checkSequenceLock = NSLock()
 
@@ -98,11 +101,16 @@ public final class HealthCheckImpl: HealthCheck {
             return mem >= 0
         }
 
+        let serverPort = DobbyConfigsRepositoryImpl.shared.getServerPort()
+        lastProtectedServerAddress = serverPort.isEmpty ? "(none)" : serverPort
         let serverAliveProtected = runWithRetry(name: "Server reachability (protected)", attempts: 1) {
-            let serverPort = DobbyConfigsRepositoryImpl.shared.getServerPort()
-            if serverPort.isEmpty { return true }
+            if serverPort.isEmpty {
+                self.logs.writeLog(log: "[HC] [ping-protected UpstreamServer] skipped: serverPort is empty")
+                return true
+            }
             return self.pingAddressProtected(serverPort, name: "UpstreamServer")
         }
+        lastProtectedServerOk = serverAliveProtected
 
         let outlineProxyOk = runWithRetry(name: "Outline local proxy check", attempts: 1) {
             self.isOutlineProxyAliveViaXPC()
@@ -123,7 +131,8 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(
             log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) " +
             "(vpn=\(vpnOk), network=\(networkOk), heartbeat=\(heartbeatOk), " +
-            "outlineProxy=\(outlineProxyOk), serverAlive=\(serverAliveProtected), " +
+            "outlineProxy=\(outlineProxyOk), upstreamProtected=\(serverAliveProtected), " +
+            "upstreamAddress=\(lastProtectedServerAddress), " +
             "userStopRequested=\(userStopAtEnd))"
         )
         if !result && userStopAtEnd {
@@ -218,6 +227,18 @@ public final class HealthCheckImpl: HealthCheck {
         let tunnelIPOk = isTunnelIPAssigned()
         logs.writeLog(log: "[HC] [diag] tunnel_ip_assigned=\(tunnelIPOk)")
         logs.writeLog(log: "[HC] [diag] outline_proxy_alive=\(lastOutlineProxyOk)")
+        let nonDNSUDPDisabledByConfig = isNonDNSUDPDisabledByConfig()
+        let outlineStatusContainsDisableFlag = lastOutlineStatus.contains("disableNonDNSUDP=true")
+        let websocketConfig = DobbyConfigsRepositoryImpl.shared.getIsWebsocketEnabled()
+        logs.writeLog(
+            log: "[HC] [diag] upstream_bypass_protected=\(lastProtectedServerOk) " +
+                "upstreamAddress=\(lastProtectedServerAddress)"
+        )
+        logs.writeLog(
+            log: "[HC] [diag] routed_non_dns_udp_config disabledByConfig=\(nonDNSUDPDisabledByConfig) " +
+                "outlineStatusContainsDisableFlag=\(outlineStatusContainsDisableFlag) " +
+                "websocketConfig=\(websocketConfig)"
+        )
 
         let udpDNSOk = runWithRetry(name: "Routed UDP DNS diagnostic", attempts: 1, timeoutPerAttempt: 6.0) {
             self.udpDNSProbe()
@@ -230,14 +251,28 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(log: "[HC] [diag] routed_non_dns_udp=\(nonDNSUDPOk)")
         groupResults["Routed non-DNS UDP group"] = nonDNSUDPOk
         if !nonDNSUDPOk {
+            let reason = nonDNSUDPDisabledByConfig
+                ? "disabledByConfig=true; Speedtest/QUIC UDP is expected to fail until transport UDP is enabled"
+                : "disabledByConfig=false; real UDP path is broken"
             logs.writeLog(
                 log: "[HC] Group FAILED: Routed non-DNS UDP group " +
-                    "(Speedtest/QUIC/real app UDP traffic is not working)"
+                    "(\(reason))"
             )
             failedGroups.append("Routed non-DNS UDP group")
         } else {
             logs.writeLog(log: "[HC] Group OK: Routed non-DNS UDP group")
         }
+
+        let dnsGroupOk = groupResults["DNS Resolve group"] ?? false
+        logs.writeLog(
+            log: "[HC] HEALTH_MATRIX id=\(checkId) " +
+                "tunnelOS=\(tunnelIPOk) dns=\(dnsGroupOk) " +
+                "shortHealth=\(shortOk) outlineProxy=\(lastOutlineProxyOk) " +
+                "upstreamProtected=\(lastProtectedServerOk) upstreamAddress=\(lastProtectedServerAddress) " +
+                "routedUdpDns=\(udpDNSOk) routedNonDnsUdp=\(nonDNSUDPOk) " +
+                "nonDnsUdpDisabledByConfig=\(nonDNSUDPDisabledByConfig) " +
+                "userStopRequested=\(isUserStopRequested())"
+        )
 
         // --- Result ---
         let result = failedGroups.isEmpty
@@ -271,7 +306,8 @@ public final class HealthCheckImpl: HealthCheck {
             tcp443: tcp443Ok,
             outlineProxy: lastOutlineProxyOk,
             https: httpsOk,
-            nonDNSUDP: nonDNSUDPOk
+            nonDNSUDP: nonDNSUDPOk,
+            nonDNSUDPDisabledByConfig: nonDNSUDPDisabledByConfig
         )
 
         return result
@@ -296,30 +332,35 @@ public final class HealthCheckImpl: HealthCheck {
         tcp443: Bool,
         outlineProxy: Bool,
         https: Bool,
-        nonDNSUDP: Bool
+        nonDNSUDP: Bool,
+        nonDNSUDPDisabledByConfig: Bool
     ) {
         let diagnosis: String
-        switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https, nonDNSUDP) {
-        case (false, _, _, _, _, _, _):
-            diagnosis = "SIDE: CLIENT | REASON: tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level"
-        case (true, _, _, _, false, _, _):
-            diagnosis = "SIDE: CLIENT | REASON: local Outline SOCKS5 proxy is unavailable — tun2socks has no working upstream proxy"
-        case (true, _, false, _, _, _, _):
-            diagnosis = "SIDE: CLIENT OR SERVER | REASON: DNS not resolving — DNS-over-tunnel is failing or blocked"
-        case (true, _, true, _, true, false, _):
-            // Check metrics[win] in logs: proto=h3+total=- → QUIC/UDP not proxied (no udpPath? pool full?);
-            // proto=h2+high total → server is slow or blocking TLS
-            diagnosis = "SIDE: CLIENT OR SERVER | REASON: Outline proxy is alive but HTTPS checks fail — check [win] metrics for h3/h2 timing and server behavior"
-        case (true, false, true, _, true, _, _):
-            diagnosis = "SIDE: CLIENT | REASON: TCP diagnostic failed after DNS/HTTP checks — possible tun2socks forwarding issue"
-        case (true, true, true, false, true, _, _):
-            diagnosis = "SIDE: SERVER (likely) | REASON: TCP diagnostic to :443 failed — server blocks HTTPS port or intermediate node filters it"
-        case (true, true, true, true, true, true, false):
-            diagnosis = "SIDE: CLIENT OR TRANSPORT | REASON: TCP/DNS/HTTPS passed but routed non-DNS UDP failed — Speedtest/QUIC apps can freeze; check PacketFlowBridge flow stats and Outline dialStats udpNonDNSRejected/udpErr"
-        case (true, true, true, true, true, true, true):
-            diagnosis = "ALL OK — connection is working"
-        default:
-            diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) outlineProxy=\(outlineProxy) https=\(https) nonDNSUDP=\(nonDNSUDP)"
+        if tunnelIP && tcpProxy && dns && tcp443 && outlineProxy && https && !nonDNSUDP && nonDNSUDPDisabledByConfig {
+            diagnosis = "SIDE: CONFIG/TRANSPORT | REASON: TCP/DNS/HTTPS passed, but non-DNS UDP is disabled by current transport config — Speedtest/QUIC apps will fail by design"
+        } else {
+            switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https, nonDNSUDP) {
+            case (false, _, _, _, _, _, _):
+                diagnosis = "SIDE: CLIENT | REASON: tunnel IP 198.18.0.1 not assigned — tunnel failed to start at OS level"
+            case (true, _, _, _, false, _, _):
+                diagnosis = "SIDE: CLIENT | REASON: local Outline SOCKS5 proxy is unavailable — tun2socks has no working upstream proxy"
+            case (true, _, false, _, _, _, _):
+                diagnosis = "SIDE: CLIENT OR SERVER | REASON: DNS not resolving — DNS-over-tunnel is failing or blocked"
+            case (true, _, true, _, true, false, _):
+                // Check metrics[win] in logs: proto=h3+total=- → QUIC/UDP not proxied (no udpPath? pool full?);
+                // proto=h2+high total → server is slow or blocking TLS
+                diagnosis = "SIDE: CLIENT OR SERVER | REASON: Outline proxy is alive but HTTPS checks fail — check [win] metrics for h3/h2 timing and server behavior"
+            case (true, false, true, _, true, _, _):
+                diagnosis = "SIDE: CLIENT | REASON: TCP diagnostic failed after DNS/HTTP checks — possible tun2socks forwarding issue"
+            case (true, true, true, false, true, _, _):
+                diagnosis = "SIDE: SERVER (likely) | REASON: TCP diagnostic to :443 failed — server blocks HTTPS port or intermediate node filters it"
+            case (true, true, true, true, true, true, false):
+                diagnosis = "SIDE: CLIENT OR TRANSPORT | REASON: TCP/DNS/HTTPS passed but routed non-DNS UDP failed — Speedtest/QUIC apps can freeze; check PacketFlowBridge flow stats and Outline dialStats udpNonDNSRejected/udpErr"
+            case (true, true, true, true, true, true, true):
+                diagnosis = "ALL OK — connection is working"
+            default:
+                diagnosis = "UNDEFINED | Pattern: tunnel=\(tunnelIP) tcp=\(tcpProxy) dns=\(dns) tcp443=\(tcp443) outlineProxy=\(outlineProxy) https=\(https) nonDNSUDP=\(nonDNSUDP)"
+            }
         }
         logs.writeLog(log: "[HC] DIAGNOSIS: \(diagnosis)")
     }
@@ -959,6 +1000,7 @@ public final class HealthCheckImpl: HealthCheck {
 
     private func isOutlineProxyAliveViaXPC() -> Bool {
         let raw = providerMessage("getOutlineStatus", label: "Outline")
+        lastOutlineStatus = raw ?? ""
         logs.writeLog(log: "[HC] [Outline] status: \(raw ?? "nil")")
         guard let raw else { return false }
         if raw.contains("localProxyAlive=true") {
@@ -977,6 +1019,18 @@ public final class HealthCheckImpl: HealthCheck {
             )
         }
         return legacyHealthyStatus
+    }
+
+    private func isNonDNSUDPDisabledByConfig() -> Bool {
+        let outlineStatusFlag = lastOutlineStatus.contains("disableNonDNSUDP=true")
+        let websocketConfig = DobbyConfigsRepositoryImpl.shared.getIsWebsocketEnabled()
+        if !outlineStatusFlag && websocketConfig {
+            logs.writeLog(
+                log: "[HC] [diag] non-DNS UDP disabled inferred from websocketConfig=true; " +
+                    "Outline status did not contain disableNonDNSUDP=true yet"
+            )
+        }
+        return outlineStatusFlag || websocketConfig
     }
 
     private func logTunnelDiagnostics(checkId: String, reason: String) {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -30,6 +30,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var pathMonitor: Network.NWPathMonitor?
     private var lastPathFingerprint: String?
     private var packetFlowBridge: PacketFlowBridge?
+    private var lastRouteDiagnostics = "routeDiagnostics=not_built"
 
     deinit {
         logs.writeLog(log: "[tunnel:\(tunnelId)] deinit")
@@ -188,11 +189,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
             // DNS resolution at tunnel start can hang in offline/captive-portal cases, so we do it with a hard timeout.
             var excludedRoutes: [NEIPv4Route] = []
+            var routeDiagnosticParts: [String] = []
             if let hostOrIp = extractIP(from: configsRepository.getServerPort()) {
                 let trimmed = hostOrIp.trimmingCharacters(in: .whitespacesAndNewlines)
                 if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
                    let route = makeExcludedRoute(host: ip) {
                     excludedRoutes.append(route)
+                    routeDiagnosticParts.append("outlineHost=\(maskStr(value: trimmed)) outlineResolvedIPv4=\(maskStr(value: ip)) outlineExcludedRoute=\(ip)/32")
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
                     } else {
@@ -202,14 +205,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                         )
                     }
                 } else {
+                    routeDiagnosticParts.append("outlineHost=\(maskStr(value: trimmed)) outlineResolvedIPv4=failed outlineExcludedRoute=none")
                     logs.writeLog(log: "Excluded route for Outline host skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
+            } else {
+                routeDiagnosticParts.append("outlineHost=none outlineResolvedIPv4=none outlineExcludedRoute=none")
             }
             if let remoteHost = extractRemoteHost(from: cloakConfig) {
                 let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
                 if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
                    let route = makeExcludedRoute(host: ip) {
                     excludedRoutes.append(route)
+                    routeDiagnosticParts.append("cloakRemoteHost=\(maskStr(value: trimmed)) cloakResolvedIPv4=\(maskStr(value: ip)) cloakExcludedRoute=\(ip)/32")
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
                     } else {
@@ -219,9 +226,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                         )
                     }
                 } else {
+                    routeDiagnosticParts.append("cloakRemoteHost=\(maskStr(value: trimmed)) cloakResolvedIPv4=failed cloakExcludedRoute=none")
                     logs.writeLog(log: "Excluded route for Cloak RemoteHost skipped (can't resolve to IPv4): \(maskStr(value: trimmed))")
                 }
+            } else {
+                routeDiagnosticParts.append("cloakRemoteHost=none cloakResolvedIPv4=none cloakExcludedRoute=none")
             }
+            let excludedRouteSummary = excludedRoutes.isEmpty
+                ? "(none)"
+                : excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ",")
+            lastRouteDiagnostics = "excludedRoutes=\(excludedRouteSummary) " +
+                routeDiagnosticParts.joined(separator: " ")
             if !excludedRoutes.isEmpty {
                 let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
                 logs.writeLog(log: "Excluded IPv4 routes: \(list)")
@@ -278,6 +293,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(
                 log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings applied in \(elapsedMs(since: settingsStart))ms"
             )
+            logs.writeLog(log: "[tunnel:\(tunnelId)] route exclusion validation after settings: \(lastRouteDiagnostics)")
             logGoProtectionDiagnostics(label: "after setTunnelNetworkSettings")
 
             // iOS 26 research: Log network interfaces AFTER tunnel starts
@@ -448,6 +464,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_XPC_TUNNEL_DIAGNOSTICS ==========")
         return "nativeBuildInfo=\(Cloak_outlineNativeBuildInfo()) " +
             "protection={\(protection)} " +
+            "routes={\(lastRouteDiagnostics)} " +
             "outline={\(outlineStatus)} " +
             "bridge={\(bridgeStatus)}"
     }


### PR DESCRIPTION
## Background

iOS 26 logs showed that the packet tunnel starts successfully, receives the `198.18.0.1` tunnel address, starts PacketFlowBridge, and starts Outline. The remaining failure mode is not tunnel startup itself: protected upstream dials can still connect with local source `198.18.x.x`, which means the "protected" socket effectively re-entered the VPN tunnel.

That creates a routing-loop risk and makes `IP_BOUND_IF` verification insufficient: the socket option may be set, but the connected path can still be wrong.

The same logs also show routed non-DNS UDP failures. For the current WebSocket Outline transport this is expected because non-DNS UDP is disabled by config, but the health logs did not make that distinction clear enough for Speedtest/QUIC failures.

## Fix

- Add effective protected-bypass validation for TCP, connected UDP, and packet UDP paths.
- Log a structured `effective_bypass` verdict with requested network, actual network, destination host/port type, resolved remote, local source, local interface mapping, remote interface mapping, elapsed time, and protection diagnostics.
- Fail hard when a protected upstream dial uses the tunnel source range `198.18.0.0/15` instead of only logging a warning.
- Route Outline packet dialing through the validated protected UDP dial path.
- Include configured iOS interface name in Go-side protection diagnostics.
- Add explicit UDP policy logging: `non_dns_udp_disabled_by_config` vs `non_dns_udp_enabled`.
- Add Swift health `HEALTH_MATRIX` logs that separate tunnel OS state, DNS, short health, Outline proxy, protected upstream bypass, routed UDP DNS, routed non-DNS UDP, and whether non-DNS UDP is disabled by config.
- Persist route exclusion diagnostics into tunnel diagnostics so excluded server/Cloak routes are visible via XPC diagnostics.
- Bump native build marker to `ios-native/2026-05-05.4`.

## Expected Log Outcomes

- `effective_bypass verdict=BYPASS_OK`: protected upstream socket is effectively bypassing the tunnel.
- `effective_bypass verdict=BYPASS_FAILED_TUNNEL_SOURCE`: root cause confirmed; protected upstream socket entered the VPN tunnel and the dial is failed immediately.
- `HEALTH_MATRIX ... nonDnsUdpDisabledByConfig=true`: Speedtest/QUIC UDP failure is configuration/transport-limited, not an unknown tunnel failure.
- `route exclusion validation after settings`: shows resolved Outline/Cloak hosts and excluded `/32` routes after network settings are applied.

## Validation

- `go test ./outline ./tunnel/protected_dialer ./core/pkg ./healthcheck`
- `git diff --check`

Not run locally:

- iOS/macOS Swift build or `swiftlint`, because the local environment does not provide the Apple toolchain.
- `go test ./ios_exports`, because the local module layout is missing Cloak internal packages required by that package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced bypass validation and diagnostics logging for protected network connections.
  * Improved diagnostics tracking for protected server reachability and route exclusion resolution.
  * Enhanced UDP policy logging for clearer transport configuration visibility.

* **Chores**
  * Updated iOS native build version with new feature flag enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->