### PR TITLE
Improve tunnel stability diagnostics

### DIFF
--- a/go_module/log/logger.go
+++ b/go_module/log/logger.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -148,8 +150,28 @@ func SetPath(path string) error {
 	lg.dumpBuffer()
 
 	logrus.AddHook(&logrusToSlogHook{})
+	logRuntimeInfo()
 
 	return nil
+}
+
+func logRuntimeInfo() {
+	modulePath := "(unknown)"
+	moduleVersion := "(unknown)"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		modulePath = info.Main.Path
+		moduleVersion = info.Main.Version
+	}
+
+	Infof(
+		"[GoRuntime] goos=%s goarch=%s goVersion=%s numCPU=%d module=%s moduleVersion=%s",
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+		runtime.NumCPU(),
+		modulePath,
+		moduleVersion,
+	)
 }
 
 func (logger *Logger) bufInfof(format string, args ...any) {

--- a/go_module/outline/internal/outline_device.go
+++ b/go_module/outline/internal/outline_device.go
@@ -111,7 +111,7 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 
 	server := socks5.NewServer(
 		socks5.WithDial(od.handleDial),
-		socks5.WithLogger(socksLogger{}),
+		socks5.WithLogger(socksLogger{device: od}),
 	)
 
 	lc := net.ListenConfig{}
@@ -139,9 +139,11 @@ func NewOutlineDevice(transportConfig string) (*OutlineDevice, error) {
 	return od, nil
 }
 
-type socksLogger struct{}
+type socksLogger struct {
+	device *OutlineDevice
+}
 
-func (socksLogger) Errorf(format string, args ...interface{}) {
+func (l socksLogger) Errorf(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	if strings.Contains(msg, "EOF") ||
 		strings.Contains(msg, "use of closed network connection") ||
@@ -150,7 +152,27 @@ func (socksLogger) Errorf(format string, args ...interface{}) {
 	}
 	if strings.Contains(msg, "chacha20poly1305: message authentication failed") {
 		count := socksInternalAuthErr.Add(1)
-		log.Infof("[SOCKS5 internal][auth_error count=%d] %s", count, msg)
+		if l.device != nil {
+			log.Infof(
+				"[SOCKS5 internal][auth_error count=%d websocket=%v tcpPath=%v udpPath=%v packetDialer=%T] %s",
+				count,
+				l.device.websocket,
+				l.device.hasTCPPath,
+				l.device.hasUDPPath,
+				l.device.packetDialer,
+				msg,
+			)
+			if count == 1 || count%25 == 0 {
+				log.Infof(
+					"[SOCKS5 UDP DIAG] auth errors mean UDP responses could not be decrypted; websocket=%v udpPath=%v packetDialer=%T",
+					l.device.websocket,
+					l.device.hasUDPPath,
+					l.device.packetDialer,
+				)
+			}
+		} else {
+			log.Infof("[SOCKS5 internal][auth_error count=%d] %s", count, msg)
+		}
 		return
 	}
 	if strings.Contains(msg, "connection reset by peer") {

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -25,13 +25,9 @@ var (
 )
 
 const (
-	maxActiveTCPConnections         = 256
-	maxActiveTCPConnectionsPerHost  = 64
-	maxActiveTCPConnectionsPerDest  = 32
-	maxActiveUDPAssociations        = 256
-	maxActiveUDPAssociationsPerHost = 64
-	maxActiveUDPAssociationsPerDest = 32
-	udpAssociationIdleTimeout       = 10 * time.Second
+	maxActiveTCPConnections  = 256
+	maxActiveUDPAssociations = 256
+	udpAssociationIdleTimeout = 10 * time.Second
 )
 
 type DobbyProxy struct {
@@ -182,7 +178,7 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 }
 
 func (p *DobbyProxy) dialTCPRoute(ctx context.Context, metadata *M.Metadata, route string, px proxy.Proxy, attempt uint64, dest string, start time.Time) (net.Conn, error) {
-	active, release, err := p.tcpSlot.reserve(dest, &p.activeTCP)
+	active, release, err := p.tcpSlot.reserve(&p.activeTCP)
 	if err != nil {
 		p.tcpLimitErr.Add(1)
 		log.Infof("[Router] %s TCP dial error attempt=%d dest=%s elapsed=%s stats={%s} err=%v", route, attempt, dest, time.Since(start), p.flowStats(), err)
@@ -212,7 +208,7 @@ func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 }
 
 func (p *DobbyProxy) dialUDPRoute(metadata *M.Metadata, route string, px proxy.Proxy, attempt uint64, dest string, start time.Time) (net.PacketConn, error) {
-	active, release, err := p.udpSlot.reserve(dest, &p.activeUDP)
+	active, release, err := p.udpSlot.reserve(&p.activeUDP)
 	if err != nil {
 		p.udpLimitErr.Add(1)
 		log.Infof("[Router] %s UDP dial error attempt=%d dest=%s elapsed=%s stats={%s} err=%v", route, attempt, dest, time.Since(start), p.flowStats(), err)
@@ -270,34 +266,13 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 		return fmt.Errorf("current dialer is not a proxy")
 	}
 	log.Infof("[Engine] vpn outbound proxy type=%T addr=%s", vpnOutbound, vpnOutbound.Addr())
-	log.Infof(
-		"[Engine] DobbyProxy limits tcp(total=%d host=%d dest=%d) udp(total=%d host=%d dest=%d idleTimeout=%s)",
-		maxActiveTCPConnections,
-		maxActiveTCPConnectionsPerHost,
-		maxActiveTCPConnectionsPerDest,
-		maxActiveUDPAssociations,
-		maxActiveUDPAssociationsPerHost,
-		maxActiveUDPAssociationsPerDest,
-		udpAssociationIdleTimeout,
-	)
+	log.Infof("[Engine] DobbyProxy limits tcp=%d udp=%d idleTimeout=%s", maxActiveTCPConnections, maxActiveUDPAssociations, udpAssociationIdleTimeout)
 
 	wrapper := &DobbyProxy{
-		vpn:    vpnOutbound,
-		direct: &protected_dialer.ProtectedDirectProxy{Proxy: proxy.NewDirect()},
-		tcpSlot: flowSlot{
-			byHost:   make(map[string]int),
-			byDest:   make(map[string]int),
-			maxTotal: maxActiveTCPConnections,
-			maxHost:  maxActiveTCPConnectionsPerHost,
-			maxDest:  maxActiveTCPConnectionsPerDest,
-		},
-		udpSlot: flowSlot{
-			byHost:   make(map[string]int),
-			byDest:   make(map[string]int),
-			maxTotal: maxActiveUDPAssociations,
-			maxHost:  maxActiveUDPAssociationsPerHost,
-			maxDest:  maxActiveUDPAssociationsPerDest,
-		},
+		vpn:     vpnOutbound,
+		direct:  &protected_dialer.ProtectedDirectProxy{Proxy: proxy.NewDirect()},
+		tcpSlot: flowSlot{maxTotal: maxActiveTCPConnections},
+		udpSlot: flowSlot{maxTotal: maxActiveUDPAssociations},
 	}
 
 	t.SetDialer(wrapper)
@@ -333,7 +308,7 @@ func StopEngine() {
 
 func (p *DobbyProxy) flowStats() string {
 	return fmt.Sprintf(
-		"activeTCP=%d peakTCP=%d activeUDP=%d peakUDP=%d tcpAttempt=%d udpAttempt=%d tcpLimitErr=%d udpLimitErr=%d udpIdleTimeout=%d limits=tcp:%d/%d/%d,udp:%d/%d/%d",
+		"activeTCP=%d peakTCP=%d activeUDP=%d peakUDP=%d tcpAttempt=%d udpAttempt=%d tcpLimitErr=%d udpLimitErr=%d udpIdleTimeout=%d limits=tcp:%d,udp:%d",
 		p.activeTCP.Load(),
 		p.peakTCP.Load(),
 		p.activeUDP.Load(),
@@ -344,11 +319,7 @@ func (p *DobbyProxy) flowStats() string {
 		p.udpLimitErr.Load(),
 		p.udpIdleTimeout.Load(),
 		maxActiveTCPConnections,
-		maxActiveTCPConnectionsPerHost,
-		maxActiveTCPConnectionsPerDest,
 		maxActiveUDPAssociations,
-		maxActiveUDPAssociationsPerHost,
-		maxActiveUDPAssociationsPerDest,
 	)
 }
 
@@ -377,60 +348,14 @@ func updatePeakInt64(peak *atomic.Int64, current int64) {
 }
 
 type flowSlot struct {
-	mu       sync.Mutex
-	byHost   map[string]int
-	byDest   map[string]int
 	maxTotal int64
-	maxHost  int
-	maxDest  int
 }
 
-func (s *flowSlot) reserve(dest string, active *atomic.Int64) (cur int64, release func() int64, err error) {
-	host := flowHost(dest)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	cur = active.Load()
-	switch {
-	case cur >= s.maxTotal:
-		return cur, nil, fmt.Errorf("flow limit reached active=%d max=%d", cur, s.maxTotal)
-	case s.byHost[host] >= s.maxHost:
-		return cur, nil, fmt.Errorf("host flow limit reached host=%s active=%d max=%d", host, s.byHost[host], s.maxHost)
-	case s.byDest[dest] >= s.maxDest:
-		return cur, nil, fmt.Errorf("destination flow limit reached dest=%s active=%d max=%d", dest, s.byDest[dest], s.maxDest)
-	}
-
-	s.byHost[host]++
-	s.byDest[dest]++
+func (s *flowSlot) reserve(active *atomic.Int64) (cur int64, release func() int64, err error) {
 	cur = active.Add(1)
-
-	release = func() int64 {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		decrementFlowCount(s.byHost, host)
-		decrementFlowCount(s.byDest, dest)
-		return active.Add(-1)
+	if cur > s.maxTotal {
+		active.Add(-1)
+		return cur - 1, nil, fmt.Errorf("flow limit reached active=%d max=%d", cur-1, s.maxTotal)
 	}
-
-	return cur, release, nil
-}
-
-func decrementFlowCount(counts map[string]int, key string) {
-	if counts[key] <= 1 {
-		delete(counts, key)
-		return
-	}
-	counts[key]--
-}
-
-func flowHost(dest string) string {
-	host, _, err := net.SplitHostPort(dest)
-	if err != nil || host == "" {
-		if dest == "" {
-			return "(unknown)"
-		}
-		return dest
-	}
-	return host
+	return cur, func() int64 { return active.Add(-1) }, nil
 }

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -25,12 +25,12 @@ var (
 )
 
 const (
-	maxActiveTCPConnections         = 96
-	maxActiveTCPConnectionsPerHost  = 32
-	maxActiveTCPConnectionsPerDest  = 16
-	maxActiveUDPAssociations        = 64
-	maxActiveUDPAssociationsPerHost = 16
-	maxActiveUDPAssociationsPerDest = 8
+	maxActiveTCPConnections         = 256
+	maxActiveTCPConnectionsPerHost  = 64
+	maxActiveTCPConnectionsPerDest  = 32
+	maxActiveUDPAssociations        = 256
+	maxActiveUDPAssociationsPerHost = 64
+	maxActiveUDPAssociationsPerDest = 32
 	udpAssociationIdleTimeout       = 10 * time.Second
 )
 
@@ -270,6 +270,16 @@ func StartEngine(cfg platform_engine.EngineConfig) error {
 		return fmt.Errorf("current dialer is not a proxy")
 	}
 	log.Infof("[Engine] vpn outbound proxy type=%T addr=%s", vpnOutbound, vpnOutbound.Addr())
+	log.Infof(
+		"[Engine] DobbyProxy limits tcp(total=%d host=%d dest=%d) udp(total=%d host=%d dest=%d idleTimeout=%s)",
+		maxActiveTCPConnections,
+		maxActiveTCPConnectionsPerHost,
+		maxActiveTCPConnectionsPerDest,
+		maxActiveUDPAssociations,
+		maxActiveUDPAssociationsPerHost,
+		maxActiveUDPAssociationsPerDest,
+		udpAssociationIdleTimeout,
+	)
 
 	wrapper := &DobbyProxy{
 		vpn:    vpnOutbound,
@@ -323,7 +333,7 @@ func StopEngine() {
 
 func (p *DobbyProxy) flowStats() string {
 	return fmt.Sprintf(
-		"activeTCP=%d peakTCP=%d activeUDP=%d peakUDP=%d tcpAttempt=%d udpAttempt=%d tcpLimit=%d udpLimit=%d udpIdleTimeout=%d",
+		"activeTCP=%d peakTCP=%d activeUDP=%d peakUDP=%d tcpAttempt=%d udpAttempt=%d tcpLimitErr=%d udpLimitErr=%d udpIdleTimeout=%d limits=tcp:%d/%d/%d,udp:%d/%d/%d",
 		p.activeTCP.Load(),
 		p.peakTCP.Load(),
 		p.activeUDP.Load(),
@@ -333,6 +343,12 @@ func (p *DobbyProxy) flowStats() string {
 		p.tcpLimitErr.Load(),
 		p.udpLimitErr.Load(),
 		p.udpIdleTimeout.Load(),
+		maxActiveTCPConnections,
+		maxActiveTCPConnectionsPerHost,
+		maxActiveTCPConnectionsPerDest,
+		maxActiveUDPAssociations,
+		maxActiveUDPAssociationsPerHost,
+		maxActiveUDPAssociationsPerDest,
 	)
 }
 

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.android.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.android.kt
@@ -1,6 +1,7 @@
 package com.dobby.feature.logging.domain
 
 import android.content.Context
+import android.os.Build
 import okio.Path
 import okio.Path.Companion.toPath
 import com.dobby.outline.OutlineGo
@@ -15,6 +16,21 @@ internal fun initLogFilePath(context: Context) {
 
 actual fun provideLogFilePath(): Path {
     return "${appContext.filesDir.absolutePath}/app_logs.txt".toPath()
+}
+
+actual fun platformLogInfo(): String {
+    return "platform=android " +
+        "sdk=${Build.VERSION.SDK_INT} " +
+        "release=${Build.VERSION.RELEASE} " +
+        "codename=${Build.VERSION.CODENAME} " +
+        "incremental=${Build.VERSION.INCREMENTAL} " +
+        "manufacturer=${Build.MANUFACTURER} " +
+        "brand=${Build.BRAND} " +
+        "model=${Build.MODEL} " +
+        "device=${Build.DEVICE} " +
+        "product=${Build.PRODUCT} " +
+        "hardware=${Build.HARDWARE} " +
+        "abis=${Build.SUPPORTED_ABIS.joinToString(",")}"
 }
 
 fun initLogger() {

--- a/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.kt
+++ b/kmp_module/app/src/commonMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.kt
@@ -13,6 +13,7 @@ import org.koin.compose.koinInject
 
 expect val fileSystem: FileSystem
 expect fun provideLogFilePath(): Path
+expect fun platformLogInfo(): String
 
 interface SentryLogsRepository{
     fun log(string: String) {
@@ -49,6 +50,7 @@ class LogsRepository(
         if (!fileSystem.exists(logFilePath)) {
             fileSystem.sink(logFilePath).buffer().use { }
         }
+        writeLog("[Platform] ${platformLogInfo()} logPath=$logFilePath")
         CoroutineScope(Dispatchers.Default).launch {
             logEventsChannel.emitLogs(readLogs(UI_TAIL_LINES))
         }

--- a/kmp_module/app/src/iosMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.ios.kt
+++ b/kmp_module/app/src/iosMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.ios.kt
@@ -4,6 +4,7 @@ import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
 import platform.Foundation.NSFileManager
+import platform.Foundation.NSProcessInfo
 
 actual val fileSystem: FileSystem = FileSystem.SYSTEM
 
@@ -25,4 +26,14 @@ actual fun provideLogFilePath(): Path {
         println("Log file already exists at: $logFilePath")
     }
     return logFilePath
+}
+
+actual fun platformLogInfo(): String {
+    val processInfo = NSProcessInfo.processInfo
+    val version = processInfo.operatingSystemVersion
+    return "platform=ios " +
+        "osVersion=${version.majorVersion}.${version.minorVersion}.${version.patchVersion} " +
+        "osDescription=${processInfo.operatingSystemVersionString} " +
+        "process=${processInfo.processName} " +
+        "physicalMemory=${processInfo.physicalMemory}"
 }

--- a/kmp_module/app/src/jvmMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.jvm.kt
+++ b/kmp_module/app/src/jvmMain/kotlin/com/dobby/feature/logging/domain/LogsRepository.jvm.kt
@@ -16,3 +16,13 @@ actual fun provideLogFilePath(): Path {
     val logFile = File(appDir, "app_logs.txt")
     return logFile.absolutePath.toPath()
 }
+
+actual fun platformLogInfo(): String {
+    return "platform=jvm " +
+        "osName=${System.getProperty("os.name")} " +
+        "osVersion=${System.getProperty("os.version")} " +
+        "osArch=${System.getProperty("os.arch")} " +
+        "javaVersion=${System.getProperty("java.version")} " +
+        "javaVendor=${System.getProperty("java.vendor")} " +
+        "javaVm=${System.getProperty("java.vm.name")}"
+}

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -27,6 +27,43 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var memoryHighWaterMarkMB = 0.0
     private var tunnelStartedAt = Date()
 
+    private func fixedCString<T>(_ value: inout T) -> String {
+        withUnsafePointer(to: &value) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: MemoryLayout<T>.size) { cString in
+                String(cString: cString)
+            }
+        }
+    }
+
+    private func logSystemInfo(osVersionString: String) {
+        let processInfo = ProcessInfo.processInfo
+        var sysname = "unknown"
+        var release = "unknown"
+        var version = "unknown"
+        var machine = "unknown"
+
+        var uts = utsname()
+        if uname(&uts) == 0 {
+            var utsSysname = uts.sysname
+            var utsRelease = uts.release
+            var utsVersion = uts.version
+            var utsMachine = uts.machine
+            sysname = fixedCString(&utsSysname)
+            release = fixedCString(&utsRelease)
+            version = fixedCString(&utsVersion)
+            machine = fixedCString(&utsMachine)
+        }
+
+        let physicalMemoryMB = processInfo.physicalMemory / 1024 / 1024
+        logs.writeLog(
+            log: "[tunnel:\(tunnelId)] OS platform=iOS osVersion=\(osVersionString) " +
+                "osDescription=\(processInfo.operatingSystemVersionString) " +
+                "process=\(processInfo.processName) kernel=\(sysname) " +
+                "kernelRelease=\(release) kernelVersion=\(version) " +
+                "machine=\(machine) physicalMemoryMB=\(physicalMemoryMB)"
+        )
+    }
+
     func reportMemoryUsageMB() -> Double {
         var info = task_vm_info_data_t()
         var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.stride / MemoryLayout<natural_t>.stride)
@@ -130,6 +167,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
         let osVersionString = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
         let optionKeys = options?.keys.sorted().joined(separator: ",") ?? "(none)"
+        logSystemInfo(osVersionString: osVersionString)
         logs.writeLog(log: "[iOS26-RESEARCH] iOS version: \(osVersionString)")
         logs.writeLog(log: "[tunnel:\(tunnelId)] startTunnel tid=\(tid) launchId=\(launchId) optionKeys=\(optionKeys)")
         logs.writeLog(log: "Sentry is running in PacketTunnelProvider")


### PR DESCRIPTION
Summary:
- Raise TCP/UDP flow limits hit by SpeedTest bursts
- Add OS/runtime diagnostics across Go, Kotlin platform targets, and iOS packet tunnel
- Add UDP auth failure context for Outline/WebSocket paths

Testing:
- git diff --check
- go -C DobbyVPN/go_module test ./log ./outline/internal ./tunnel

Notes:
- Full go test ./... remains blocked by existing missing go.sum entries for unrelated gRPC/Cloak dependencies
- Gradle compile remains blocked by local Android SDK NDK license/package setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging now captures richer system and platform metadata (OS/runtime/device details) at startup across platforms.
  * Device-specific diagnostics added to connection error logs for clearer troubleshooting.

* **Performance & Stability**
  * Tunnel concurrency was simplified to global TCP/UDP limits to streamline connection handling.
  * Flow statistics and limit reporting enhanced with separate error counters and explicit configured limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->