### PR TITLE
Add iOS 26 tunnel diagnostics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go_module/go.mod
-          cache-dependency-path: go_module/go.sum
+          cache: false
 
       - name: Run golangci-lint with reviewdog
         uses: reviewdog/action-golangci-lint@f9bba13753278f6a73b27a56a3ffb1bfda90ed71 # v2.8.0

--- a/go_module/cloak/client.go
+++ b/go_module/cloak/client.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cbeuw/Cloak/exported_client"
 	"go_module/common"
 	"net"
+	"runtime"
+	"runtime/debug"
 	"sync"
 
 	"go_module/log"
@@ -85,6 +87,14 @@ func StartCloakClient(localHost, localPort, config string, udp bool) {
 	err = common.Client.Connect(Name)
 	if err != nil {
 		log.Infof("cloak client: Failed to connect to cloak client - %v", err)
+		client = nil
+		if cloakConfig.RemoteHost != "" {
+			common.Client.MarkInCriticalSection(Name)
+			StopRoutingCloak(cloakConfig.RemoteHost)
+			common.Client.MarkOutOffCriticalSection(Name)
+			cloakConfig.RemoteHost = ""
+		}
+		common.Client.MarkInactive(Name)
 		return
 	}
 
@@ -132,6 +142,12 @@ func StopCloakClient() {
 	client = nil
 
 	log.Infof("Client disconnected")
+
+	// Explicitly reclaim memory after the Cloak session and stream buffers are gone.
+	// This is especially useful inside iOS Network Extensions with tight memory caps.
+	runtime.GC()
+	debug.FreeOSMemory()
+	log.Infof("StopCloakClient: memory released")
 }
 
 func resolveRemoteHostIfNeeded(host string) (string, error) {

--- a/go_module/cloak/client.go
+++ b/go_module/cloak/client.go
@@ -143,8 +143,6 @@ func StopCloakClient() {
 
 	log.Infof("Client disconnected")
 
-	// Explicitly reclaim memory after the Cloak session and stream buffers are gone.
-	// This is especially useful inside iOS Network Extensions with tight memory caps.
 	runtime.GC()
 	debug.FreeOSMemory()
 	log.Infof("StopCloakClient: memory released")

--- a/go_module/healthcheck/address_port_check.go
+++ b/go_module/healthcheck/address_port_check.go
@@ -2,14 +2,17 @@ package healthcheck
 
 import (
 	"errors"
-	"fmt"
+	"go_module/log"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 )
 
 func CheckServerAlive(address string, port int) error {
-	target := fmt.Sprintf("%s:%d", address, port)
+	target := net.JoinHostPort(address, strconv.Itoa(port))
+	start := time.Now()
+	log.Infof("[HealthCheck] CheckServerAlive begin target=%s attempts=3 timeout=1s", target)
 
 	d := net.Dialer{
 		Timeout:   1 * time.Second,
@@ -19,19 +22,53 @@ func CheckServerAlive(address string, port int) error {
 	var lastErr error
 
 	for i := 0; i < 3; i++ {
+		attemptStart := time.Now()
+		log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s dial_begin", i+1, target)
 		conn, err := d.Dial("tcp", target)
 		if err != nil {
 			lastErr = err
+			log.Infof(
+				"[HealthCheck] CheckServerAlive attempt=%d target=%s dial_failed elapsedMs=%d err=%v",
+				i+1,
+				target,
+				time.Since(attemptStart).Milliseconds(),
+				err,
+			)
 			if strings.Contains(err.Error(), "refused") {
+				log.Infof("[HealthCheck] CheckServerAlive target=%s refusing immediately err=%v", target, err)
 				return err
 			}
 			continue
 		}
+		log.Infof(
+			"[HealthCheck] CheckServerAlive attempt=%d target=%s dial_ok local=%s remote=%s elapsedMs=%d",
+			i+1,
+			target,
+			conn.LocalAddr(),
+			conn.RemoteAddr(),
+			time.Since(attemptStart).Milliseconds(),
+		)
 
 		func() {
-			defer func() { _ = conn.Close() }()
+			defer func() {
+				if closeErr := conn.Close(); closeErr != nil {
+					log.Infof(
+						"[HealthCheck] CheckServerAlive attempt=%d target=%s close_failed err=%v",
+						i+1,
+						target,
+						closeErr,
+					)
+				} else {
+					log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s close_ok", i+1, target)
+				}
+			}()
 
-			_ = conn.SetDeadline(time.Now().Add(1 * time.Second))
+			if err := conn.SetDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				lastErr = err
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s set_deadline_failed err=%v", i+1, target, err)
+				return
+			}
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_begin bytes=1", i+1, target)
 
 			// We intentionally perform both Write and Read in addition to Dial.
 			//
@@ -53,29 +90,41 @@ func CheckServerAlive(address string, port int) error {
 
 			if _, writeErr := conn.Write([]byte{0x00}); writeErr != nil {
 				lastErr = writeErr
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_failed err=%v", i+1, target, writeErr)
 				return
 			}
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s write_probe_ok read_probe_begin bytes=1", i+1, target)
 
 			buf := make([]byte, 1)
-			_, readErr := conn.Read(buf)
+			n, readErr := conn.Read(buf)
 			if readErr != nil {
 				var ne net.Error
 				if errors.As(readErr, &ne) && ne.Timeout() {
 					lastErr = nil
+					log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_timeout_treated_alive", i+1, target)
 					return
 				}
 
 				lastErr = readErr
+				log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_failed err=%v", i+1, target, readErr)
 				return
 			}
 
 			lastErr = nil
+			log.Infof("[HealthCheck] CheckServerAlive attempt=%d target=%s read_probe_ok bytes=%d", i+1, target, n)
 		}()
 
 		if lastErr == nil {
+			log.Infof(
+				"[HealthCheck] CheckServerAlive OK target=%s attempt=%d totalElapsedMs=%d",
+				target,
+				i+1,
+				time.Since(start).Milliseconds(),
+			)
 			return nil
 		}
 	}
 
+	log.Infof("[HealthCheck] CheckServerAlive failed target=%s totalElapsedMs=%d lastErr=%v", target, time.Since(start).Milliseconds(), lastErr)
 	return lastErr
 }

--- a/go_module/healthcheck/tcp_ping.go
+++ b/go_module/healthcheck/tcp_ping.go
@@ -1,13 +1,11 @@
 package healthcheck
 
 import (
-	"context"
 	"time"
 
 	"github.com/matsuridayo/libneko/speedtest"
 
 	"go_module/log"
-	"go_module/tunnel/protected_dialer"
 )
 
 const (

--- a/go_module/healthcheck/tcp_ping.go
+++ b/go_module/healthcheck/tcp_ping.go
@@ -25,27 +25,3 @@ func TCPPing(address string) (int32, error) {
 	log.Infof("[HealthCheck] TCPPing OK address=%s retMs=%d elapsedMs=%d", address, ret, time.Since(start).Milliseconds())
 	return ret, nil
 }
-
-func ProtectedTCPPing(address string) (int32, error) {
-	start := time.Now()
-	log.Infof("[HealthCheck] ProtectedTCPPing begin address=%s timeoutMs=%d", address, pingTimeoutMilliseconds)
-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeoutMilliseconds*time.Millisecond)
-	defer cancel()
-
-	conn, err := protected_dialer.DialContextWithProtect(ctx, "tcp", address)
-	if err != nil {
-		log.Infof("[HealthCheck] ProtectedTCPPing failed address=%s elapsedMs=%d err=%v", address, time.Since(start).Milliseconds(), err)
-		return -1, err
-	}
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			log.Infof("[HealthCheck] ProtectedTCPPing close_failed address=%s err=%v", address, closeErr)
-		} else {
-			log.Infof("[HealthCheck] ProtectedTCPPing close_ok address=%s", address)
-		}
-	}()
-
-	elapsed := int32(time.Since(start).Milliseconds())
-	log.Infof("[HealthCheck] ProtectedTCPPing OK address=%s local=%s remote=%s elapsedMs=%d", address, conn.LocalAddr(), conn.RemoteAddr(), elapsed)
-	return elapsed, nil
-}

--- a/go_module/healthcheck/tcp_ping.go
+++ b/go_module/healthcheck/tcp_ping.go
@@ -1,7 +1,13 @@
 package healthcheck
 
 import (
+	"context"
+	"time"
+
 	"github.com/matsuridayo/libneko/speedtest"
+
+	"go_module/log"
+	"go_module/tunnel/protected_dialer"
 )
 
 const (
@@ -9,5 +15,37 @@ const (
 )
 
 func TCPPing(address string) (int32, error) {
-	return speedtest.TcpPing(address, pingTimeoutMilliseconds)
+	start := time.Now()
+	log.Infof("[HealthCheck] TCPPing begin address=%s timeoutMs=%d", address, pingTimeoutMilliseconds)
+	ret, err := speedtest.TcpPing(address, pingTimeoutMilliseconds)
+	if err != nil {
+		log.Infof("[HealthCheck] TCPPing failed address=%s elapsedMs=%d err=%v", address, time.Since(start).Milliseconds(), err)
+		return ret, err
+	}
+	log.Infof("[HealthCheck] TCPPing OK address=%s retMs=%d elapsedMs=%d", address, ret, time.Since(start).Milliseconds())
+	return ret, nil
+}
+
+func ProtectedTCPPing(address string) (int32, error) {
+	start := time.Now()
+	log.Infof("[HealthCheck] ProtectedTCPPing begin address=%s timeoutMs=%d", address, pingTimeoutMilliseconds)
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeoutMilliseconds*time.Millisecond)
+	defer cancel()
+
+	conn, err := protected_dialer.DialContextWithProtect(ctx, "tcp", address)
+	if err != nil {
+		log.Infof("[HealthCheck] ProtectedTCPPing failed address=%s elapsedMs=%d err=%v", address, time.Since(start).Milliseconds(), err)
+		return -1, err
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Infof("[HealthCheck] ProtectedTCPPing close_failed address=%s err=%v", address, closeErr)
+		} else {
+			log.Infof("[HealthCheck] ProtectedTCPPing close_ok address=%s", address)
+		}
+	}()
+
+	elapsed := int32(time.Since(start).Milliseconds())
+	log.Infof("[HealthCheck] ProtectedTCPPing OK address=%s local=%s remote=%s elapsedMs=%d", address, conn.LocalAddr(), conn.RemoteAddr(), elapsed)
+	return elapsed, nil
 }

--- a/go_module/ios_exports/cloak.go
+++ b/go_module/ios_exports/cloak.go
@@ -1,13 +1,21 @@
 package cloak_outline
 
 import (
-    "go_module/cloak"
+	"go_module/cloak"
+	"go_module/log"
+	"time"
 )
 
 func StartCloakClient(localHost string, localPort string, config string, udp bool) {
-    cloak.StartCloakClient(localHost, localPort, config, udp)
+	start := time.Now()
+	log.Infof("[ios_exports] StartCloakClient begin localHost=%s localPort=%s config.len=%d udp=%v", localHost, localPort, len(config), udp)
+	cloak.StartCloakClient(localHost, localPort, config, udp)
+	log.Infof("[ios_exports] StartCloakClient returned elapsed=%s", time.Since(start))
 }
 
 func StopCloakClient() {
-    cloak.StopCloakClient()
+	start := time.Now()
+	log.Infof("[ios_exports] StopCloakClient begin")
+	cloak.StopCloakClient()
+	log.Infof("[ios_exports] StopCloakClient returned elapsed=%s", time.Since(start))
 }

--- a/go_module/ios_exports/guard.go
+++ b/go_module/ios_exports/guard.go
@@ -1,9 +1,19 @@
 package cloak_outline
 
 import (
+	"fmt"
 	"go_module/log"
 	"runtime/debug"
 )
+
+func init() {
+	// iOS Network Extensions are typically killed above ~50 MB of physical memory.
+	// A 35 MB soft limit tells the Go GC to run aggressively before we hit that ceiling.
+	// Combined with a lower GOGC, this reduces peak heap at the cost of slightly more
+	// frequent (but shorter) GC pauses - an acceptable trade-off inside a VPN extension.
+	debug.SetMemoryLimit(35 * 1024 * 1024)
+	debug.SetGCPercent(50)
+}
 
 // guard logs panics at the gomobile boundary so the iOS tunnel doesn't "silently die".
 // Note: panics in Go called from Swift/NEPacketTunnelProvider can terminate the extension
@@ -16,12 +26,25 @@ func guard(fn string) func() {
 	}
 }
 
+func guardErr(fn string, errp *error) func() {
+	return func() {
+		if r := recover(); r != nil {
+			msg := fmt.Sprintf("[ios_exports] panic in %s: %v", fn, r)
+			log.Infof("%s\n%s", msg, string(debug.Stack()))
+			if errp != nil {
+				*errp = fmt.Errorf("%s", msg)
+			}
+		}
+	}
+}
 
-func init() {
-	// iOS Network Extensions are typically killed above ~50 MB of physical memory.
-	// A 35 MB soft limit tells the Go GC to run aggressively before we hit that ceiling.
-	// Combined with a lower GOGC, this reduces peak heap at the cost of slightly more
-	// frequent (but shorter) GC pauses — an acceptable trade-off inside a VPN extension.
-	debug.SetMemoryLimit(35 * 1024 * 1024)
-	debug.SetGCPercent(50)
+func guardStatus(fn string, statusp *int32) func() {
+	return func() {
+		if r := recover(); r != nil {
+			log.Infof("[ios_exports] panic in %s: %v\n%s", fn, r, string(debug.Stack()))
+			if statusp != nil {
+				*statusp = -1
+			}
+		}
+	}
 }

--- a/go_module/ios_exports/health_check.go
+++ b/go_module/ios_exports/health_check.go
@@ -17,18 +17,6 @@ func TcpPing(address string) (ret int32, err error) {
 	return ret, nil
 }
 
-func ProtectedTcpPing(address string) (ret int32, err error) {
-	defer guardErr("ProtectedTcpPing", &err)()
-	log.Infof("[ios_exports] ProtectedTcpPing begin address=%s", address)
-	ret, err = healthcheck.ProtectedTCPPing(address)
-	if err != nil {
-		log.Infof("[ios_exports] ProtectedTcpPing failed address=%s err=%v", address, err)
-		return ret, err
-	}
-	log.Infof("[ios_exports] ProtectedTcpPing OK address=%s ms=%d", address, ret)
-	return ret, nil
-}
-
 func UrlTest(url string, standard int) (ret int32, err error) {
 	defer guardErr("UrlTest", &err)()
 	log.Infof("[ios_exports] UrlTest begin url=%s standard=%d", url, standard)

--- a/go_module/ios_exports/health_check.go
+++ b/go_module/ios_exports/health_check.go
@@ -5,22 +5,51 @@ import (
 	"go_module/log"
 )
 
-func TcpPing(address string) (int32, error) {
-	defer guard("TcpPing")()
-	return healthcheck.TCPPing(address)
+func TcpPing(address string) (ret int32, err error) {
+	defer guardErr("TcpPing", &err)()
+	log.Infof("[ios_exports] TcpPing begin address=%s", address)
+	ret, err = healthcheck.TCPPing(address)
+	if err != nil {
+		log.Infof("[ios_exports] TcpPing failed address=%s err=%v", address, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] TcpPing OK address=%s ms=%d", address, ret)
+	return ret, nil
 }
 
-func UrlTest(url string, standard int) (int32, error) {
-	defer guard("UrlTest")()
-	return healthcheck.URLTest(url, standard)
+func ProtectedTcpPing(address string) (ret int32, err error) {
+	defer guardErr("ProtectedTcpPing", &err)()
+	log.Infof("[ios_exports] ProtectedTcpPing begin address=%s", address)
+	ret, err = healthcheck.ProtectedTCPPing(address)
+	if err != nil {
+		log.Infof("[ios_exports] ProtectedTcpPing failed address=%s err=%v", address, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] ProtectedTcpPing OK address=%s ms=%d", address, ret)
+	return ret, nil
 }
 
-func CheckServerAlive(address string, port int) int32 {
-	defer guard("CheckServerAlive")()
+func UrlTest(url string, standard int) (ret int32, err error) {
+	defer guardErr("UrlTest", &err)()
+	log.Infof("[ios_exports] UrlTest begin url=%s standard=%d", url, standard)
+	ret, err = healthcheck.URLTest(url, standard)
+	if err != nil {
+		log.Infof("[ios_exports] UrlTest failed url=%s standard=%d err=%v", url, standard, err)
+		return ret, err
+	}
+	log.Infof("[ios_exports] UrlTest OK url=%s standard=%d ms=%d", url, standard, ret)
+	return ret, nil
+}
+
+func CheckServerAlive(address string, port int) (status int32) {
+	status = -1
+	defer guardStatus("CheckServerAlive", &status)()
+	log.Infof("[ios_exports] CheckServerAlive begin address=%s port=%d", address, port)
 	res := healthcheck.CheckServerAlive(address, port)
-	log.Infof("Health check result: %v", res)
 	if res == nil {
+		log.Infof("[ios_exports] CheckServerAlive OK address=%s port=%d", address, port)
 		return 0
 	}
+	log.Infof("[ios_exports] CheckServerAlive failed address=%s port=%d err=%v", address, port, res)
 	return -1
 }

--- a/go_module/outline/client_mobile.go
+++ b/go_module/outline/client_mobile.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"time"
 )
 
 type OutlineClient struct {
@@ -27,24 +28,26 @@ func NewClient(transportConfig string, tun io.ReadWriteCloser) *OutlineClient {
 		config: transportConfig,
 		tun:    tun,
 	}
-	log.Infof("outline client created (tun2socks version)")
+	log.Infof("outline client created (tun2socks version) config.len=%d tunType=%T", len(transportConfig), tun)
 	common.Client.SetVpnClient(outlineCommon.Name, c)
 	return c
 }
 
 func (c *OutlineClient) Connect() error {
+	start := time.Now()
 	defer func() {
 		if r := recover(); r != nil {
-			log.Infof("RECOVERED from fail in Connect: %v", r)
+			log.Infof("RECOVERED from fail in Connect after %s: %v", time.Since(start), r)
 		}
 	}()
+	log.Infof("outline Connect begin config.len=%d tunType=%T", len(c.config), c.tun)
 	od, err := internal.NewOutlineDevice(c.config)
 	if err != nil {
-		log.Infof("failed to create outline device: %v\n", err)
+		log.Infof("failed to create outline device after %s: %v\n", time.Since(start), err)
 		return err
 	}
 
-	log.Infof("outline device (SOCKS5 bridge) created")
+	log.Infof("outline device (SOCKS5 bridge) created proxy=%s serverIP=%v elapsed=%s", od.GetProxyAddr(), od.GetServerIP(), time.Since(start))
 	c.device = od
 
 	var fd int
@@ -53,39 +56,46 @@ func (c *OutlineClient) Connect() error {
 		err := unix.SetNonblock(fd, true)
 		if err != nil {
 			log.Infof("Set unix.SetNonblock error: %v", err)
+		} else {
+			log.Infof("Set unix.SetNonblock OK fd=%d", fd)
 		}
 	} else {
 		log.Infof("failed to get FD from tun: not an *os.File")
 		return fmt.Errorf("invalid tun device type")
 	}
 
-	log.Infof("starting tun2socks engine with proxy %s", od.GetProxyAddr())
+	log.Infof("starting tun2socks engine with proxy %s fd=%d", od.GetProxyAddr(), fd)
 	err = tunnel.StartEngine(platform_engine.EngineConfig{
 		ProxyAddr:   od.GetProxyAddr(),
 		FD:          fd,
 		UplinkIface: "",
 	})
 	if err != nil {
-		log.Infof("Can't start tun2socks: %v", err)
+		log.Infof("Can't start tun2socks after %s: %v", time.Since(start), err)
 		return err
 	}
 
 	common.Client.MarkActive(outlineCommon.Name)
-	log.Infof("outline client connected successfully via tun2socks")
+	log.Infof("outline client connected successfully via tun2socks elapsed=%s", time.Since(start))
 	return nil
 }
 
 func (c *OutlineClient) Disconnect() error {
+	start := time.Now()
+	log.Infof("outline Disconnect begin deviceNil=%v", c.device == nil)
+	log.Infof("outline Disconnect stopping tun2socks engine")
 	tunnel.StopEngine()
+	log.Infof("outline Disconnect tun2socks engine stopped elapsed=%s", time.Since(start))
 
 	if c.device != nil {
+		log.Infof("outline Disconnect closing outline device proxy=%s", c.device.GetProxyAddr())
 		if err := c.device.Close(); err != nil {
 			log.Infof("failed to close outline device: %v\n", err)
 		}
 		c.device = nil
 	}
 
-	log.Infof("outline client disconnected")
+	log.Infof("outline client disconnected elapsed=%s", time.Since(start))
 	common.Client.MarkInactive(outlineCommon.Name)
 	return nil
 }

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
@@ -24,6 +25,19 @@ type OutlineDevice struct {
 	streamDialer transport.StreamDialer
 	packetDialer transport.PacketDialer
 	useCloak     bool
+	websocket    bool
+	hasTCPPath   bool
+	hasUDPPath   bool
+	startedAt    time.Time
+
+	tcpDialAttempt  atomic.Uint64
+	tcpDialOK       atomic.Uint64
+	tcpDialErr      atomic.Uint64
+	udpDialAttempt  atomic.Uint64
+	udpDialOK       atomic.Uint64
+	udpDialErr      atomic.Uint64
+	udpDNSTruncated atomic.Uint64
+	unsupportedDial atomic.Uint64
 }
 
 func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
@@ -46,7 +60,20 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	}
 
 	useCloak := ip.IsLoopback()
+	isWebSocket := strings.Contains(transportConfig, "ws:")
+	hasTCPPath := strings.Contains(transportConfig, "tcp_path=")
+	hasUDPPath := strings.Contains(transportConfig, "udp_path=")
 
+	log.Infof(
+		"outline client: transport summary len=%d serverIP=%s websocket=%v tcpPath=%v udpPath=%v streamDialer=%T packetDialer=%T",
+		len(transportConfig),
+		ip.String(),
+		isWebSocket,
+		hasTCPPath,
+		hasUDPPath,
+		sd,
+		pd,
+	)
 	log.Infof("outline client: cloak mode = %v", useCloak)
 
 	od := &OutlineDevice{
@@ -54,10 +81,15 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 		streamDialer: sd,
 		packetDialer: pd,
 		useCloak:     useCloak,
+		websocket:    isWebSocket,
+		hasTCPPath:   hasTCPPath,
+		hasUDPPath:   hasUDPPath,
+		startedAt:    time.Now(),
 	}
 
 	server := socks5.NewServer(
 		socks5.WithDial(od.handleDial),
+		socks5.WithLogger(socksLogger{}),
 	)
 
 	lc := net.ListenConfig{}
@@ -73,16 +105,48 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	go func() {
 		log.Infof("SOCKS5 started on %s", od.proxyAddr)
 		if err := server.Serve(listener); err != nil {
-			log.Infof("SOCKS5 stopped: %v", err)
+			if errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "use of closed network connection") {
+				log.Infof("SOCKS5 stopped on %s: closed", od.proxyAddr)
+			} else {
+				log.Infof("SOCKS5 stopped unexpectedly on %s: %v", od.proxyAddr, err)
+			}
 		}
 	}()
 
 	return od, nil
 }
 
+type socksLogger struct{}
+
+func (socksLogger) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "client want to used addr") {
+		return
+	}
+	log.Infof("[SOCKS5 internal] %s", msg)
+}
+
 func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (net.Conn, error) {
 
-	log.Infof("[SOCKS5] dial %s %s", network, addr)
+	start := time.Now()
+	serverIP := "<nil>"
+	if d.svrIP != nil {
+		serverIP = d.svrIP.String()
+	}
+
+	log.Infof(
+		"[SOCKS5] dial network=%s addr=%s via server=%s websocket=%v tcpPath=%v udpPath=%v cloak=%v stats={%s}",
+		network,
+		addr,
+		serverIP,
+		d.websocket,
+		d.hasTCPPath,
+		d.hasUDPPath,
+		d.useCloak,
+		d.dialStats(),
+	)
 
 	host, portStr, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(portStr)
@@ -90,36 +154,61 @@ func (d *OutlineDevice) handleDial(ctx context.Context, network, addr string) (n
 	switch network {
 
 	case "tcp":
+		attempt := d.tcpDialAttempt.Add(1)
 		conn, err := d.streamDialer.DialStream(ctx, addr)
 		if err != nil {
-			log.Infof("[SOCKS5 TCP ERROR] %v", err)
+			d.tcpDialErr.Add(1)
+			log.Infof("[SOCKS5 TCP ERROR] attempt=%d dst=%s server=%s elapsed=%s stats={%s} err=%v", attempt, addr, serverIP, time.Since(start), d.dialStats(), err)
 			return nil, err
 		}
 
-		log.Infof("[SOCKS5 TCP OK] %s", addr)
+		d.tcpDialOK.Add(1)
+		log.Infof("[SOCKS5 TCP OK] attempt=%d dst=%s server=%s elapsed=%s local=%s remote=%s stats={%s}", attempt, addr, serverIP, time.Since(start), conn.LocalAddr(), conn.RemoteAddr(), d.dialStats())
 		return conn, nil
 
 	case "udp":
+		attempt := d.udpDialAttempt.Add(1)
 
 		// DNS fallback for Cloak
 		if d.useCloak && port == 53 {
+			d.udpDNSTruncated.Add(1)
 
-			log.Infof("[SOCKS5 DNS] returning truncated DNS (cloak mode)")
+			log.Infof("[SOCKS5 DNS] returning truncated DNS attempt=%d addr=%s cloak=%v stats={%s}", attempt, addr, d.useCloak, d.dialStats())
 
 			return newTruncatedDNSConn(host, port), nil
 		}
 
 		conn, err := d.packetDialer.DialPacket(ctx, addr)
 		if err != nil {
-			log.Infof("[SOCKS5 UDP ERROR] %v", err)
+			d.udpDialErr.Add(1)
+			log.Infof("[SOCKS5 UDP ERROR] attempt=%d dst=%s server=%s elapsed=%s stats={%s} err=%v", attempt, addr, serverIP, time.Since(start), d.dialStats(), err)
 			return nil, err
 		}
 
-		log.Infof("[SOCKS5 UDP OK] %s", addr)
+		d.udpDialOK.Add(1)
+		log.Infof("[SOCKS5 UDP OK] attempt=%d dst=%s server=%s elapsed=%s local=%s stats={%s}", attempt, addr, serverIP, time.Since(start), conn.LocalAddr(), d.dialStats())
 		return conn, nil
 	}
 
-	return nil, fmt.Errorf("unsupported network %s", network)
+	err := fmt.Errorf("unsupported network %s", network)
+	d.unsupportedDial.Add(1)
+	log.Infof("[SOCKS5 ERROR] dst=%s server=%s elapsed=%s err=%v", addr, serverIP, time.Since(start), err)
+	return nil, err
+}
+
+func (d *OutlineDevice) dialStats() string {
+	return fmt.Sprintf(
+		"uptime=%s tcp=%d/%d/%d udp=%d/%d/%d udpDNSTrunc=%d unsupported=%d",
+		time.Since(d.startedAt).Truncate(time.Millisecond),
+		d.tcpDialAttempt.Load(),
+		d.tcpDialOK.Load(),
+		d.tcpDialErr.Load(),
+		d.udpDialAttempt.Load(),
+		d.udpDialOK.Load(),
+		d.udpDialErr.Load(),
+		d.udpDNSTruncated.Load(),
+		d.unsupportedDial.Load(),
+	)
 }
 
 type truncatedDNSConn struct {
@@ -195,6 +284,7 @@ func ResolveServerIPFromConfig(transportConfig string) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("outline client: DNS returned %d addresses for %s", len(ipList), host)
 
 	for _, ip := range ipList {
 		if v4 := ip.IP.To4(); v4 != nil {
@@ -261,6 +351,7 @@ func (d *OutlineDevice) GetProxyAddr() string {
 }
 
 func (d *OutlineDevice) Close() error {
+	log.Infof("SOCKS5 close requested proxy=%s stats={%s}", d.proxyAddr, d.dialStats())
 	if d.listener != nil {
 		return d.listener.Close()
 	}

--- a/go_module/tunnel/platform_engine/engine_fd.go
+++ b/go_module/tunnel/platform_engine/engine_fd.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/xjasonlyu/tun2socks/v2/engine"
+
+	"go_module/log"
 )
 
 func startPlatformEngine(cfg interface{}) error {
@@ -20,9 +22,14 @@ func startPlatformEngine(cfg interface{}) error {
 		MTU:      1500,
 	}
 
+	log.Infof("[Engine][FD] Insert key proxy=%s device=fd://%d mtu=%d", proxyAddr, fd, key.MTU)
 	engine.Insert(key)
+	log.Infof("[Engine][FD] Start begin")
 	engine.Start()
+	log.Infof("[Engine][FD] Start returned")
 	return nil
 }
 
-func stopPlatformEngine() {}
+func stopPlatformEngine() {
+	log.Infof("[Engine][FD] platform stop hook")
+}

--- a/go_module/tunnel/protected_dialer/dialer.go
+++ b/go_module/tunnel/protected_dialer/dialer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"syscall"
+	"time"
 
 	M "github.com/xjasonlyu/tun2socks/v2/metadata"
 	"github.com/xjasonlyu/tun2socks/v2/proxy"
@@ -51,34 +52,61 @@ func listenAddr(network string) string {
 
 func DialContextWithProtect(ctx context.Context, network, address string) (net.Conn, error) {
 	realNet := normalizeTCP(address)
+	start := time.Now()
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s protector=%T", network, realNet, address, deadline.Format(time.RFC3339Nano), protector)
+	} else {
+		log.Infof("[Protect] TCP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none) protector=%T", network, realNet, address, protector)
+	}
 
 	if isLoopback(address) {
 		log.Infof("[Protect] TCP BYPASS loopback: %s", address)
 		var d net.Dialer
-		return d.DialContext(ctx, realNet, address)
+		conn, err := d.DialContext(ctx, realNet, address)
+		if err != nil {
+			log.Infof("[Protect] TCP BYPASS loopback failed network=%s dest=%s elapsed=%s err=%v", realNet, address, time.Since(start), err)
+			return nil, err
+		}
+		log.Infof("[Protect] TCP BYPASS loopback OK network=%s dest=%s elapsed=%s local=%s remote=%s", realNet, address, time.Since(start), conn.LocalAddr(), conn.RemoteAddr())
+		return conn, nil
 	}
 
 	d := &net.Dialer{
 		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				if protector != nil {
-					protector.Protect(fd, realNet)
+			err := c.Control(func(fd uintptr) {
+				if protector == nil {
+					log.Infof("[Protect] WARNING: no socket protector registered network=%s fd=%d destination=%s", realNet, fd, address)
+					return
 				}
+				log.Infof("[Protect] protect_begin network=%s fd=%d destination=%s protector=%T", realNet, fd, address, protector)
+				protector.Protect(fd, realNet)
+				log.Infof("[Protect] protect_end network=%s fd=%d destination=%s protector=%T", realNet, fd, address, protector)
 			})
+			if err != nil {
+				log.Infof("[Protect] TCP control error network=%s dest=%s err=%v", realNet, address, err)
+			}
+			return err
 		},
 	}
 
 	conn, err := d.DialContext(ctx, realNet, address)
 	if err != nil {
-		log.Infof("[Protect] TCP dial error: %v", err)
+		log.Infof("[Protect] TCP dial FAILED dest=%s elapsed=%s err=%v", address, time.Since(start), err)
 		return nil, err
 	}
 
+	log.Infof("[Protect] TCP dial OK dest=%s elapsed=%s local=%s remote=%s", address, time.Since(start), conn.LocalAddr(), conn.RemoteAddr())
 	return conn, nil
 }
 
 func DialUDPWithProtect(ctx context.Context, network, address string) (net.PacketConn, error) {
 	realNet := normalizeUDP(address)
+	start := time.Now()
+	if deadline, ok := ctx.Deadline(); ok {
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=%s protector=%T", network, realNet, address, deadline.Format(time.RFC3339Nano), protector)
+	} else {
+		log.Infof("[Protect] UDP dial begin requestedNetwork=%s realNetwork=%s dest=%s deadline=(none) protector=%T", network, realNet, address, protector)
+	}
 
 	if isLoopback(address) {
 		log.Infof("[Protect] UDP BYPASS loopback: %s", address)
@@ -87,15 +115,20 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 		pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 		if err != nil {
+			log.Infof("[Protect] UDP BYPASS loopback listen error network=%s destination=%s elapsed=%s err=%v", realNet, address, time.Since(start), err)
 			return nil, err
 		}
 
 		udpAddr, err := net.ResolveUDPAddr(realNet, address)
 		if err != nil {
-			_ = pc.Close()
+			if closeErr := pc.Close(); closeErr != nil {
+				log.Infof("[Protect] UDP BYPASS loopback close after resolve error failed network=%s destination=%s closeErr=%v", realNet, address, closeErr)
+			}
+			log.Infof("[Protect] UDP BYPASS loopback resolve error network=%s destination=%s elapsed=%s err=%v", realNet, address, time.Since(start), err)
 			return nil, err
 		}
 
+		log.Infof("[Protect] UDP BYPASS loopback OK network=%s destination=%s elapsed=%s local=%s remote=%s", realNet, address, time.Since(start), pc.LocalAddr(), udpAddr)
 		return &connectedUDPConn{
 			PacketConn: pc,
 			remoteAddr: udpAddr,
@@ -104,25 +137,38 @@ func DialUDPWithProtect(ctx context.Context, network, address string) (net.Packe
 
 	lc := net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				if protector != nil {
-					protector.Protect(fd, realNet)
+			err := c.Control(func(fd uintptr) {
+				if protector == nil {
+					log.Infof("[Protect] WARNING: no socket protector registered network=%s fd=%d destination=%s", realNet, fd, address)
+					return
 				}
+				log.Infof("[Protect] protect_begin network=%s fd=%d destination=%s protector=%T", realNet, fd, address, protector)
+				protector.Protect(fd, realNet)
+				log.Infof("[Protect] protect_end network=%s fd=%d destination=%s protector=%T", realNet, fd, address, protector)
 			})
+			if err != nil {
+				log.Infof("[Protect] UDP control error network=%s dest=%s err=%v", realNet, address, err)
+			}
+			return err
 		},
 	}
 
 	pc, err := lc.ListenPacket(ctx, realNet, listenAddr(realNet))
 	if err != nil {
+		log.Infof("[Protect] UDP listen error network=%s destination=%s elapsed=%s err=%v", realNet, address, time.Since(start), err)
 		return nil, err
 	}
 
 	udpAddr, err := net.ResolveUDPAddr(realNet, address)
 	if err != nil {
-		_ = pc.Close()
+		if closeErr := pc.Close(); closeErr != nil {
+			log.Infof("[Protect] UDP close after resolve error failed network=%s destination=%s closeErr=%v", realNet, address, closeErr)
+		}
+		log.Infof("[Protect] UDP resolve error network=%s destination=%s elapsed=%s err=%v", realNet, address, time.Since(start), err)
 		return nil, err
 	}
 
+	log.Infof("[Protect] UDP dial OK network=%s destination=%s elapsed=%s local=%s remote=%s", realNet, address, time.Since(start), pc.LocalAddr(), udpAddr)
 	return &connectedUDPConn{
 		PacketConn: pc,
 		remoteAddr: udpAddr,

--- a/go_module/tunnel/protected_dialer/protect_ios.go
+++ b/go_module/tunnel/protected_dialer/protect_ios.go
@@ -1,15 +1,41 @@
 package protected_dialer
 
-import "syscall"
+import (
+	"fmt"
+	"net"
+	"strings"
+	"syscall"
+
+	"go_module/log"
+)
 
 const SO_NO_TC_NETPOLICY = 0x1101
 
 type iosProtector struct{}
 
 func (i *iosProtector) Protect(fd uintptr, network string) {
-	_ = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
+	err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_NO_TC_NETPOLICY, 1)
+	if err != nil {
+		log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY failed fd=%d network=%s err=%v interfaces=[%s]", fd, network, err, describeInterfacesForLog())
+		return
+	}
+	log.Infof("[iOS-Protect] SO_NO_TC_NETPOLICY success fd=%d network=%s interfaces=[%s]", fd, network, describeInterfacesForLog())
+}
+
+func describeInterfacesForLog() string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Sprintf("scan_error=%v", err)
+	}
+
+	parts := make([]string, 0, len(interfaces))
+	for _, iface := range interfaces {
+		parts = append(parts, fmt.Sprintf("%s(index=%d flags=%s mtu=%d)", iface.Name, iface.Index, iface.Flags.String(), iface.MTU))
+	}
+	return strings.Join(parts, ";")
 }
 
 func init() {
 	protector = &iosProtector{}
+	log.Infof("[iOS-Protect] Initialized with SO_NO_TC_NETPOLICY diagnostics")
 }

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	M "github.com/xjasonlyu/tun2socks/v2/metadata"
 	"github.com/xjasonlyu/tun2socks/v2/proxy"
@@ -22,26 +24,98 @@ var (
 )
 
 type DobbyProxy struct {
-	vpn    proxy.Proxy
-	direct proxy.Proxy
+	vpn       proxy.Proxy
+	direct    proxy.Proxy
+	activeTCP atomic.Int64
+	activeUDP atomic.Int64
+}
+
+type trackedConn struct {
+	net.Conn
+	counter *atomic.Int64
+	route   string
+	dest    string
+	started time.Time
+	once    sync.Once
+}
+
+func (c *trackedConn) Close() error {
+	var err error
+	c.once.Do(func() {
+		active := c.counter.Add(-1)
+		log.Infof("[Router] TCP closed route=%s dest=%s lifetime=%s activeTCP=%d", c.route, c.dest, time.Since(c.started), active)
+		err = c.Conn.Close()
+	})
+	return err
+}
+
+type trackedPacketConn struct {
+	net.PacketConn
+	counter *atomic.Int64
+	route   string
+	dest    string
+	started time.Time
+	once    sync.Once
+}
+
+func (c *trackedPacketConn) Close() error {
+	var err error
+	c.once.Do(func() {
+		active := c.counter.Add(-1)
+		log.Infof("[Router] UDP closed route=%s dest=%s lifetime=%s activeUDP=%d", c.route, c.dest, time.Since(c.started), active)
+		err = c.PacketConn.Close()
+	})
+	return err
 }
 
 func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (proxyConn net.Conn, err error) {
+	start := time.Now()
+	dest := metadata.DestinationAddress()
 	if IsBypass(metadata) {
-		log.Infof("[Router] Using DIRECT for %s", metadata.DstIP)
-		return p.direct.DialContext(ctx, metadata)
+		log.Infof("[Router] TCP dial attempt route=DIRECT dstIP=%s dest=%s proto=%s activeTCP=%d activeUDP=%d", metadata.DstIP, dest, metadata.Network, p.activeTCP.Load(), p.activeUDP.Load())
+		conn, err := p.direct.DialContext(ctx, metadata)
+		if err != nil {
+			log.Infof("[Router] DIRECT TCP dial error dest=%s elapsed=%s err=%v", dest, time.Since(start), err)
+			return nil, err
+		}
+		active := p.activeTCP.Add(1)
+		log.Infof("[Router] DIRECT TCP dial OK dest=%s elapsed=%s local=%s remote=%s activeTCP=%d", dest, time.Since(start), conn.LocalAddr(), conn.RemoteAddr(), active)
+		return &trackedConn{Conn: conn, counter: &p.activeTCP, route: "DIRECT", dest: dest, started: time.Now()}, nil
 	}
-	log.Infof("[Router] Using VPN for %s", metadata.DstIP)
-	return p.vpn.DialContext(ctx, metadata)
+	log.Infof("[Router] TCP dial attempt route=VPN dstIP=%s dest=%s proto=%s activeTCP=%d activeUDP=%d", metadata.DstIP, dest, metadata.Network, p.activeTCP.Load(), p.activeUDP.Load())
+	conn, err := p.vpn.DialContext(ctx, metadata)
+	if err != nil {
+		log.Infof("[Router] VPN TCP dial error dest=%s elapsed=%s err=%v", dest, time.Since(start), err)
+		return nil, err
+	}
+	active := p.activeTCP.Add(1)
+	log.Infof("[Router] VPN TCP dial OK dest=%s elapsed=%s local=%s remote=%s activeTCP=%d", dest, time.Since(start), conn.LocalAddr(), conn.RemoteAddr(), active)
+	return &trackedConn{Conn: conn, counter: &p.activeTCP, route: "VPN", dest: dest, started: time.Now()}, nil
 }
 
 func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
+	start := time.Now()
+	dest := metadata.DestinationAddress()
 	if IsBypass(metadata) {
-		log.Infof("[Router] Using UDP DIRECT for %s", metadata.DstIP)
-		return p.direct.DialUDP(metadata)
+		log.Infof("[Router] UDP dial attempt route=DIRECT dstIP=%s dest=%s proto=%s activeTCP=%d activeUDP=%d", metadata.DstIP, dest, metadata.Network, p.activeTCP.Load(), p.activeUDP.Load())
+		conn, err := p.direct.DialUDP(metadata)
+		if err != nil {
+			log.Infof("[Router] DIRECT UDP dial error dest=%s elapsed=%s err=%v", dest, time.Since(start), err)
+			return nil, err
+		}
+		active := p.activeUDP.Add(1)
+		log.Infof("[Router] DIRECT UDP dial OK dest=%s elapsed=%s local=%s activeUDP=%d", dest, time.Since(start), conn.LocalAddr(), active)
+		return &trackedPacketConn{PacketConn: conn, counter: &p.activeUDP, route: "DIRECT", dest: dest, started: time.Now()}, nil
 	}
-	log.Infof("[Router] Using UDP VPN for %s", metadata.DstIP)
-	return p.vpn.DialUDP(metadata)
+	log.Infof("[Router] UDP dial attempt route=VPN dstIP=%s dest=%s proto=%s activeTCP=%d activeUDP=%d", metadata.DstIP, dest, metadata.Network, p.activeTCP.Load(), p.activeUDP.Load())
+	conn, err := p.vpn.DialUDP(metadata)
+	if err != nil {
+		log.Infof("[Router] VPN UDP dial error dest=%s elapsed=%s err=%v", dest, time.Since(start), err)
+		return nil, err
+	}
+	active := p.activeUDP.Add(1)
+	log.Infof("[Router] VPN UDP dial OK dest=%s elapsed=%s local=%s activeUDP=%d", dest, time.Since(start), conn.LocalAddr(), active)
+	return &trackedPacketConn{PacketConn: conn, counter: &p.activeUDP, route: "VPN", dest: dest, started: time.Now()}, nil
 }
 
 func (p *DobbyProxy) Addr() string {
@@ -57,25 +131,32 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 	defer mu.Unlock()
 
 	if isRunning {
-		StopEngine()
+		log.Infof("[Engine] StartEngine requested while already running; stopping previous engine first")
+		stopLocked()
 	}
 
+	log.Infof("[Engine] StartEngine config proxy=%s fd=%d uplinkIface=%s", cfg.ProxyAddr, cfg.FD, cfg.UplinkIface)
+	log.Infof("[Engine] StartEngine: calling StartPlatformEngine")
 	err := platform_engine.StartPlatformEngine(cfg)
 	if err != nil {
+		log.Infof("[Engine] StartPlatformEngine failed: %v", err)
 		return err
 	}
+	log.Infof("[Engine] StartPlatformEngine OK")
 
 	t := tunnel.T()
 	if t == nil {
+		log.Infof("[Engine] tunnel.T() is nil after engine start")
 		return fmt.Errorf("tunnel not initialized after engine start")
 	}
 
 	currentDialer := t.Dialer()
 	vpnOutbound, ok := currentDialer.(proxy.Proxy)
 	if !ok {
-		log.Infof("[Engine] Current dialer is not a proxy")
+		log.Infof("[Engine] Current dialer is not a proxy (type=%T)", currentDialer)
 		return fmt.Errorf("current dialer is not a proxy")
 	}
+	log.Infof("[Engine] vpn outbound proxy type=%T addr=%s", vpnOutbound, vpnOutbound.Addr())
 
 	directOutbound := &protected_dialer.ProtectedDirectProxy{
 		Proxy: proxy.NewDirect(),
@@ -87,8 +168,16 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 	}
 
 	t.SetDialer(wrapper)
+	log.Infof("[Engine] DobbyProxy installed")
 	isRunning = true
 	return nil
+}
+
+func stopLocked() {
+	log.Infof("[Engine] stopping tun2socks engine")
+	platform_engine.EngineStop()
+	isRunning = false
+	log.Infof("[Engine] tun2socks engine stopped")
 }
 
 func StopEngine() {
@@ -96,9 +185,9 @@ func StopEngine() {
 	defer mu.Unlock()
 
 	if !isRunning {
+		log.Infof("[Engine] StopEngine skipped: not running")
 		return
 	}
 
-	platform_engine.EngineStop()
-	isRunning = false
+	stopLocked()
 }

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -68,7 +68,7 @@ func (c *trackedPacketConn) Close() error {
 	return err
 }
 
-func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (proxyConn net.Conn, err error) {
+func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net.Conn, error) {
 	start := time.Now()
 	dest := metadata.DestinationAddress()
 	if IsBypass(metadata) {

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/diagnostic/domain/HealthCheckManager.kt
@@ -28,6 +28,7 @@ class HealthCheckManager(
     private val gracePeriodMs: Long = 15_000
     private var lastVpnStartMark: TimeMark? = null
     private var lastFullConnectionSucceed = false
+    private var healthGeneration = 0L
 
     suspend fun startHealthCheck(address: String, port: Int) {
         logger.log("[HC] startHealthCheck() called")
@@ -45,6 +46,8 @@ class HealthCheckManager(
         )
 
         logger.log("[HC] Health check started")
+        healthGeneration += 1
+        val generation = healthGeneration
 
         if (address != "localhost" && address != "127.0.0.1") {
             val serverAlive = healthCheck.checkServerAlive(address, port)
@@ -59,7 +62,12 @@ class HealthCheckManager(
             delay(healthCheck.getTimeToWakeUp() * 1_000L)
 
             while (isActive) {
-               if (configsRepository.getIsUserInitStop()) {
+                if (generation != healthGeneration) {
+                    logger.log("[HC] Stop condition: generation changed → exiting loop")
+                    return@launch
+                }
+
+                if (configsRepository.getIsUserInitStop()) {
                     logger.log("[HC] Stop condition: getIsUserInitStop() == true → exiting loop")
                     return@launch
                 }
@@ -71,6 +79,11 @@ class HealthCheckManager(
                 } catch (t: Throwable) {
                     logger.log("[HC] isConnected() threw exception: ${t.message}")
                     false
+                }
+
+                if (generation != healthGeneration) {
+                    logger.log("[HC] Health check stopped while native check was in flight → ignoring result")
+                    return@launch
                 }
 
                 val vpnStarted = mainViewModel.connectionStateRepository.vpnStartedFlow.value
@@ -107,7 +120,9 @@ class HealthCheckManager(
     fun stopHealthCheck() {
         logger.log("[HC] stopHealthCheck() called")
         logger.log("[HC] Cancelling job: ${healthJob?.isActive == true}")
+        logger.log("[HC] In-flight native checks may continue logging until their timeout")
 
+        healthGeneration += 1
         healthJob?.cancel()
         healthJob = null
 

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/presentation/MainViewModel.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/main/presentation/MainViewModel.kt
@@ -239,13 +239,13 @@ class MainViewModel(
     }
 
     fun stopVpnService(stoppedByHealthCheck: Boolean = false) {
-        logger.log("Stopping VPN service...")
+        logger.log("Stopping VPN service... stoppedByHealthCheck=$stoppedByHealthCheck")
         vpnManager.stop()
         if (!stoppedByHealthCheck) {
             configsRepository.clearOutlineAndCloakConfig()
             connectionStateRepository.tryUpdateStatus(false)
         }
-        logger.log("VPN service stopped successfully, state reset to disconnected")
+        logger.log("VPN stop requested; local state updated. Await NEVPNStatusDidChange for actual disconnected status")
     }
 
     private fun updateServerTargetFromConfig(): Boolean {

--- a/swift_module/CommonDI/HealthCheckImpl.swift
+++ b/swift_module/CommonDI/HealthCheckImpl.swift
@@ -6,6 +6,43 @@ import Foundation
 import SystemConfiguration
 import Network
 
+private final class HttpMetricsDelegate: NSObject, URLSessionDataDelegate {
+    private let url: String
+    private let log: (String) -> Void
+
+    init(url: String, log: @escaping (String) -> Void) {
+        self.url = url
+        self.log = log
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        for (index, transaction) in metrics.transactionMetrics.enumerated() {
+            func ms(_ start: Date?, _ end: Date?) -> String {
+                guard let start, let end else { return "-" }
+                return "\(Int(end.timeIntervalSince(start) * 1000))ms"
+            }
+
+            let completed = transaction.responseEndDate != nil
+            let proto = transaction.networkProtocolName ?? "?"
+            let local = transaction.localAddress ?? "-"
+            let remote = "\(transaction.remoteAddress ?? "-"):\(transaction.remotePort.map { "\($0)" } ?? "-")"
+            log(
+                "[HC] [httpMetrics#\(index)\(completed ? "[complete]" : "[partial]")] url=\(url) " +
+                "proto=\(proto) reused=\(transaction.isReusedConnection) local=\(local) remote=\(remote) " +
+                "dns=\(ms(transaction.domainLookupStartDate, transaction.domainLookupEndDate)) " +
+                "tcp=\(ms(transaction.connectStartDate, transaction.connectEndDate)) " +
+                "tls=\(ms(transaction.secureConnectionStartDate, transaction.secureConnectionEndDate)) " +
+                "ttfb=\(ms(transaction.requestEndDate, transaction.responseStartDate)) " +
+                "total=\(ms(transaction.fetchStartDate, transaction.responseEndDate))"
+            )
+        }
+    }
+}
+
 public final class HealthCheckImpl: HealthCheck {
 
     public static let shared = HealthCheckImpl()
@@ -13,10 +50,19 @@ public final class HealthCheckImpl: HealthCheck {
     private let logs = NativeModuleHolder.logsRepository
     private let timeout: TimeInterval = 4.0
 
+    private enum DNSCheckResult {
+        case success(String)
+        case failure(String)
+        case timeout
+    }
+
     public private(set) var currentMemmoryUsageMb = 0.0
+    private var checkSequence = 0
+    private let checkSequenceLock = NSLock()
 
     public func shortConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "Start shortConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "short")
+        logs.writeLog(log: "[HC] Start shortConnectionCheckUp id=\(checkId) userStopRequested=\(isUserStopRequested())")
 
         let checks: [(String, () -> Bool)] = [
             ("HTTP https://google.com/gen_204", {
@@ -36,12 +82,13 @@ public final class HealthCheckImpl: HealthCheck {
         }
 
         let result = vpnOk && networkOk
-        logs.writeLog(log: "End shortConnectionCheckUp => \(result)")
+        logs.writeLog(log: "[HC] End shortConnectionCheckUp id=\(checkId) => \(result) (vpn=\(vpnOk), network=\(networkOk), userStopRequested=\(isUserStopRequested()))")
         return result
     }
 
     public func fullConnectionCheckUp() -> Bool {
-        logs.writeLog(log: "[HC] Start fullConnectionCheckUp")
+        let checkId = nextCheckId(prefix: "full")
+        logs.writeLog(log: "[HC] Start fullConnectionCheckUp id=\(checkId) userStopRequested=\(isUserStopRequested())")
 
         let groups: [(String, [(String, () -> Bool)])] = [
             ("TCP Ping group", [
@@ -49,8 +96,8 @@ public final class HealthCheckImpl: HealthCheck {
                 ("Ping 1.1.1.1", { self.pingAddress("1.1.1.1:53", name: "OneOneOneOne") })
             ]),
             ("DNS Resolve group", [
-                ("DNS google.com", { self.resolveDNSWithTimeout(host: "google.com") != "Timeout" }),
-                ("DNS one.one.one.one", { self.resolveDNSWithTimeout(host: "one.one.one.one") != "Timeout" })
+                ("DNS google.com", { self.resolveDNSCheck(host: "google.com") }),
+                ("DNS one.one.one.one", { self.resolveDNSCheck(host: "one.one.one.one") })
             ]),
             ("DNS Ping group", [
                 ("Ping google.com (DNS)", { self.pingAddress("google.com:80", name: "GoogleDNS") }),
@@ -110,8 +157,20 @@ public final class HealthCheckImpl: HealthCheck {
             logs.writeLog(log: "[HC] Memory usage: unknown (can't get XPC memory)")
         }
 
-        logs.writeLog(log: "[HC] RESULT = \(result)")
+        logs.writeLog(log: "[HC] RESULT id=\(checkId) = \(result) failedGroups=\(failedGroups.joined(separator: ",")) userStopRequested=\(isUserStopRequested())")
         return result
+    }
+
+    private func nextCheckId(prefix: String) -> String {
+        checkSequenceLock.lock()
+        checkSequence += 1
+        let value = checkSequence
+        checkSequenceLock.unlock()
+        return "\(prefix)-\(value)"
+    }
+
+    private func isUserStopRequested() -> Bool {
+        DobbyConfigsRepositoryImpl.shared.getIsUserInitStop()
     }
 
     private func runWithRetry(
@@ -122,6 +181,7 @@ public final class HealthCheckImpl: HealthCheck {
     ) -> Bool {
         for attempt in 1...attempts {
             logs.writeLog(log: "[HC] \(name) attempt \(attempt)")
+            let started = Date()
             let ok: Bool
             if let timeoutPerAttempt {
                 ok = runWithTimeout(timeout: timeoutPerAttempt, block: block)
@@ -130,11 +190,17 @@ public final class HealthCheckImpl: HealthCheck {
             }
 
             if ok {
+                logs.writeLog(log: "[HC] \(name) attempt \(attempt) OK in \(elapsedMs(since: started))ms")
                 return true
             }
+            logs.writeLog(log: "[HC] \(name) attempt \(attempt) failed in \(elapsedMs(since: started))ms")
         }
         logs.writeLog(log: "[HC] \(name) FAILED after \(attempts) attempts")
         return false
+    }
+
+    private func elapsedMs(since started: Date) -> Int {
+        Int(Date().timeIntervalSince(started) * 1000)
     }
 
     private func runWithTimeout(
@@ -163,26 +229,48 @@ public final class HealthCheckImpl: HealthCheck {
         return value
     }
 
-    private func resolveDNSWithTimeout(host: String) -> String? {
-        var result: String?
+    private func resolveDNSCheck(host: String) -> Bool {
+        switch resolveDNSWithTimeout(host: host) {
+        case .success(let ip):
+            logs.writeLog(log: "[HC] DNS \(host) resolved to \(ip)")
+            return true
+        case .failure(let error):
+            logs.writeLog(log: "[HC] DNS \(host) failed: \(error)")
+            return false
+        case .timeout:
+            logs.writeLog(log: "[HC] DNS \(host) timed out after \(Int(timeout * 1000))ms")
+            return false
+        }
+    }
+
+    private func resolveDNSWithTimeout(host: String) -> DNSCheckResult {
+        let lock = NSLock()
+        var result = DNSCheckResult.failure("No resolver result")
         let group = DispatchGroup()
         group.enter()
 
         DispatchQueue.global(qos: .userInitiated).async {
-            result = self.resolveDNS(host: host)
+            let value = self.resolveDNS(host: host)
+            lock.lock()
+            result = value
+            lock.unlock()
             group.leave()
         }
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
-            return "Timeout"
+            return .timeout
         }
-        return result
+
+        lock.lock()
+        let value = result
+        lock.unlock()
+        return value
     }
 
-    private func resolveDNS(host: String) -> String {
+    private func resolveDNS(host: String) -> DNSCheckResult {
         var hints = addrinfo(
-            ai_flags: AI_PASSIVE,
+            ai_flags: 0,
             ai_family: AF_UNSPEC,
             ai_socktype: SOCK_STREAM,
             ai_protocol: 0,
@@ -196,7 +284,7 @@ public final class HealthCheckImpl: HealthCheck {
         let status = getaddrinfo(host, nil, &hints, &infoPointer)
 
         guard status == 0, let first = infoPointer else {
-            return String(cString: gai_strerror(status))
+            return .failure(String(cString: gai_strerror(status)))
         }
 
         defer { freeaddrinfo(infoPointer) }
@@ -213,19 +301,25 @@ public final class HealthCheckImpl: HealthCheck {
                 0,
                 NI_NUMERICHOST
             ) == 0 {
-                return String(cString: buffer)
+                return .success(String(cString: buffer))
             }
             ptr = current.pointee.ai_next
         }
 
-        return "Can't resolve DNS"
+        return .failure("No numeric address returned")
     }
 
     private func httpPing(urlString: String) -> Bool {
-        guard let url = URL(string: urlString) else { return false }
+        guard let url = URL(string: urlString) else {
+            logs.writeLog(log: "[HC] HTTP invalid URL: \(urlString)")
+            return false
+        }
 
         let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
         var success = false
+        var detail = "no callback"
+        let started = Date()
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -235,14 +329,31 @@ public final class HealthCheckImpl: HealthCheck {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = timeout
         config.timeoutIntervalForResource = timeout
-        let session = URLSession(configuration: config)
+        let metricsDelegate = HttpMetricsDelegate(url: urlString) { [weak self] message in
+            self?.logs.writeLog(log: message)
+        }
+        let session = URLSession(configuration: config, delegate: metricsDelegate, delegateQueue: nil)
 
         let task = session.dataTask(with: request) { _, response, error in
+            var ok = false
+            var message: String
             if error == nil,
                let http = response as? HTTPURLResponse,
                (200..<400).contains(http.statusCode) {
-                success = true
+                ok = true
+                message = "status=\(http.statusCode)"
+            } else if let error {
+                let nsError = error as NSError
+                message = "errorDomain=\(nsError.domain) code=\(nsError.code) message=\(error.localizedDescription)"
+            } else if let http = response as? HTTPURLResponse {
+                message = "status=\(http.statusCode)"
+            } else {
+                message = "nonHTTP response"
             }
+            lock.lock()
+            success = ok
+            detail = message
+            lock.unlock()
             semaphore.signal()
         }
         task.resume()
@@ -250,8 +361,19 @@ public final class HealthCheckImpl: HealthCheck {
         let wait = semaphore.wait(timeout: .now() + timeout)
         if wait == .timedOut {
             task.cancel()
+            session.invalidateAndCancel()
+            logs.writeLog(log: "[HC] HTTP \(urlString) timed out after \(Int(timeout * 1000))ms")
+            return false
         }
-        return success
+        session.finishTasksAndInvalidate()
+
+        lock.lock()
+        let ok = success
+        let message = detail
+        lock.unlock()
+
+        logs.writeLog(log: "[HC] HTTP \(urlString) result=\(ok) \(message) elapsed=\(elapsedMs(since: started))ms")
+        return ok
     }
 
     private func pingAddress(_ address: String, name: String) -> Bool {
@@ -317,10 +439,12 @@ public final class HealthCheckImpl: HealthCheck {
     private func isVPNInterfaceExists() -> Bool {
         var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
         guard getifaddrs(&ifaddrPtr) == 0, let firstAddr = ifaddrPtr else {
+            logs.writeLog(log: "[HC] VPN interface scan failed")
             return false
         }
         defer { freeifaddrs(ifaddrPtr) }
 
+        var matches: [String] = []
         var ptr: UnsafeMutablePointer<ifaddrs>? = firstAddr
         while let addr = ptr {
             let name = String(cString: addr.pointee.ifa_name).lowercased()
@@ -329,11 +453,17 @@ public final class HealthCheckImpl: HealthCheck {
                 || name.contains("tap")
                 || name.contains("ppp")
                 || name.contains("ipsec") {
-                return true
+                matches.append(name)
             }
             ptr = addr.pointee.ifa_next
         }
-        return false
+
+        if matches.isEmpty {
+            logs.writeLog(log: "[HC] VPN interfaces: none")
+            return false
+        }
+        logs.writeLog(log: "[HC] VPN interfaces: \(Array(Set(matches)).sorted().joined(separator: ","))")
+        return true
     }
 
     private func isTunnelAliveViaXPC() -> Double {
@@ -341,18 +471,29 @@ public final class HealthCheckImpl: HealthCheck {
         let semaphore = DispatchSemaphore(value: 0)
 
         NETunnelProviderManager.loadAllFromPreferences { managers, error in
-            guard
-                error == nil,
-                let manager = managers?.first(where: {
-                    $0.localizedDescription == VpnManagerImpl.dobbyName &&
-                    ($0.protocolConfiguration as? NETunnelProviderProtocol)?
-                        .providerBundleIdentifier == VpnManagerImpl.dobbyBundleIdentifier
-                }),
-                let session = manager.connection as? NETunnelProviderSession
-            else {
+            if let error {
+                self.logs.writeLog(log: "[HC] XPC manager load failed: \(error.localizedDescription)")
                 semaphore.signal()
                 return
             }
+
+            guard let manager = managers?.first(where: {
+                $0.localizedDescription == VpnManagerImpl.dobbyName &&
+                ($0.protocolConfiguration as? NETunnelProviderProtocol)?
+                    .providerBundleIdentifier == VpnManagerImpl.dobbyBundleIdentifier
+            }) else {
+                self.logs.writeLog(log: "[HC] XPC manager not found")
+                semaphore.signal()
+                return
+            }
+
+            guard let session = manager.connection as? NETunnelProviderSession else {
+                self.logs.writeLog(log: "[HC] XPC session unavailable status=\(manager.connection.status.rawValue)")
+                semaphore.signal()
+                return
+            }
+
+            self.logs.writeLog(log: "[HC] XPC heartbeat send status=\(manager.connection.status.rawValue)")
 
             do {
                 try session.sendProviderMessage(
@@ -360,13 +501,22 @@ public final class HealthCheckImpl: HealthCheck {
                 ) { response in
                     defer { semaphore.signal() }
                     memory = self.parseMemoryResponse(response)
+                    if memory >= 0 {
+                        self.logs.writeLog(log: "[HC] XPC heartbeat OK memory=\(memory)MB")
+                    } else {
+                        self.logs.writeLog(log: "[HC] XPC heartbeat invalid response")
+                    }
                 }
             } catch {
+                self.logs.writeLog(log: "[HC] XPC heartbeat send failed: \(error.localizedDescription)")
                 semaphore.signal()
             }
         }
 
-        _ = semaphore.wait(timeout: .now() + timeout)
+        let wait = semaphore.wait(timeout: .now() + timeout)
+        if wait == .timedOut {
+            logs.writeLog(log: "[HC] XPC heartbeat timed out after \(Int(timeout * 1000))ms")
+        }
         return memory
     }
 
@@ -384,6 +534,14 @@ public final class HealthCheckImpl: HealthCheck {
     }
 
     public func checkServerAlive(address: String, port: Int32) -> Bool {
-        return pingAddress("\(address):\(port)", name: "ServerAlive")
+        let start = Date()
+        logs.writeLog(log: "[HC] [ServerAlive] native CheckServerAlive begin address=\(address) port=\(port)")
+        let status = Cloak_outlineCheckServerAlive(address, Int(port))
+        let ok = status == 0
+        logs.writeLog(
+            log: "[HC] [ServerAlive] native CheckServerAlive result=\(ok) status=\(status) " +
+                "elapsed=\(elapsedMs(since: start))ms"
+        )
+        return ok
     }
 }

--- a/swift_module/CommonDI/VpnManagerImpl.swift
+++ b/swift_module/CommonDI/VpnManagerImpl.swift
@@ -47,8 +47,13 @@ public class VpnManagerImpl: VpnManager {
                   let connection = notification.object as? NEVPNConnection else { return }
 
             if let myConnection = self.vpnManager?.connection, myConnection !== connection {
+                self.logs.writeLog(log: "[NEVPNStatusDidChange] ignoring non-Dobby connection status=\(self.statusName(connection.status)) raw=\(connection.status.rawValue)")
                 return
             }
+
+            let previous = self.state
+            self.state = connection.status
+            self.logs.writeLog(log: "[NEVPNStatusDidChange] \(self.statusName(previous))(\(previous.rawValue)) -> \(self.statusName(connection.status))(\(connection.status.rawValue))")
 
             switch connection.status {
             case .connected:
@@ -82,7 +87,7 @@ public class VpnManagerImpl: VpnManager {
     }
 
     public func start() {
-        self.logs.writeLog(log: "call start")
+        self.logs.writeLog(log: "call start launchId=\(Self.launchId)")
         self.logs.writeLog(log: "Routing table without vpn:")
         getOrCreateManager { manager, _ in
             self.handleStart(manager: manager)
@@ -95,6 +100,7 @@ public class VpnManagerImpl: VpnManager {
             return
         }
         let status = manager.connection.status
+        self.logs.writeLog(log: "[start] manager loaded status=\(statusName(status)) raw=\(status.rawValue)")
         if status == .connecting || status == .disconnecting || status == .reasserting {
             self.logs.writeLog(log: "[start] Skip: connection is transitioning (\(status.rawValue))")
             return
@@ -116,9 +122,9 @@ public class VpnManagerImpl: VpnManager {
                 self.logs.writeLog(log: "VPN configuration saved successfully!")
                 do {
                     self.logs.writeLog(log: "self.vpnManager = \(manager)")
-                    self.logs.writeLog(log: "starting tunnel \(manager.connection.status)")
+                    self.logs.writeLog(log: "starting tunnel status=\(self.statusName(manager.connection.status)) raw=\(manager.connection.status.rawValue)")
                     try manager.connection.startVPNTunnel()
-                    self.logs.writeLog(log: "Tunnel was started! manager.connection.status = \(manager.connection.status)")
+                    self.logs.writeLog(log: "startVPNTunnel returned; manager.connection.status = \(self.statusName(manager.connection.status)) raw=\(manager.connection.status.rawValue)")
                 } catch {
                     self.logs.writeLog(log: "Error starting VPNTunnel \(error)")
                 }
@@ -132,7 +138,7 @@ public class VpnManagerImpl: VpnManager {
             self.logs.writeLog(log: "[stop] Skip: vpnManager is nil")
             return
         }
-        self.logs.writeLog(log: "[stop] User initiated stopVPNTunnel()")
+        self.logs.writeLog(log: "[stop] stopVPNTunnel requested status=\(statusName(manager.connection.status)) raw=\(manager.connection.status.rawValue)")
         manager.connection.stopVPNTunnel()
         self.logs.writeLog(log: "[stop] stopVPNTunnel() called, waiting for .disconnecting")
     }
@@ -140,10 +146,14 @@ public class VpnManagerImpl: VpnManager {
     private func getOrCreateManager(completion: @escaping (NETunnelProviderManager?, Error?) -> Void) {
         NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
             guard let self else { return }
+            if let error {
+                self.logs.writeLog(log: "Failed to load VPN preferences: \(error.localizedDescription)")
+            }
+            self.logs.writeLog(log: "Loaded VPN managers count=\(managers?.count ?? 0)")
 
             if let existingManager = managers?.first(where: { $0.localizedDescription == Self.dobbyName }) {
                 vpnManager = existingManager
-                self.logs.writeLog(log: "Existing manager found.")
+                self.logs.writeLog(log: "Existing manager found status=\(self.statusName(existingManager.connection.status)) raw=\(existingManager.connection.status.rawValue)")
                 self.applyProtocolDefaults(manager: existingManager)
                 completion(existingManager, nil)
             } else {
@@ -193,6 +203,25 @@ public class VpnManagerImpl: VpnManager {
             proto.excludeDeviceCommunication = false
         }
         manager.protocolConfiguration = proto
+    }
+
+    private func statusName(_ status: NEVPNStatus) -> String {
+        switch status {
+        case .invalid:
+            return "invalid"
+        case .disconnected:
+            return "disconnected"
+        case .connecting:
+            return "connecting"
+        case .connected:
+            return "connected"
+        case .reasserting:
+            return "reasserting"
+        case .disconnecting:
+            return "disconnecting"
+        @unknown default:
+            return "unknown"
+        }
     }
 
 //    static func startSentry() {

--- a/swift_module/tunnel/CloakInteractor.swift
+++ b/swift_module/tunnel/CloakInteractor.swift
@@ -12,15 +12,19 @@ public final class CloakInteractor {
     private var cloakStarted: Bool = false
 
     func startCloak(outlineServerPort: String) throws {
+        let start = Date()
         let localPort = String(configsRepository.getCloakLocalPort())
-        logs.writeLog(log: "startCloakOutline: entering")
+        logs.writeLog(log: "startCloakOutline: entering localPort=\(localPort) outlineServerPort.len=\(outlineServerPort.count)")
         
         if configsRepository.getIsCloakEnabled() {
             let cloakConfig = configsRepository.getCloakConfig()
             if cloakConfig.isEmpty {
                 let host = OutlineInteractor.extractHost(from: outlineServerPort).lowercased()
                 let cloakRequired = (host == "127.0.0.1" || host == "localhost")
-                logs.writeLog(log: "startCloakOutline: enabled but config empty (required=\(cloakRequired), host=\(host))")
+                logs.writeLog(
+                    log: "startCloakOutline: enabled but config empty " +
+                        "(required=\(cloakRequired), host=\(maskStr(value: host)))"
+                )
                 if cloakRequired {
                     throw NSError(
                         domain: "PacketTunnelProvider",
@@ -28,24 +32,36 @@ public final class CloakInteractor {
                         userInfo: [NSLocalizedDescriptionKey: "Cloak enabled but config is empty"]
                     )
                 }
+                logs.writeLog(log: "startCloakOutline: config empty but not required elapsedMs=\(elapsedMs(since: start))")
                 return
             }
-            logs.writeLog(log: "startCloakOutline: starting cloak")
+            logs.writeLog(log: "startCloakOutline: starting cloak config.len=\(cloakConfig.count)")
+            let nativeStart = Date()
             Cloak_outlineStartCloakClient("127.0.0.1", localPort, cloakConfig, false)
             cloakStarted = true
-            logs.writeLog(log: "startCloakOutline: started")
+            logs.writeLog(
+                log: "startCloakOutline: Cloak_outlineStartCloakClient returned " +
+                    "nativeMs=\(elapsedMs(since: nativeStart)) totalMs=\(elapsedMs(since: start))"
+            )
         } else {
-            logs.writeLog(log: "startCloakOutline: cloak disabled")
+            logs.writeLog(log: "startCloakOutline: cloak disabled elapsedMs=\(elapsedMs(since: start))")
         }
     }
 
     func stopCloak() throws {
         if cloakStarted {
-            var err: NSError?
-            Cloak_outlineOutlineDisconnect(&err)
-            if let error = err {
-                throw error
-            }
+            let start = Date()
+            logs.writeLog(log: "stopCloak: stopping Cloak client")
+            Cloak_outlineStopCloakClient()
+            cloakStarted = false
+            logs.writeLog(log: "stopCloak: Cloak client stopped elapsedMs=\(elapsedMs(since: start))")
+        } else {
+            logs.writeLog(log: "[DEBUG] stopCloak: skipped cloakStarted=false")
         }
+        cloakStarted = false
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }

--- a/swift_module/tunnel/OutlineInteractor.swift
+++ b/swift_module/tunnel/OutlineInteractor.swift
@@ -9,9 +9,12 @@ import Network
 
 public final class OutlineInteractor {
     private var logs = NativeModuleHolder.logsRepository
+    private var outlineStarted: Bool = false
 
     func startOutline() throws {
-        
+        let start = Date()
+        logs.writeLog(log: "[Outline] startOutline begin")
+
         let methodPassword = configsRepository.getMethodPasswordOutline()
         let serverPort = configsRepository.getServerPortOutline()
         let prefix = configsRepository.getPrefixOutline()
@@ -22,7 +25,7 @@ public final class OutlineInteractor {
 
         // Validate config early (prevents passing empty config into native layer).
         if methodPassword.isEmpty || serverPort.isEmpty {
-            logs.writeLog(log: "[startTunnel] Empty Outline config (methodPassword/serverPort) → abort")
+            logs.writeLog(log: "[startTunnel] Empty Outline config: methodPassword.isEmpty=\(methodPassword.isEmpty) serverPort.isEmpty=\(serverPort.isEmpty) → abort")
             throw NSError(
                 domain: "PacketTunnelProvider",
                 code: -2,
@@ -40,29 +43,58 @@ public final class OutlineInteractor {
         )
         logs.writeLog(log: "Outline config built (prefix=\(!prefix.isEmpty), ws=\(websocketEnabled), tcpPath=\(!tcpPath.isEmpty), udpPath=\(!udpPath.isEmpty))")
         if websocketEnabled {
-            logs.writeLog(log: "WebSocket transport requested (wss)")
+            logs.writeLog(
+                log: "WebSocket transport requested (wss) " +
+                    "serverHost=\(maskStr(value: OutlineInteractor.extractHost(from: serverPort)))"
+            )
         }
         
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native NewOutlineClient config.len=\(config.count)")
+        let newClientStart = Date()
         Cloak_outlineNewOutlineClient(config, &err)
         if let error = err {
+            logs.writeLog(
+                log: "[Outline] NewOutlineClient failed in \(elapsedMs(since: newClientStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
+        logs.writeLog(log: "[Outline] NewOutlineClient succeeded in \(elapsedMs(since: newClientStart))ms")
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineConnect")
+        let connectStart = Date()
         Cloak_outlineOutlineConnect(&err)
         if let error = err {
+            logs.writeLog(
+                log: "[Outline] OutlineConnect failed in \(elapsedMs(since: connectStart))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
+        outlineStarted = true
+        logs.writeLog(
+            log: "[Outline] OutlineConnect succeeded in \(elapsedMs(since: connectStart))ms " +
+                "totalStartMs=\(elapsedMs(since: start))"
+        )
     }
 
     func stopOutline() throws {
         var err: NSError?
 
+        logs.writeLog(log: "[DEBUG][Outline] calling native OutlineDisconnect outlineStarted=\(outlineStarted)")
+        let start = Date()
         Cloak_outlineOutlineDisconnect(&err)
         if let error = err {
+            logs.writeLog(
+                log: "[Outline] OutlineDisconnect failed in \(elapsedMs(since: start))ms: " +
+                    "\(error.localizedDescription)"
+            )
             throw error
         }
+        outlineStarted = false
+        logs.writeLog(log: "[DEBUG][Outline] OutlineDisconnect returned in \(elapsedMs(since: start))ms")
     }
     
     func buildOutlineConfig(
@@ -104,6 +136,10 @@ public final class OutlineInteractor {
         // If WebSocket is enabled, wrap the Shadowsocks URL into WebSocket-over-TLS transport (wss://)
         if websocketEnabled {
             let effectiveHost = extractHost(serverPort).trimmingCharacters(in: .whitespacesAndNewlines)
+            logs.writeLog(
+                log: "[Outline] building WSS config effectiveHost=\(maskStr(value: effectiveHost)) " +
+                    "tcpPath.len=\(tcpPath.count) udpPath.len=\(udpPath.count)"
+            )
 
             var wsParams: [String] = []
             // outline-sdk v0.0.16: ws: does not support the `host=` option ("Unsupported option host")
@@ -137,5 +173,9 @@ public final class OutlineInteractor {
             return String(trimmed[..<lastColon])
         }
         return trimmed
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 }

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -22,7 +22,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var userDefaults: UserDefaults = UserDefaults(suiteName: appGroupIdentifier)!
 
     private var pathMonitor: Network.NWPathMonitor?
-    private var lastPathStatus: Network.NWPath.Status?
+    private var lastPathSignature: String?
 
     func reportMemoryUsageMB() -> Double {
         var info = task_vm_info_data_t()
@@ -60,15 +60,72 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         freeifaddrs(ifaddrPtr)
     }
 
+    func logInterfacesDetailed(label: String) {
+        logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: \(label) ==========")
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else {
+            logs.writeLog(log: "[DEBUG][Interfaces] getifaddrs failed errno=\(errno)")
+            logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_\(label) ==========")
+            return
+        }
+        defer {
+            freeifaddrs(ifaddrPtr)
+            logs.writeLog(log: "[iOS26-RESEARCH] ========== INTERFACES: END_\(label) ==========")
+        }
+
+        var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        var count = 0
+        while let current = ptr {
+            count += 1
+            let name = String(cString: current.pointee.ifa_name)
+            let flags = current.pointee.ifa_flags
+            let family = current.pointee.ifa_addr?.pointee.sa_family
+            let familyDescription = family.map { String($0) } ?? "nil"
+            let address = addressDescription(current.pointee.ifa_addr)
+            logs.writeLog(
+                log: "[DEBUG][Interfaces] \(label) name=\(name) family=\(familyDescription) " +
+                    "flags=0x\(String(flags, radix: 16)) address=\(address)"
+            )
+            ptr = current.pointee.ifa_next
+        }
+        if count == 0 {
+            logs.writeLog(log: "[DEBUG][Interfaces] \(label) no interfaces visible")
+        }
+    }
+
+    private func addressDescription(_ addr: UnsafePointer<sockaddr>?) -> String {
+        guard let addr else { return "nil" }
+        var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+        let length: socklen_t
+        switch Int32(addr.pointee.sa_family) {
+        case AF_INET:
+            length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        case AF_INET6:
+            length = socklen_t(MemoryLayout<sockaddr_in6>.size)
+        default:
+            return "family=\(addr.pointee.sa_family)"
+        }
+        if getnameinfo(addr, length, &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST) == 0 {
+            return String(cString: host)
+        }
+        return "family=\(addr.pointee.sa_family) getnameinfoErr=\(errno)"
+    }
+
     override func startTunnel(options: [String : NSObject]?) async throws {
         let tid = UInt64(pthread_mach_thread_np(pthread_self()))
-        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId)")
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+        let optionKeys = options?.keys.sorted().joined(separator: ",") ?? "(none)"
+        logs.writeLog(log: "[iOS26-RESEARCH] iOS version: \(osVersionString)")
+        logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId) optionKeys=\(optionKeys)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")
+        logInterfacesDetailed(label: "BEFORE_VPN_TUNNEL")
 
         // Defensive: if the system retries start without a proper stop, ensure we teardown previous state.
         await teardownForStop(reason: "pre-start cleanup")
 
         startPathLogging()
+        logInitialNetworkPath(timeout: 1.0)
 
         let cloakConfig = configsRepository.getCloakConfig()
         // Excluding the remote server route helps avoid routing loops (especially with WSS/domain hosts).
@@ -127,37 +184,92 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         settings.dnsSettings?.matchDomains = [""]
 
         logs.writeLog(log: "Settings are ready:")
-        try await self.setTunnelNetworkSettings(settings)
+        logs.writeLog(log: "[tunnel:\(tunnelId)] settings mtu=\(settings.mtu?.stringValue ?? "nil") ipv4=\(localAddress)/\(subnetMask) remote=\(remoteAddress) dns=\(dnsServers.joined(separator: ",")) excludedRoutes=\(excludedRoutes.count)")
+        do {
+            try await self.setTunnelNetworkSettings(settings)
+        } catch {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] setTunnelNetworkSettings failed: \(error.localizedDescription)")
+            throw error
+        }
         logs.writeLog(log: "Tunnel settings applied")
 
         logInterfaces()
+        logInterfacesDetailed(label: "AFTER_VPN_TUNNEL")
 
         let path = LogsRepository_iosKt.provideLogFilePath().normalized().description()
         logs.writeLog(log: "Start go logger init path = \(path)")
         Cloak_outlineInitLogger(path)
         logs.writeLog(log: "Finish go logger init")
         Cloak_outlineSetGeoRoutingConf(configsRepository.getGeoRoutingConf())
-        try outlineInteractor.startOutline()
+        do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startOutline begin")
+            try outlineInteractor.startOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startOutline success")
+        } catch {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startOutline failed: \(error.localizedDescription)")
+            await teardownForStop(reason: "startOutline failure")
+            throw error
+        }
         logs.writeLog(log: "[tunnel:\(tunnelId)] Device initialized OK")
-        try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
+        do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startCloak begin")
+            try cloakInteractor.startCloak(outlineServerPort: configsRepository.getServerPortOutline())
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startCloak success")
+        } catch {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] startCloak failed: \(error.localizedDescription)")
+            await teardownForStop(reason: "startCloak failure")
+            throw error
+        }
 
         logs.writeLog(log: "startTunnel: all packet loops started")
+        logInterfacesDetailed(label: "AFTER_PROTOCOL_STARTUP")
     }
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel reason=\(reason.rawValue) (\(reason))")
         configsRepository.setIsUserInitStop(isUserInitStop: true)
+        logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel clearing geo routing config")
         Cloak_outlineClearGeoRoutingConf()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel geo routing clear returned")
         Task {
             await teardownForStop(reason: "stopTunnel(\(reason))")
+            logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel teardown complete; calling completionHandler")
             completionHandler()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] stopTunnel completionHandler returned")
         }
     }
 
-    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
-        if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
-            completionHandler?("Memory:\(reportMemoryUsageMB())".data(using: .utf8))
+    override func cancelTunnelWithError(_ error: Error?) {
+        if let error {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: \(error.localizedDescription)")
         } else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] cancelTunnelWithError: nil")
+        }
+        super.cancelTunnelWithError(error)
+    }
+
+    override func sleep(completionHandler: @escaping () -> Void) {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] sleep()")
+        completionHandler()
+    }
+
+    override func wake() {
+        logs.writeLog(log: "[tunnel:\(tunnelId)] wake()")
+    }
+
+    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
+        logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage bytes=\(messageData.count)")
+        if let msg = String(data: messageData, encoding: .utf8), msg == "getMemory" {
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory")
+            let response = "Memory:\(reportMemoryUsageMB())".data(using: .utf8)
+            logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage getMemory responseBytes=\(response?.count ?? -1)")
+            completionHandler?(response)
+        } else {
+            if let msg = String(data: messageData, encoding: .utf8) {
+                logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage unknown='\(msg)' echo bytes=\(messageData.count)")
+            } else {
+                logs.writeLog(log: "[DEBUG][tunnel:\(tunnelId)] handleAppMessage nonUtf8 echo bytes=\(messageData.count)")
+            }
             completionHandler?(messageData)
         }
     }
@@ -171,12 +283,26 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
             let status = path.status
-            if self.lastPathStatus != status {
-                self.lastPathStatus = status
-                let ifaces = path.availableInterfaces.map { "\($0.type)" }.joined(separator: ",")
-                let expensive = path.isExpensive
-                let constrained = path.isConstrained
-                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] pathUpdate status=\(status) ifaces=[\(ifaces)] expensive=\(expensive) constrained=\(constrained)")
+            let ifaces = path.availableInterfaces.map { "\($0.name)[\(self.interfaceTypeKey($0.type))]" }.joined(separator: ",")
+            let expensive = path.isExpensive
+            let constrained = path.isConstrained
+            let signature = "status=\(status) ifaces=[\(ifaces)] expensive=\(expensive) constrained=\(constrained) supportsIPv4=\(path.supportsIPv4) supportsIPv6=\(path.supportsIPv6)"
+            if self.lastPathSignature != signature {
+                let previous = self.lastPathSignature ?? "(none)"
+                self.lastPathSignature = signature
+                if previous != "(none)" {
+                    self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] [iOS26-RESEARCH] NETWORK_CHANGED: \(previous) -> \(signature)")
+                }
+                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] PATH_UPDATE \(signature)")
+                if expensive && constrained {
+                    self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] WARNING: path is both expensive and constrained")
+                }
+                if status == .unsatisfied {
+                    self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] WARNING: path is unsatisfied")
+                }
+                for iface in path.availableInterfaces {
+                    self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] [iOS26-RESEARCH] INTERFACE name=\(iface.name) type=\(self.interfaceTypeKey(iface.type)) raw=\(iface.type)")
+                }
             }
         }
 
@@ -184,9 +310,64 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         logs.writeLog(log: "[tunnel:\(tunnelId)] NWPathMonitor started")
     }
 
+    private func logInitialNetworkPath(timeout: TimeInterval) {
+        let monitor = Network.NWPathMonitor()
+        let q = DispatchQueue(label: "vpn.dobby.app.tunnel.startup-path.\(tunnelId)")
+        let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var captured = false
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            lock.lock()
+            if captured {
+                lock.unlock()
+                self.logs.writeLog(log: "[tunnel:\(self.tunnelId)] STARTUP_NETWORK: duplicate path update ignored")
+                return
+            }
+            captured = true
+            lock.unlock()
+
+            let ifaces = path.availableInterfaces.map { "\($0.name):\(self.interfaceTypeKey($0.type))" }.joined(separator: ",")
+            self.logs.writeLog(
+                log: "[tunnel:\(self.tunnelId)] STARTUP_NETWORK status=\(path.status) ifaces=[\(ifaces)] " +
+                    "expensive=\(path.isExpensive) constrained=\(path.isConstrained) " +
+                    "supportsIPv4=\(path.supportsIPv4) supportsIPv6=\(path.supportsIPv6)"
+            )
+            semaphore.signal()
+        }
+
+        logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: starting temporary NWPathMonitor timeoutMs=\(Int(timeout * 1000))")
+        monitor.start(queue: q)
+        if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_WARNING: timed out waiting for initial network path")
+        } else {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: initial path captured")
+        }
+        monitor.cancel()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] STARTUP_NETWORK: temporary NWPathMonitor cancelled")
+    }
+
+    private func interfaceTypeKey(_ type: Network.NWInterface.InterfaceType) -> String {
+        switch type {
+        case .wifi:
+            return "wifi"
+        case .cellular:
+            return "cellular"
+        case .wiredEthernet:
+            return "ethernet"
+        case .loopback:
+            return "loopback"
+        case .other:
+            return "other"
+        @unknown default:
+            return "unknown"
+        }
+    }
+
     @MainActor
     private func teardownForStop(reason: String) async {
-        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason)")
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] begin (\(reason))")
 
         do {
             try cloakInteractor.stopCloak()
@@ -195,6 +376,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         do {
+            try outlineInteractor.stopOutline()
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] outline stopped")
+        } catch {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] could not stop outline: \(error.localizedDescription)")
+        }
+
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing geo routing config")
+        Cloak_outlineClearGeoRoutingConf()
+        logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] geo routing clear returned")
+
+        do {
+            logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] clearing tunnel network settings")
             try await self.setTunnelNetworkSettings(nil)
             logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] cleared tunnel network settings")
         } catch {
@@ -203,29 +396,52 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         pathMonitor?.cancel()
         pathMonitor = nil
-        lastPathStatus = nil
+        lastPathSignature = nil
 
         logs.writeLog(log: "[tunnel:\(tunnelId)] [teardown] end (\(reason))")
     }
 
-    /// Extracts the host/IP part from a string like "ip:port"
+    /// Extracts the host/IP part from a string like "ip:port" or "[ipv6]:port".
     func extractIP(from serverPort: String) -> String? {
-        guard !serverPort.isEmpty else { return nil }
-        return serverPort.split(separator: ":").first.map(String.init)
+        let host = OutlineInteractor.extractHost(from: serverPort).trimmingCharacters(in: .whitespacesAndNewlines)
+        if host.isEmpty {
+            logs.writeLog(log: "[DEBUG][Routing] Outline host extraction skipped: serverPort empty")
+            return nil
+        }
+        logs.writeLog(log: "[DEBUG][Routing] Outline host extracted host=\(maskStr(value: host))")
+        return host
     }
 
     /// Extracts `RemoteHost` from Cloak JSON
     func extractRemoteHost(from cloakConfig: String) -> String? {
-        guard
-            !cloakConfig.isEmpty,
-            let data = cloakConfig.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let remoteHost = json["RemoteHost"] as? String,
-            !remoteHost.isEmpty
-        else {
+        guard !cloakConfig.isEmpty else {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: config empty")
             return nil
         }
-        return remoteHost
+        guard let data = cloakConfig.data(using: .utf8) else {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: config is not UTF-8")
+            return nil
+        }
+        do {
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: JSON root is not object")
+                return nil
+            }
+            guard let remoteHost = json["RemoteHost"] as? String else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: RemoteHost key missing")
+                return nil
+            }
+            let trimmed = remoteHost.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction skipped: RemoteHost empty")
+                return nil
+            }
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extracted host=\(maskStr(value: trimmed))")
+            return trimmed
+        } catch {
+            logs.writeLog(log: "[DEBUG][Routing] Cloak RemoteHost extraction failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Converts host/IP into an excluded /32 route
@@ -247,6 +463,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         if isValidIPv4(trimmed) { return trimmed }
+        let start = Date()
+        logs.writeLog(log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed))")
 
         var hints = addrinfo(
             ai_flags: AI_ADDRCONFIG,
@@ -260,14 +478,36 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         )
         var res: UnsafeMutablePointer<addrinfo>?
         let rc = getaddrinfo(trimmed, nil, &hints, &res)
-        guard rc == 0, let first = res else { return nil }
+        guard rc == 0, let first = res else {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) failed " +
+                    "rc=\(rc) error=\(String(cString: gai_strerror(rc))) elapsed=\(elapsedMs(since: start))ms"
+            )
+            return nil
+        }
         defer { freeaddrinfo(res) }
 
         var addr = first.pointee.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee.sin_addr }
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         let ptr = inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-        guard ptr != nil else { return nil }
-        return String(cString: buffer)
+        guard ptr != nil else {
+            let ntopErrno = errno
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) inet_ntop failed " +
+                    "errno=\(ntopErrno) \(String(cString: strerror(ntopErrno))) elapsed=\(elapsedMs(since: start))ms"
+            )
+            return nil
+        }
+        let value = String(cString: buffer)
+        logs.writeLog(
+            log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: trimmed)) ok " +
+                "ip=\(maskStr(value: value)) elapsed=\(elapsedMs(since: start))ms"
+        )
+        return value
+    }
+
+    private func elapsedMs(since start: Date) -> Int {
+        Int(Date().timeIntervalSince(start) * 1000)
     }
 
     private func resolveIPv4IfNeededWithTimeout(_ host: String, timeout: TimeInterval) -> String? {
@@ -286,6 +526,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
         let wait = group.wait(timeout: .now() + timeout)
         if wait == .timedOut {
+            logs.writeLog(
+                log: "[DEBUG][Routing] resolving IPv4 host=\(maskStr(value: host)) timed out after \(Int(timeout * 1000))ms"
+            )
             return nil
         }
         lock.lock()


### PR DESCRIPTION
## Why

The attached `DobbyVPN_logs_2026-05-07_09-48-37.txt` does not show the Network Extension being killed by iOS.

What it does show:

- `2026-05-07 07:47:00`: `startTunnel` completes and the VPN reaches `VPN connected`.
- `2026-05-07 07:48:09` onward: the tunnel starts producing many upstream Outline/WSS failures:
  - 100 TCP `connection reset by peer` errors
  - 13 UDP packet-dial failures caused by the same upstream TCP reset
  - all to `155.212.183.196:443`
- `2026-05-07 07:48:32`: the app logs that the connection button was clicked while `vpnStarted=true`, then requests `stopVPNTunnel()`.
- `2026-05-07 07:48:32`: `stopTunnel reason=1` follows that user/app stop request.

So the current evidence points at upstream WSS socket resets before the user/app stop, not at a proven iOS tunnel crash. The existing logs were not detailed enough to tell whether those upstream sockets were being protected/bypassed correctly on iOS 26, whether routing changed underneath the tunnel, or whether health-check logs after stop were just in-flight checks.

This PR ports the useful logging ideas from `ai-ios26-dig` into current `main`, but does not adopt that branch's alternate broken startup path.

## What changed

- Added detailed iOS tunnel lifecycle logs:
  - iOS version, launch/tunnel ids, startup options
  - `setTunnelNetworkSettings` begin/failure/success context
  - interface snapshots before tunnel, after tunnel settings, and after protocol startup
  - `NWPathMonitor` path/interface changes
  - `cancelTunnelWithError`, `sleep`, `wake`, app-message handling, teardown stages
- Added Outline/Cloak Swift interactor timing:
  - config shape without secrets
  - native call begin/end/failure timing
  - WSS host/path diagnostics
  - fixed `stopCloak()` to call the Cloak stop API instead of Outline disconnect
- Added Go Outline/SOCKS diagnostics:
  - transport summary
  - TCP/UDP dial attempt, success, failure, elapsed time, local/remote addresses
  - cumulative dial stats
  - SOCKS server stop/error detail
- Added tun2socks/protected socket diagnostics:
  - route decision logs for DIRECT vs VPN
  - active TCP/UDP connection counts and lifetimes
  - protected TCP/UDP dial logs
  - iOS `SO_NO_TC_NETPOLICY` success/failure plus visible interface list
- Added health-check logging and accuracy fixes:
  - DNS resolve failures no longer count as success just because they are not the string `Timeout`
  - HTTP checks now log URLSession metrics, protocol, local/remote address, DNS/TCP/TLS/TTFB/total timings
  - server-alive checks log dial/write/read/timeout/reset outcomes
  - iOS `checkServerAlive` now uses the native read/write probe instead of the simpler TCP ping path
  - XPC heartbeat errors/timeouts are logged explicitly
- Fixed misleading stop logs:
  - stop now logs that `stopVPNTunnel()` was requested and waits for `NEVPNStatusDidChange`
  - health-check cancellation now logs that in-flight native checks may continue until timeout

## What this should prove in the next iOS 26 capture

The next log should answer:

- Does each upstream WSS dial get socket protection applied successfully?
- Which local address/interface is used for upstream server sockets?
- Are failures happening before or after SOCKS/Outline creates the WSS connection?
- Do health-check HTTP requests route through the tunnel or bypass it?
- Does `NWPath` change immediately before resets start?
- Are false failure logs only emitted after a user/app stop request?

## Validation

Passed:

```sh
git diff --check
go test ./healthcheck ./outline ./outline/internal ./tunnel/...
```

Could not complete locally:

- `go test ./ios_exports` / `go test ./cloak`: existing missing `go.sum` entries for `google.golang.org/grpc`.
- Kotlin Gradle compile: local Java is `25.0.3-ea`, which Gradle rejects before compiling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS-facing health-check wrappers and protected TCP ping with richer diagnostics.

* **Bug Fixes**
  * Prevented stale health-check results after restart cycles.
  * Improved timeout and error handling for connectivity probes.

* **Improvements**
  * Enhanced active-connection tracking and VPN lifecycle logging.
  * Better network interface/path diagnostics and detailed health-check metrics.
  * Explicit memory cleanup on client disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->