### PR TITLE
Fix CLoak on macos

### DIFF
--- a/go_module/cloak/routing_macos.go
+++ b/go_module/cloak/routing_macos.go
@@ -17,7 +17,7 @@ func StartRoutingCloak(proxyIP string) error {
 	if err != nil {
 		return fmt.Errorf("failed to discover gateway for Cloak route: %w", err)
 	}
-	addSpecificRoute2 := fmt.Sprintf("sudo route add -net %s/32 %s", proxyIP, gatewayIP.String())
+	addSpecificRoute2 := fmt.Sprintf("route -n add -host %s %s", proxyIP, gatewayIP.String())
 
 	if _, err := routing.ExecuteCommand(addSpecificRoute2); err != nil {
 		log.Infof("failed to add specific route: %v", err)
@@ -32,7 +32,7 @@ func StopRoutingCloak(proxyIP string) error {
 	if err != nil {
 		return fmt.Errorf("failed to discover gateway for Cloak route removal: %w", err)
 	}
-	removeSpecificRoute := fmt.Sprintf("sudo route delete -net %s/32 %s", proxyIP, gatewayIP.String())
+	removeSpecificRoute := fmt.Sprintf("route -n delete -host %s %s", proxyIP, gatewayIP.String())
 	if _, err := routing.ExecuteCommand(removeSpecificRoute); err != nil {
 		log.Infof("failed to remove specific route: %v", err)
 		return fmt.Errorf("failed to remove Cloak route for %s via %s: %w", proxyIP, gatewayIP.String(), err)

--- a/go_module/desktop_exports/api/cloak.go
+++ b/go_module/desktop_exports/api/cloak.go
@@ -7,15 +7,19 @@ import (
 	"go_module/log"
 )
 
-func StartCloakClient(localHost, localPort, config string, udp bool) {
+func StartCloakClient(localHost, localPort, config string, udp bool) error {
 	log.Infof("StartCloakClient")
-	cloak.StartCloakClient(
+	if err := cloak.StartCloakClient(
 		localHost,
 		localPort,
 		config,
 		bool(udp),
-	)
+	); err != nil {
+		log.Infof("StartCloakClient failed: %v", err)
+		return err
+	}
 	log.Infof("end StartCloakClient")
+	return nil
 }
 
 func StopCloakClient() {

--- a/go_module/desktop_exports/proto/cloak.go
+++ b/go_module/desktop_exports/proto/cloak.go
@@ -13,7 +13,10 @@ import (
 
 func (s *Server) StartCloakClient(_ context.Context, in *grpcproto.StartCloakClientRequest) (*grpcproto.Empty, error) {
 	log.Infof("StartCloakClient")
-	go api.StartCloakClient(in.GetLocalHost(), in.GetLocalPort(), in.GetConfig(), in.GetUdp())
+	if err := api.StartCloakClient(in.GetLocalHost(), in.GetLocalPort(), in.GetConfig(), in.GetUdp()); err != nil {
+		log.Infof("StartCloakClient failed: %v", err)
+		return nil, err
+	}
 	return &grpcproto.Empty{}, nil
 }
 

--- a/go_module/modules/Cloak/exported_client/ck-client.go
+++ b/go_module/modules/Cloak/exported_client/ck-client.go
@@ -155,6 +155,7 @@ func (c *CkClient) Connect() (returnErr error) {
 	}
 
 	done := make(chan struct{})
+	ready := make(chan error, 1)
 	c.routeDone = done
 
 	go func() {
@@ -174,18 +175,21 @@ func (c *CkClient) Connect() (returnErr error) {
 			conn, err := net.ListenUDP("udp", udpAddr)
 			if err != nil {
 				log.Infof("ck-client: goroutines: err %v\n", err)
+				ready <- fmt.Errorf("failed to listen on UDP %s: %w", localConfig.LocalAddr, err)
 				return
 			}
 
 			c.udpConn = conn
 
 			log.Infof("ck-client: start listening on UDP %v for %v client", localConfig.LocalAddr, authInfo.ProxyMethod)
+			ready <- nil
 			client.RouteUDP(func() (*net.UDPConn, error) { return conn, nil }, localConfig.Timeout, remoteConfig.Singleplex, seshMaker)
 			log.Infof("ck-client: stop listening on UDP %v for %v client", localConfig.LocalAddr, authInfo.ProxyMethod)
 		} else {
 			baseListener, err := net.Listen("tcp", localConfig.LocalAddr)
 			if err != nil {
 				log.Infof("ck-client: goroutines: err %v\n", err)
+				ready <- fmt.Errorf("failed to listen on TCP %s: %w", localConfig.LocalAddr, err)
 				return
 			}
 
@@ -193,10 +197,22 @@ func (c *CkClient) Connect() (returnErr error) {
 			c.listener = l
 
 			log.Infof("ck-client: start listening on TCP %v for %v client", localConfig.LocalAddr, authInfo.ProxyMethod)
+			ready <- nil
 			client.RouteTCP(l, localConfig.Timeout, remoteConfig.Singleplex, seshMaker)
 			log.Infof("ck-client: stop listening on TCP %v for %v client", localConfig.LocalAddr, authInfo.ProxyMethod)
 		}
 	}()
+
+	select {
+	case err := <-ready:
+		if err != nil {
+			c.connected = false
+			return err
+		}
+	case <-time.After(2 * time.Second):
+		c.connected = false
+		return fmt.Errorf("timed out waiting for Cloak listener on %s", localConfig.LocalAddr)
+	}
 
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloak client startup now includes error reporting and a timeout mechanism to prevent indefinite waiting during connection initialization
  * Enhanced error logging when Cloak client fails to start
  * Improved macOS network routing command syntax and error handling
  * Better connection state synchronization between client and startup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->