### PR TITLE
WebViewScreen (android): route non-http URLs out and surface load errors

### DIFF
--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/authentication/ui/WebViewScreen.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/authentication/ui/WebViewScreen.kt
@@ -1,17 +1,31 @@
 package com.dobby.feature.authentication.ui
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
+import android.net.Uri
+import android.util.Log
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 
 @Composable
@@ -21,26 +35,56 @@ actual fun WebViewScreen(
     enableJavaScript: Boolean
 ) {
     var isLoading by remember { mutableStateOf(true) }
+    var errorDescription by remember { mutableStateOf<String?>(null) }
+    val context = LocalContext.current
 
     Column(modifier = modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
             AndroidView(
-                factory = { context ->
-                    WebView(context).apply {
+                factory = { ctx ->
+                    WebView(ctx).apply {
                         settings.javaScriptEnabled = enableJavaScript
                         webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                request: WebResourceRequest?
+                            ): Boolean {
+                                val target = request?.url ?: return false
+                                val scheme = target.scheme?.lowercase()
+                                if (scheme == "http" || scheme == "https") {
+                                    return false
+                                }
+                                return launchExternal(context, target)
+                            }
+
                             override fun onPageStarted(
                                 view: WebView?,
                                 url: String?,
                                 favicon: Bitmap?
                             ) {
                                 super.onPageStarted(view, url, favicon)
+                                errorDescription = null
                                 isLoading = true
                             }
 
                             override fun onPageFinished(view: WebView?, url: String?) {
                                 super.onPageFinished(view, url)
                                 isLoading = false
+                            }
+
+                            override fun onReceivedError(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                                error: WebResourceError?
+                            ) {
+                                super.onReceivedError(view, request, error)
+                                if (request?.isForMainFrame != true) return
+                                errorDescription = error?.description?.toString() ?: "unknown"
+                                isLoading = false
+                                Log.w(
+                                    "DobbyWebView",
+                                    "load error ${error?.errorCode}: $errorDescription @ ${request.url}"
+                                )
                             }
                         }
                         loadUrl(url)
@@ -49,10 +93,35 @@ actual fun WebViewScreen(
                 modifier = Modifier.fillMaxSize()
             )
 
-            // Loader
-            if (isLoading) {
+            if (isLoading && errorDescription == null) {
                 LoadingScreen()
             }
+            errorDescription?.let { description ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(24.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(text = "Failed to load page")
+                    Text(text = description)
+                }
+            }
         }
+    }
+}
+
+private fun launchExternal(context: Context, uri: Uri): Boolean {
+    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    return try {
+        context.startActivity(intent)
+        true
+    } catch (e: ActivityNotFoundException) {
+        Log.w("DobbyWebView", "No handler for $uri", e)
+        Toast.makeText(context, "No app to open this link", Toast.LENGTH_LONG).show()
+        true
     }
 }


### PR DESCRIPTION
Closes #184.

## Summary

The Android `actual` of `WebViewScreen` (`kmp_module/app/src/androidMain/.../WebViewScreen.kt`) handled only `onPageStarted` / `onPageFinished` to drive an `isLoading` bool. This PR adds two callbacks so the authentication WebView behaves predictably under realistic conditions.

- `shouldOverrideUrlLoading` -- keep `http(s)` in the WebView and hand every other scheme (`mailto:`, `tel:`, `intent:`, `market:`, `geo:`, ...) to the system via `startActivity(Intent.ACTION_VIEW, uri)`. The launch is wrapped in `try / catch (ActivityNotFoundException)` with a Toast fallback so a missing handler does not crash the host Activity.
- `onReceivedError` (main-frame only) -- flip an `errorDescription` state and render an inline `Failed to load page` block on top of the WebView instead of an infinite spinner. Logs the `WebResourceError` code / description / failing URL for diagnostics.

Common-main `expect` signature and the `iosMain` actual are unchanged.

## Test plan

- [x] Open the WebViewScreen with the device online  LoadingScreen shows while loading, hides on page finish, page renders normally.
- [x] Tap a `mailto:` link on the rendered page -- system mail picker opens, WebView stays on the page.
- [x] Tap a `tel:` link -- dialer opens, WebView stays on the page.
- [x] Run with WiFi/cellular disabled -- the inline `Failed to load page` block appears with `net::ERR_INTERNET_DISCONNECTED` (or similar) instead of an endless spinner.
- [x] Hit a non-handlerable URI on a device without a default browser -- Toast `No app to open this link` appears, screen stays alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External links now open in appropriate applications instead of within the web view.

* **Bug Fixes**
  * Added error messages when web content fails to load.
  * Improved loading indicator accuracy during page load operations.
  * Enhanced error logging for better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DobbyVPN/DobbyVPN/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->