### PR TITLE
Fix iOS enforced routing for upstream bypass

### DIFF
--- a/go_module/ios_exports/build_info.go
+++ b/go_module/ios_exports/build_info.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const nativeFeatureBuild = "ios-native/2026-05-05.4 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo,protectionDiagnostics,routedUDPHealth,effectiveBypassValidation"
+const nativeFeatureBuild = "ios-native/2026-05-06.1 features=disableNonDNSUDP,outlineDialCounters,nativeBuildInfo,protectionDiagnostics,routedUDPHealth,effectiveBypassValidation,enforcedRoutes,serverBypassRouting"
 
 func NativeBuildInfo() string {
 	parts := []string{nativeFeatureBuild, "go=" + runtime.Version()}

--- a/go_module/tunnel/georouting.go
+++ b/go_module/tunnel/georouting.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	M "github.com/xjasonlyu/tun2socks/v2/metadata"
 
@@ -41,24 +42,18 @@ func IsBypass(metadata *M.Metadata) bool {
 	return false
 }
 
-func mustCIDR(s string) {
-	_, ipnet, err := net.ParseCIDR(s)
-	if err != nil {
-		addBypassHost(s)
-	} else {
-		defaultBypassCIDRs = append(defaultBypassCIDRs, ipnet)
-	}
-}
-
 func SetGeoRoutingConf(cidrs string) {
+	paths := strings.Fields(cidrs)
+	resolvedRoutes := make([]*net.IPNet, 0, len(paths))
+
+	for _, entry := range paths {
+		resolvedRoutes = append(resolvedRoutes, bypassCIDRsForEntry(entry)...)
+	}
+
 	routesMu.Lock()
 	defer routesMu.Unlock()
 
-	paths := strings.Fields(cidrs)
-
-	for _, cidr := range paths {
-		mustCIDR(cidr)
-	}
+	defaultBypassCIDRs = resolvedRoutes
 
 	log.Infof("[Routing] Set defaultBypassCIDRs: %v", defaultBypassCIDRs)
 }
@@ -71,15 +66,36 @@ func ClearGeoRoutingConf() {
 	log.Infof("[Routing] Cleared defaultBypassCIDRs")
 }
 
+func bypassCIDRsForEntry(entry string) []*net.IPNet {
+	_, ipnet, err := net.ParseCIDR(entry)
+	if err == nil {
+		log.Infof("[Bypass] added %s", ipnet.String())
+		return []*net.IPNet{ipnet}
+	}
+
+	cidrs := resolveHostToCIDRs(entry)
+	if len(cidrs) == 0 {
+		log.Infof("[Bypass] no IPs resolved for %s", entry)
+		return nil
+	}
+	for _, c := range cidrs {
+		log.Infof("[Bypass] added %s for host %s", c.String(), entry)
+	}
+	return cidrs
+}
+
 func resolveHostToCIDRs(host string) []*net.IPNet {
 	resolver := net.Resolver{}
 
-	ctx := context.Background()
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	ips, err := resolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		log.Infof("[Bypass] resolve failed for %s: %v", host, err)
+		log.Infof("[Bypass] resolve failed for %s elapsedMs=%d err=%v", host, time.Since(start).Milliseconds(), err)
 		return nil
 	}
+	log.Infof("[Bypass] resolve OK host=%s count=%d elapsedMs=%d", host, len(ips), time.Since(start).Milliseconds())
 
 	var result []*net.IPNet
 	for _, ip := range ips {
@@ -92,21 +108,4 @@ func resolveHostToCIDRs(host string) []*net.IPNet {
 		result = append(result, n)
 	}
 	return result
-}
-
-func addBypassHost(host string) {
-	cidrs := resolveHostToCIDRs(host)
-	if len(cidrs) == 0 {
-		log.Infof("[Bypass] no IPs resolved for %s", host)
-		return
-	}
-
-	routesMu.Lock()
-	defer routesMu.Unlock()
-
-	defaultBypassCIDRs = append(defaultBypassCIDRs, cidrs...)
-
-	for _, c := range cidrs {
-		log.Infof("[Bypass] added %s for host %s", c.String(), host)
-	}
 }

--- a/go_module/tunnel/georouting_test.go
+++ b/go_module/tunnel/georouting_test.go
@@ -1,0 +1,63 @@
+package tunnel
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestSetGeoRoutingConfReplacesRoutes(t *testing.T) {
+	ClearGeoRoutingConf()
+	t.Cleanup(ClearGeoRoutingConf)
+
+	SetGeoRoutingConf("10.0.0.0/8")
+	assertBypassRouteCount(t, 1)
+
+	SetGeoRoutingConf("192.0.2.1/32")
+	assertBypassRouteCount(t, 1)
+
+	routesMu.RLock()
+	defer routesMu.RUnlock()
+
+	if !defaultBypassCIDRs[0].Contains(net.ParseIP("192.0.2.1")) {
+		t.Fatalf("expected replacement route to contain 192.0.2.1, got %v", defaultBypassCIDRs)
+	}
+	if defaultBypassCIDRs[0].Contains(net.ParseIP("10.1.2.3")) {
+		t.Fatalf("old route was retained after replacement: %v", defaultBypassCIDRs)
+	}
+}
+
+func TestSetGeoRoutingConfResolvesHostWithoutDeadlock(t *testing.T) {
+	ClearGeoRoutingConf()
+	t.Cleanup(ClearGeoRoutingConf)
+
+	done := make(chan struct{})
+	go func() {
+		SetGeoRoutingConf("localhost")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetGeoRoutingConf deadlocked while resolving host entry")
+	}
+
+	routesMu.RLock()
+	defer routesMu.RUnlock()
+
+	if len(defaultBypassCIDRs) == 0 {
+		t.Fatal("expected localhost to resolve to at least one bypass route")
+	}
+}
+
+func assertBypassRouteCount(t *testing.T, expected int) {
+	t.Helper()
+
+	routesMu.RLock()
+	defer routesMu.RUnlock()
+
+	if len(defaultBypassCIDRs) != expected {
+		t.Fatalf("expected %d bypass routes, got %d: %v", expected, len(defaultBypassCIDRs), defaultBypassCIDRs)
+	}
+}

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -251,14 +251,19 @@ public final class HealthCheckImpl: HealthCheck {
         logs.writeLog(log: "[HC] [diag] routed_non_dns_udp=\(nonDNSUDPOk)")
         groupResults["Routed non-DNS UDP group"] = nonDNSUDPOk
         if !nonDNSUDPOk {
-            let reason = nonDNSUDPDisabledByConfig
-                ? "disabledByConfig=true; Speedtest/QUIC UDP is expected to fail until transport UDP is enabled"
-                : "disabledByConfig=false; real UDP path is broken"
-            logs.writeLog(
-                log: "[HC] Group FAILED: Routed non-DNS UDP group " +
-                    "(\(reason))"
-            )
-            failedGroups.append("Routed non-DNS UDP group")
+            if nonDNSUDPDisabledByConfig {
+                logs.writeLog(
+                    log: "[HC] Group DIAGNOSTIC FAILED: Routed non-DNS UDP group " +
+                        "(disabledByConfig=true; not required for health; " +
+                        "Speedtest/QUIC UDP is expected to fail until transport UDP is enabled)"
+                )
+            } else {
+                logs.writeLog(
+                    log: "[HC] Group FAILED: Routed non-DNS UDP group " +
+                        "(disabledByConfig=false; real UDP path is broken)"
+                )
+                failedGroups.append("Routed non-DNS UDP group")
+            }
         } else {
             logs.writeLog(log: "[HC] Group OK: Routed non-DNS UDP group")
         }
@@ -271,6 +276,7 @@ public final class HealthCheckImpl: HealthCheck {
                 "upstreamProtected=\(lastProtectedServerOk) upstreamAddress=\(lastProtectedServerAddress) " +
                 "routedUdpDns=\(udpDNSOk) routedNonDnsUdp=\(nonDNSUDPOk) " +
                 "nonDnsUdpDisabledByConfig=\(nonDNSUDPDisabledByConfig) " +
+                "routedNonDnsUdpRequired=\(!nonDNSUDPDisabledByConfig) " +
                 "userStopRequested=\(isUserStopRequested())"
         )
 
@@ -305,6 +311,8 @@ public final class HealthCheckImpl: HealthCheck {
             dns: dnsOk,
             tcp443: tcp443Ok,
             outlineProxy: lastOutlineProxyOk,
+            upstreamProtected: lastProtectedServerOk,
+            upstreamAddress: lastProtectedServerAddress,
             https: httpsOk,
             nonDNSUDP: nonDNSUDPOk,
             nonDNSUDPDisabledByConfig: nonDNSUDPDisabledByConfig
@@ -331,12 +339,16 @@ public final class HealthCheckImpl: HealthCheck {
         dns: Bool,
         tcp443: Bool,
         outlineProxy: Bool,
+        upstreamProtected: Bool,
+        upstreamAddress: String,
         https: Bool,
         nonDNSUDP: Bool,
         nonDNSUDPDisabledByConfig: Bool
     ) {
         let diagnosis: String
-        if tunnelIP && tcpProxy && dns && tcp443 && outlineProxy && https && !nonDNSUDP && nonDNSUDPDisabledByConfig {
+        if tunnelIP && dns && outlineProxy && !upstreamProtected {
+            diagnosis = "SIDE: CLIENT/iOS ROUTING | REASON: protected upstream server check failed for \(upstreamAddress) - server dials are not reliably bypassing the packet tunnel; check effective_bypass verdict/localInterfaces"
+        } else if tunnelIP && tcpProxy && dns && tcp443 && outlineProxy && https && !nonDNSUDP && nonDNSUDPDisabledByConfig {
             diagnosis = "SIDE: CONFIG/TRANSPORT | REASON: TCP/DNS/HTTPS passed, but non-DNS UDP is disabled by current transport config — Speedtest/QUIC apps will fail by design"
         } else {
             switch (tunnelIP, tcpProxy, dns, tcp443, outlineProxy, https, nonDNSUDP) {

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -188,19 +188,26 @@ public class VpnManagerImpl: VpnManager {
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
         proto.serverAddress = currentServerAddress()
         proto.providerConfiguration = [:]
-        proto.includeAllNetworks = true
+        applyRoutingDefaults(proto: proto)
+        newVpnManager.protocolConfiguration = proto
+        newVpnManager.isEnabled = true
+        return newVpnManager
+    }
+
+    private func applyRoutingDefaults(proto: NETunnelProviderProtocol) {
+        // iOS 26: includeAllNetworks can scope protected upstream sockets back
+        // into the packet tunnel. Use explicit included/excluded routes from
+        // NEPacketTunnelNetworkSettings and enforce them instead.
+        proto.includeAllNetworks = false
         proto.excludeLocalNetworks = true
         if #available(iOS 16.4, *) {
             proto.excludeCellularServices = false
             proto.excludeAPNs = false
         }
-        proto.enforceRoutes = false
+        proto.enforceRoutes = true
         if #available(iOS 17.4, *) {
             proto.excludeDeviceCommunication = false
         }
-        newVpnManager.protocolConfiguration = proto
-        newVpnManager.isEnabled = true
-        return newVpnManager
     }
 
     private func applyProtocolDefaults(manager: NETunnelProviderManager) {
@@ -210,17 +217,13 @@ public class VpnManagerImpl: VpnManager {
         }
         proto.providerBundleIdentifier = Self.dobbyBundleIdentifier
         proto.serverAddress = currentServerAddress()
-        proto.includeAllNetworks = true
-        proto.excludeLocalNetworks = true
-        if #available(iOS 16.4, *) {
-            proto.excludeCellularServices = false
-            proto.excludeAPNs = false
-        }
-        proto.enforceRoutes = false
-        if #available(iOS 17.4, *) {
-            proto.excludeDeviceCommunication = false
-        }
+        applyRoutingDefaults(proto: proto)
         manager.protocolConfiguration = proto
+        logs.writeLog(
+            log: "applyProtocolDefaults: routing includeAllNetworks=\(proto.includeAllNetworks) " +
+                "enforceRoutes=\(proto.enforceRoutes) excludeLocalNetworks=\(proto.excludeLocalNetworks) " +
+                "serverAddress=\(proto.serverAddress ?? "nil")"
+        )
     }
 
     private func currentServerAddress() -> String {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -180,9 +180,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: initial interface detection")
             enterStage("geo routing config")
             let geoRoutingConf = configsRepository.getGeoRoutingConf()
-            logs.writeLog(log: "[DEBUG][Routing] applying geo routing config length=\(geoRoutingConf.count)")
-            Cloak_outlineSetGeoRoutingConf(geoRoutingConf)
-            logs.writeLog(log: "[DEBUG][Routing] geo routing config applied")
+            let configuredBypassCIDRs = geoRoutingConf
+                .split(whereSeparator: { $0.isWhitespace })
+                .map(String.init)
+            var engineBypassCIDRs = configuredBypassCIDRs
+            logs.writeLog(
+                log: "[DEBUG][Routing] loaded geo routing config " +
+                    "length=\(geoRoutingConf.count) cidrCount=\(configuredBypassCIDRs.count)"
+            )
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: geo routing config load")
 
             enterStage("route exclusions")
             let cloakConfig = configsRepository.getCloakConfig()
@@ -195,6 +201,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
                    let route = makeExcludedRoute(host: ip) {
                     excludedRoutes.append(route)
+                    engineBypassCIDRs.append("\(ip)/32")
                     routeDiagnosticParts.append("outlineHost=\(maskStr(value: trimmed)) outlineResolvedIPv4=\(maskStr(value: ip)) outlineExcludedRoute=\(ip)/32")
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Outline host: \(maskStr(value: ip))/32")
@@ -216,6 +223,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 if let ip = resolveIPv4IfNeededWithTimeout(trimmed, timeout: 1.0),
                    let route = makeExcludedRoute(host: ip) {
                     excludedRoutes.append(route)
+                    engineBypassCIDRs.append("\(ip)/32")
                     routeDiagnosticParts.append("cloakRemoteHost=\(maskStr(value: trimmed)) cloakResolvedIPv4=\(maskStr(value: ip)) cloakExcludedRoute=\(ip)/32")
                     if ip == trimmed {
                         logs.writeLog(log: "Excluded route for Cloak RemoteHost: \(maskStr(value: ip))/32")
@@ -235,8 +243,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let excludedRouteSummary = excludedRoutes.isEmpty
                 ? "(none)"
                 : excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ",")
+            var seenEngineBypassCIDRs = Set<String>()
+            engineBypassCIDRs = engineBypassCIDRs.filter { seenEngineBypassCIDRs.insert($0).inserted }
+            let engineBypassSummary = engineBypassCIDRs.isEmpty
+                ? "(none)"
+                : engineBypassCIDRs.joined(separator: ",")
             lastRouteDiagnostics = "excludedRoutes=\(excludedRouteSummary) " +
-                routeDiagnosticParts.joined(separator: " ")
+                routeDiagnosticParts.joined(separator: " ") +
+                " engineBypassCIDRs=\(engineBypassSummary)"
             if !excludedRoutes.isEmpty {
                 let list = excludedRoutes.map { "\($0.destinationAddress)/\($0.destinationSubnetMask)" }.joined(separator: ", ")
                 logs.writeLog(log: "Excluded IPv4 routes: \(list)")
@@ -244,6 +258,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 logs.writeLog(log: "Excluded IPv4 routes: (none)")
             }
             logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: route exclusions count=\(excludedRoutes.count)")
+            enterStage("engine bypass routing config")
+            let mergedEngineBypassConf = engineBypassCIDRs.joined(separator: " ")
+            logs.writeLog(
+                log: "[DEBUG][Routing] applying engine bypass routing " +
+                    "configuredCount=\(configuredBypassCIDRs.count) " +
+                    "totalCount=\(engineBypassCIDRs.count) cidrs=\(engineBypassSummary)"
+            )
+            Cloak_outlineSetGeoRoutingConf(mergedEngineBypassConf)
+            logs.writeLog(log: "[DEBUG][Routing] engine bypass routing config applied")
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel stage complete: engine bypass routing config")
 
             // Determine which protocol to use early - needed for Cloak startup
             let vpnInterface = configsRepository.getVpnInterface()


### PR DESCRIPTION
## Background

The latest iOS 26 log shows the NetworkExtension tunnel starts successfully, but the user data path is unhealthy:

- `setTunnelNetworkSettings` applies, PacketFlowBridge starts, Outline starts, and the UI logs `VPN connected`.
- Protected upstream dials to the VPN server still sometimes connect with local `198.18.0.1` on `utun6`.
- That produces `effective_bypass verdict=BYPASS_FAILED_TUNNEL_SOURCE`, meaning the socket that should bypass the VPN is routed back into the packet tunnel.
- When that leaked server-destined packet enters tun2socks, the router logs `PROXY route for IP: <server>`, which can recursively send the VPN server flow through the VPN server.
- Non-DNS UDP failure is expected for the current WebSocket transport because `disableNonDNSUDP=true`, but health was still counting that expected limitation as a required failure.

## Fix

- Change the iOS VPN profile routing defaults from `includeAllNetworks=true/enforceRoutes=false` to `includeAllNetworks=false/enforceRoutes=true`.
- Keep the PacketTunnel `NEIPv4Route.default()` route and explicit `/32` excluded server routes. With enforced routes, iOS should scope included routes to the VPN and excluded routes to the primary physical interface.
- Add the resolved Outline/Cloak upstream IPs to the Go/tun2socks engine bypass list as an extra safety net. If iOS still leaks a server-destined packet into the tunnel, the engine will not proxy that flow back through the VPN server.
- Change non-DNS UDP health classification: when `disableNonDNSUDP=true`, the STUN/Speedtest-style UDP probe remains logged but no longer fails overall health by itself.
- Improve health diagnosis so protected upstream bypass failure is explicitly reported as an iOS routing/protection issue.
- Fix a route-bypass setter deadlock risk: host entries are now resolved before taking the route mutex, and DNS resolution has a timeout.
- Bump native build marker to `ios-native/2026-05-06.1`.

## Expected Logs

Successful route setup should include:

- `applyProtocolDefaults: routing includeAllNetworks=false enforceRoutes=true`
- `route exclusion validation after settings: ... engineBypassCIDRs=<server>/32`
- `[Routing] Set defaultBypassCIDRs: ... <server>/32`
- Protected dials should show `effective_bypass verdict=BYPASS_OK local=<physical IP> localInterfaces=[en0...]`

If the fix does not work, the decisive failure will remain:

- `effective_bypass verdict=BYPASS_FAILED_TUNNEL_SOURCE local=198.18.0.1 localInterfaces=[utun...]`

That would mean iOS is still forcing protected server sockets into the packet tunnel despite enforced explicit routes and `IP_BOUND_IF`.

## Validation

- `go test ./tunnel ./outline ./core/pkg ./healthcheck` from `go_module`
- `git diff --check`

Not run locally:

- Swift/iOS build and `swiftlint`, because this Linux environment does not have the Apple toolchain or `swiftlint`.
- `go test ./ios_exports`, because this local module layout still lacks Cloak internal packages:
  - `github.com/cbeuw/Cloak/internal/client`
  - `github.com/cbeuw/Cloak/internal/common`
  - `github.com/cbeuw/Cloak/internal/multiplex`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enforced routes and server bypass routing capabilities.

* **Improvements**
  * Geo-routing now supports hostname resolution for bypass entries.
  * Enhanced health diagnostics with improved UDP routing path handling.
  * Updated default routing configuration for optimized network behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->