### PR TITLE
Use only IPv6

### DIFF
--- a/go_module/core/internal/app_macos.go
+++ b/go_module/core/internal/app_macos.go
@@ -96,6 +96,7 @@ func (app App) Run(ctx context.Context, initResult chan<- error) error {
 	log.Infof("[Protocol] ProtocolDevice successfully created")
 
 	var closeOnce sync.Once
+	tunName := ""
 	closeAll := func() {
 		closeOnce.Do(func() {
 			log.Infof("[Lifecycle] Shutting down VPN components (tun2socks + device)")
@@ -115,7 +116,7 @@ func (app App) Run(ctx context.Context, initResult chan<- error) error {
 	defer func() {
 		common.Client.MarkInCriticalSection(coreCommon.Name)
 		log.Infof("[Routing] Restoring system routing (removing VPN routes)...")
-		routing.StopRouting(serverIP.String(), gatewayIP.String())
+		routing.StopRouting(serverIP.String(), gatewayIP.String(), tunName)
 		log.Infof("[Routing] System default route restored via %s", gatewayIP.String())
 		common.Client.MarkOutOffCriticalSection(coreCommon.Name)
 	}()
@@ -132,7 +133,7 @@ func (app App) Run(ctx context.Context, initResult chan<- error) error {
 		return err
 	}
 
-	tunName := platform_engine.LastIface
+	tunName = platform_engine.LastIface
 
 	log.Infof("[Tunnel] tun2socks started, interface: %s", tunName)
 

--- a/go_module/routing/routing_linux.go
+++ b/go_module/routing/routing_linux.go
@@ -98,7 +98,11 @@ func getDefaultInterfaceNameFromProcRoute(gateway net.IP) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open /proc/net/route: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Infof("[Routing][Detect][WARN] Failed to close /proc/net/route: %v", err)
+		}
+	}()
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -138,7 +142,8 @@ func parseProcRouteIPv4(hexGateway string) (net.IP, error) {
 		return nil, err
 	}
 
-	return net.IPv4(byte(value), byte(value>>8), byte(value>>16), byte(value>>24)).To4(), nil
+	gateway := uint32(value)
+	return net.IPv4(byte(gateway), byte(gateway>>8), byte(gateway>>16), byte(gateway>>24)).To4(), nil
 }
 
 func EnsureProxyRoute(proxyIP, gatewayIP, iface string) (bool, error) {

--- a/go_module/routing/routing_linux.go
+++ b/go_module/routing/routing_linux.go
@@ -236,6 +236,43 @@ func CleanupMarkedRouting(tableID, priority int, iface, gatewayIP string) error 
 	return nil
 }
 
+func startIPv6Block() error {
+	log.Infof("[Routing][IPv6] Installing IPv6 block routes")
+
+	var errs []string
+	for _, subnet := range []string{"::/1", "8000::/1"} {
+		if _, err := ExecuteCommand(fmt.Sprintf("ip -6 route replace blackhole %s metric 1", subnet)); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", subnet, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to install IPv6 block routes: %s", strings.Join(errs, "; "))
+	}
+
+	log.Infof("[Routing][IPv6][OK] IPv6 block routes installed")
+	return nil
+}
+
+func stopIPv6Block() error {
+	log.Infof("[Routing][IPv6] Removing IPv6 block routes")
+
+	var errs []string
+	for _, subnet := range []string{"::/1", "8000::/1"} {
+		if _, err := ExecuteCommand(fmt.Sprintf("ip -6 route del blackhole %s metric 1", subnet)); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", subnet, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		log.Infof("[Routing][IPv6][WARN] Failed to remove some IPv6 block routes: %s", strings.Join(errs, "; "))
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+
+	log.Infof("[Routing][IPv6][OK] IPv6 block routes removed")
+	return nil
+}
+
 func StartRouting(proxyIP, gatewayIP, uplinkIface, tunName string) error {
 	log.Infof("[Routing][Start] Switching default route → TUN (%s)", tunName)
 
@@ -245,6 +282,10 @@ func StartRouting(proxyIP, gatewayIP, uplinkIface, tunName string) error {
 	log.Infof("[Routing][Start] Setting default → dev %s", tunName)
 	if _, err := ExecuteCommand(fmt.Sprintf("ip route replace default dev %s", tunName)); err != nil {
 		return fmt.Errorf("failed to set default via tun %s: %w", tunName, err)
+	}
+
+	if err := startIPv6Block(); err != nil {
+		return err
 	}
 
 	log.Infof("[Routing][Start] Ensuring VPN server bypass: %s via %s dev %s",
@@ -265,6 +306,10 @@ func StartRouting(proxyIP, gatewayIP, uplinkIface, tunName string) error {
 
 func StopRouting(proxyIP, gatewayIP, uplinkIface string) error {
 	log.Infof("[Routing][Stop] Restoring system routing")
+
+	if err := stopIPv6Block(); err != nil {
+		log.Infof("[Routing][Stop][WARN] IPv6 block cleanup failed: %v", err)
+	}
 
 	log.Infof("[Routing][Stop] Removing proxy route: %s", proxyIP)
 	if isLoopbackIP(proxyIP) {

--- a/go_module/routing/routing_linux.go
+++ b/go_module/routing/routing_linux.go
@@ -6,11 +6,11 @@ package routing
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -137,13 +137,15 @@ func getDefaultInterfaceNameFromProcRoute(gateway net.IP) (string, error) {
 }
 
 func parseProcRouteIPv4(hexGateway string) (net.IP, error) {
-	value, err := strconv.ParseUint(hexGateway, 16, 32)
+	decoded, err := hex.DecodeString(hexGateway)
 	if err != nil {
 		return nil, err
 	}
+	if len(decoded) != net.IPv4len {
+		return nil, fmt.Errorf("invalid IPv4 gateway length %d", len(decoded))
+	}
 
-	gateway := uint32(value)
-	return net.IPv4(byte(gateway), byte(gateway>>8), byte(gateway>>16), byte(gateway>>24)).To4(), nil
+	return net.IPv4(decoded[3], decoded[2], decoded[1], decoded[0]).To4(), nil
 }
 
 func EnsureProxyRoute(proxyIP, gatewayIP, iface string) (bool, error) {

--- a/go_module/routing/routing_macos.go
+++ b/go_module/routing/routing_macos.go
@@ -108,49 +108,65 @@ func isLoopbackIP(ip string) bool {
 	return parsed != nil && parsed.IsLoopback()
 }
 
-func startIPv6Block() error {
-	log.Infof("[Routing][IPv6] Installing IPv6 blackhole routes")
+var ipv6DefaultSubnets = []string{"::/1", "8000::/1"}
+
+func startIPv6Block(tunName string) error {
+	log.Infof("[Routing][IPv6] Installing IPv6 sink routes via %s", tunName)
+
+	deleteIPv6SinkRoutes(tunName, false)
 
 	var errs []string
-	for _, subnet := range []string{"::/1", "8000::/1"} {
-		cmd := fmt.Sprintf("route -n add -inet6 -net %s -interface lo0 -blackhole", subnet)
+	for _, subnet := range ipv6DefaultSubnets {
+		cmd := fmt.Sprintf("route -n add -inet6 -net %s -interface %s", subnet, tunName)
 		out, err := ExecuteCommand(cmd)
 		if err != nil {
 			if strings.Contains(out, "File exists") || strings.Contains(err.Error(), "File exists") {
-				log.Infof("[Routing][IPv6] Blackhole route already exists for %s", subnet)
+				log.Infof("[Routing][IPv6] Sink route already exists for %s", subnet)
 				continue
 			}
-			errs = append(errs, fmt.Sprintf("%s: %v, output: %s", subnet, err, out))
+			errs = append(errs, fmt.Sprintf("%s via %s: %v, output: %s", subnet, tunName, err, out))
 		}
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to install IPv6 blackhole routes: %s", strings.Join(errs, "; "))
+		return fmt.Errorf("failed to install IPv6 sink routes: %s", strings.Join(errs, "; "))
 	}
 
-	log.Infof("[Routing][IPv6][OK] IPv6 blackhole routes installed")
+	log.Infof("[Routing][IPv6][OK] IPv6 sink routes installed via %s", tunName)
 	return nil
 }
 
-func stopIPv6Block() error {
-	log.Infof("[Routing][IPv6] Removing IPv6 blackhole routes")
-
-	var errs []string
-	for _, subnet := range []string{"::/1", "8000::/1"} {
-		cmd := fmt.Sprintf("route -n delete -inet6 -net %s -interface lo0", subnet)
-		out, err := ExecuteCommand(cmd)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("%s: %v, output: %s", subnet, err, out))
-		}
+func stopIPv6Block(tunName string) error {
+	log.Infof("[Routing][IPv6] Removing IPv6 sink routes")
+	if tunName == "" {
+		log.Infof("[Routing][IPv6] Skipping IPv6 sink cleanup: TUN interface is not known")
+		return nil
 	}
 
+	errs := deleteIPv6SinkRoutes(tunName, true)
 	if len(errs) > 0 {
-		log.Infof("[Routing][IPv6][WARN] Failed to remove some IPv6 blackhole routes: %s", strings.Join(errs, "; "))
+		log.Infof("[Routing][IPv6][WARN] Failed to remove some IPv6 sink routes: %s", strings.Join(errs, "; "))
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
 
-	log.Infof("[Routing][IPv6][OK] IPv6 blackhole routes removed")
+	log.Infof("[Routing][IPv6][OK] IPv6 sink routes removed")
 	return nil
+}
+
+func deleteIPv6SinkRoutes(tunName string, collectErrors bool) []string {
+	var errs []string
+	for _, subnet := range ipv6DefaultSubnets {
+		cmd := fmt.Sprintf("route -n delete -inet6 -net %s -interface %s", subnet, tunName)
+		out, err := ExecuteCommand(cmd)
+		if err != nil && collectErrors {
+			errs = append(errs, fmt.Sprintf("%s: %v, output: %s", subnet, err, out))
+		}
+
+		legacyCmd := fmt.Sprintf("route -n delete -inet6 -net %s -interface lo0", subnet)
+		_, _ = ExecuteCommand(legacyCmd)
+	}
+
+	return errs
 }
 
 func StartRouting(proxyIP, gatewayIP, tunName string) error {
@@ -165,7 +181,7 @@ func StartRouting(proxyIP, gatewayIP, tunName string) error {
 		return fmt.Errorf("failed to set default via %s: %w", tunName, err)
 	}
 
-	if err := startIPv6Block(); err != nil {
+	if err := startIPv6Block(tunName); err != nil {
 		return err
 	}
 
@@ -184,10 +200,10 @@ func StartRouting(proxyIP, gatewayIP, tunName string) error {
 	return nil
 }
 
-func StopRouting(proxyIP, gatewayIP string) error {
+func StopRouting(proxyIP, gatewayIP, tunName string) error {
 	log.Infof("[Routing][Stop] Restoring system routing")
 
-	if err := stopIPv6Block(); err != nil {
+	if err := stopIPv6Block(tunName); err != nil {
 		log.Infof("[Routing][Stop][WARN] IPv6 block cleanup failed: %v", err)
 	}
 

--- a/go_module/routing/routing_macos.go
+++ b/go_module/routing/routing_macos.go
@@ -108,6 +108,51 @@ func isLoopbackIP(ip string) bool {
 	return parsed != nil && parsed.IsLoopback()
 }
 
+func startIPv6Block() error {
+	log.Infof("[Routing][IPv6] Installing IPv6 blackhole routes")
+
+	var errs []string
+	for _, subnet := range []string{"::/1", "8000::/1"} {
+		cmd := fmt.Sprintf("route -n add -inet6 -net %s -interface lo0 -blackhole", subnet)
+		out, err := ExecuteCommand(cmd)
+		if err != nil {
+			if strings.Contains(out, "File exists") || strings.Contains(err.Error(), "File exists") {
+				log.Infof("[Routing][IPv6] Blackhole route already exists for %s", subnet)
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("%s: %v, output: %s", subnet, err, out))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to install IPv6 blackhole routes: %s", strings.Join(errs, "; "))
+	}
+
+	log.Infof("[Routing][IPv6][OK] IPv6 blackhole routes installed")
+	return nil
+}
+
+func stopIPv6Block() error {
+	log.Infof("[Routing][IPv6] Removing IPv6 blackhole routes")
+
+	var errs []string
+	for _, subnet := range []string{"::/1", "8000::/1"} {
+		cmd := fmt.Sprintf("route -n delete -inet6 -net %s -interface lo0", subnet)
+		out, err := ExecuteCommand(cmd)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v, output: %s", subnet, err, out))
+		}
+	}
+
+	if len(errs) > 0 {
+		log.Infof("[Routing][IPv6][WARN] Failed to remove some IPv6 blackhole routes: %s", strings.Join(errs, "; "))
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+
+	log.Infof("[Routing][IPv6][OK] IPv6 blackhole routes removed")
+	return nil
+}
+
 func StartRouting(proxyIP, gatewayIP, tunName string) error {
 	log.Infof("[Routing][Start] Switching system routing to VPN (tun=%s)", tunName)
 
@@ -118,6 +163,10 @@ func StartRouting(proxyIP, gatewayIP, tunName string) error {
 	cmdDefault := fmt.Sprintf("route -n add default -interface %s", tunName)
 	if _, err := ExecuteCommand(cmdDefault); err != nil {
 		return fmt.Errorf("failed to set default via %s: %w", tunName, err)
+	}
+
+	if err := startIPv6Block(); err != nil {
+		return err
 	}
 
 	if isLoopbackIP(proxyIP) {
@@ -137,6 +186,10 @@ func StartRouting(proxyIP, gatewayIP, tunName string) error {
 
 func StopRouting(proxyIP, gatewayIP string) error {
 	log.Infof("[Routing][Stop] Restoring system routing")
+
+	if err := stopIPv6Block(); err != nil {
+		log.Infof("[Routing][Stop][WARN] IPv6 block cleanup failed: %v", err)
+	}
 
 	if isLoopbackIP(proxyIP) {
 		log.Infof("[Routing][Stop] Skipping proxy bypass removal for loopback server: %s", proxyIP)

--- a/go_module/routing/routing_windows.go
+++ b/go_module/routing/routing_windows.go
@@ -38,6 +38,8 @@ var ipv4ReservedSubnets = []string{
 	"240.0.0.0/4",
 }
 
+const ipv6BlockRuleName = "DobbyVPN Block IPv6"
+
 func ExecuteCommand(command string) (string, error) {
 	cmd := exec.Command("cmd", "/C", command)
 
@@ -51,6 +53,35 @@ func ExecuteCommand(command string) (string, error) {
 	}
 	log.Infof("Outline/routing: Command executed: %s, output: %s", log.MaskStr(command), output)
 	return string(output), nil
+}
+
+func startIPv6Block() error {
+	log.Infof("Outline/routing: Installing IPv6 outbound block rule")
+
+	_, _ = ExecuteCommand(fmt.Sprintf("netsh advfirewall firewall delete rule name=\"%s\"", ipv6BlockRuleName))
+
+	command := fmt.Sprintf(
+		"netsh advfirewall firewall add rule name=\"%s\" dir=out action=block enable=yes remoteip=::/0",
+		ipv6BlockRuleName,
+	)
+	if _, err := ExecuteCommand(command); err != nil {
+		return fmt.Errorf("failed to install IPv6 outbound block rule: %w", err)
+	}
+
+	log.Infof("Outline/routing: IPv6 outbound block rule installed")
+	return nil
+}
+
+func stopIPv6Block() error {
+	log.Infof("Outline/routing: Removing IPv6 outbound block rule")
+
+	command := fmt.Sprintf("netsh advfirewall firewall delete rule name=\"%s\"", ipv6BlockRuleName)
+	if _, err := ExecuteCommand(command); err != nil {
+		return fmt.Errorf("failed to remove IPv6 outbound block rule: %w", err)
+	}
+
+	log.Infof("Outline/routing: IPv6 outbound block rule removed")
+	return nil
 }
 
 func StartRouting(proxyIP string, GatewayIP string, TunDeviceName string, InterfaceName string, TunGateway string, TunDeviceIP string) error {
@@ -70,6 +101,9 @@ func StartRouting(proxyIP string, GatewayIP string, TunDeviceName string, Interf
 		return err
 	}
 	log.Infof("Outline/routing: Added default IPv4 redirect routes via TUN")
+	if err := startIPv6Block(); err != nil {
+		return err
+	}
 
 	log.Infof("Outline/routing: Routing configuration completed successfully.")
 	return nil
@@ -77,6 +111,9 @@ func StartRouting(proxyIP string, GatewayIP string, TunDeviceName string, Interf
 
 func StopRouting(proxyIp string, TunDeviceName string, GatewayIP string, InterfaceName string, TunGateway string) {
 	log.Infof("Outline/routing: Cleaning up routing table and rules...")
+	if err := stopIPv6Block(); err != nil {
+		log.Infof("Outline/routing: Failed to remove IPv6 outbound block rule: %v", err)
+	}
 	if err := DeleteProxyRoute(proxyIp, GatewayIP, InterfaceName); err != nil {
 		log.Infof("Outline/routing: Failed to delete proxy route for IP %s: %v", proxyIp, err)
 	}

--- a/go_module/routing/routing_windows.go
+++ b/go_module/routing/routing_windows.go
@@ -60,16 +60,27 @@ func startIPv6Block() error {
 
 	_, _ = ExecuteCommand(fmt.Sprintf("netsh advfirewall firewall delete rule name=\"%s\"", ipv6BlockRuleName))
 
-	command := fmt.Sprintf(
-		"netsh advfirewall firewall add rule name=\"%s\" dir=out action=block enable=yes remoteip=::/0",
-		ipv6BlockRuleName,
-	)
-	if _, err := ExecuteCommand(command); err != nil {
-		return fmt.Errorf("failed to install IPv6 outbound block rule: %w", err)
+	ipv6RemoteRanges := []string{
+		"0000:0000:0000:0000:0000:0000:0000:0000-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+		"0::/0",
+		"::/0",
+	}
+	var errs []string
+	for _, remoteIP := range ipv6RemoteRanges {
+		command := fmt.Sprintf(
+			"netsh advfirewall firewall add rule name=\"%s\" dir=out action=block enable=yes remoteip=%s",
+			ipv6BlockRuleName,
+			remoteIP,
+		)
+		if _, err := ExecuteCommand(command); err == nil {
+			log.Infof("Outline/routing: IPv6 outbound block rule installed with remoteip=%s", remoteIP)
+			return nil
+		} else {
+			errs = append(errs, fmt.Sprintf("remoteip=%s: %v", remoteIP, err))
+		}
 	}
 
-	log.Infof("Outline/routing: IPv6 outbound block rule installed")
-	return nil
+	return fmt.Errorf("failed to install IPv6 outbound block rule: %s", strings.Join(errs, "; "))
 }
 
 func stopIPv6Block() error {
@@ -102,7 +113,7 @@ func StartRouting(proxyIP string, GatewayIP string, TunDeviceName string, Interf
 	}
 	log.Infof("Outline/routing: Added default IPv4 redirect routes via TUN")
 	if err := startIPv6Block(); err != nil {
-		return err
+		log.Infof("Outline/routing: IPv6 outbound block rule was not installed; continuing with IPv4 routing: %v", err)
 	}
 
 	log.Infof("Outline/routing: Routing configuration completed successfully.")

--- a/go_module/tunnel/platform_engine/engine_macos.go
+++ b/go_module/tunnel/platform_engine/engine_macos.go
@@ -68,6 +68,23 @@ func startPlatformEngine(cfg interface{}) error {
 		return fmt.Errorf("ifconfig failed: %w (%s)", err, out)
 	}
 
+	cmd = exec.CommandContext(
+		context.Background(),
+		"ifconfig",
+		deviceName,
+		"inet6",
+		"fd00:dbb::2",
+		"fd00:dbb::1",
+		"prefixlen",
+		"128",
+		"up",
+	)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		engine.Stop()
+		return fmt.Errorf("ifconfig inet6 failed: %w (%s)", err, out)
+	}
+
 	return nil
 }
 

--- a/go_module/tunnel/tunnel.go
+++ b/go_module/tunnel/tunnel.go
@@ -216,6 +216,11 @@ func (p *DobbyProxy) DialContext(ctx context.Context, metadata *M.Metadata) (net
 	start := time.Now()
 	dest := metadata.DestinationAddress()
 	attempt := p.tcpDialAttempt.Add(1)
+	if isBlockedIPv6Destination(metadata) {
+		err := fmt.Errorf("IPv6 destination blocked: %s", dest)
+		log.Infof("[Router] TCP IPv6 blocked attempt=%d dstIP=%s dest=%s proto=%s stats={%s}", attempt, metadata.DstIP, dest, metadata.Network, p.flowStats())
+		return nil, err
+	}
 	route, px := "VPN", p.vpn
 	if IsBypass(metadata) {
 		route, px = "DIRECT", p.direct
@@ -246,6 +251,11 @@ func (p *DobbyProxy) DialUDP(metadata *M.Metadata) (net.PacketConn, error) {
 	start := time.Now()
 	dest := metadata.DestinationAddress()
 	attempt := p.udpDialAttempt.Add(1)
+	if isBlockedIPv6Destination(metadata) {
+		err := fmt.Errorf("IPv6 destination blocked: %s", dest)
+		log.Infof("[Router] UDP IPv6 blocked attempt=%d dstIP=%s dest=%s proto=%s stats={%s}", attempt, metadata.DstIP, dest, metadata.Network, p.flowStats())
+		return nil, err
+	}
 	route, px := "VPN", p.vpn
 	if IsBypass(metadata) {
 		route, px = "DIRECT", p.direct
@@ -277,6 +287,10 @@ func (p *DobbyProxy) dialUDPRoute(metadata *M.Metadata, route string, px proxy.P
 
 func (p *DobbyProxy) Addr() string {
 	return p.vpn.Addr()
+}
+
+func isBlockedIPv6Destination(metadata *M.Metadata) bool {
+	return metadata != nil && metadata.DstIP.Is6() && !metadata.DstIP.Is4In6()
 }
 
 func (p *DobbyProxy) Proto() proto.Proto {

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/common/Consts.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/common/Consts.kt
@@ -1,5 +1,35 @@
 package com.dobby.feature.vpn_service.common
 
+import android.net.VpnService
+import com.dobby.feature.logging.Logger
+
+private const val IPV6_BLOCK_ADDRESS = "fd00:dbb::1"
+private const val IPV6_BLOCK_ADDRESS_PREFIX = 128
+private const val IPV6_DEFAULT_ROUTE = "::"
+private const val IPV6_DEFAULT_ROUTE_PREFIX = 0
+
+fun VpnService.Builder.addIpv6BlockingRoute(logger: Logger, sessionName: String): VpnService.Builder {
+    return runCatching {
+        addAddress(IPV6_BLOCK_ADDRESS, IPV6_BLOCK_ADDRESS_PREFIX)
+        addRoute(IPV6_DEFAULT_ROUTE, IPV6_DEFAULT_ROUTE_PREFIX)
+        logger.log(
+            "$sessionName IPv6 default route captured by VPN interface: " +
+                "$IPV6_BLOCK_ADDRESS/$IPV6_BLOCK_ADDRESS_PREFIX, $IPV6_DEFAULT_ROUTE/$IPV6_DEFAULT_ROUTE_PREFIX"
+        )
+        this
+    }.onFailure { error ->
+        logger.log("$sessionName failed to install IPv6 blocking route: ${error.message}")
+    }.getOrThrow()
+}
+
+fun String.isIpv4Literal(): Boolean {
+    val parts = split(".")
+    return parts.size == 4 && parts.all { part ->
+        val octet = part.toIntOrNull()
+        part.isNotEmpty() && part.all { it.isDigit() } && octet != null && octet in 0..255
+    }
+}
+
 val reservedBypassSubnets = listOf(
     "1.0.0.0/8", "2.0.0.0/7", "4.0.0.0/6", "8.0.0.0/7", "11.0.0.0/8",
     "12.0.0.0/6", "16.0.0.0/4", "32.0.0.0/3", "64.0.0.0/3", "96.0.0.0/6",

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/outline/OutlineVpnInterfaceFactory.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/outline/OutlineVpnInterfaceFactory.kt
@@ -9,6 +9,8 @@ import android.util.Log
 import com.dobby.feature.logging.Logger
 import com.dobby.feature.vpn_service.DobbyVpnService
 import com.dobby.feature.vpn_service.VpnInterfaceFactory
+import com.dobby.feature.vpn_service.common.addIpv6BlockingRoute
+import com.dobby.feature.vpn_service.common.isIpv4Literal
 import com.dobby.feature.vpn_service.common.reservedBypassSubnets
 
 class OutlineVpnInterfaceFactory(
@@ -23,11 +25,13 @@ class OutlineVpnInterfaceFactory(
             .addAddress("10.111.222.1", 24)
             .addDnsServer("1.1.1.1")
             .addDisallowedApplication(context.packageName)
+            .addIpv6BlockingRoute(logger, "Outline")
 
         logger.log("VPN interface created: address is 10.111.222.1")
 
         val dnsServers = getDnsServers(context)
             .filter { it.isNotBlank() }
+            .filter { it.isIpv4Literal() }
             .distinct()
         if (dnsServers.isNotEmpty()) {
             dnsServers.forEach { builder.addDnsServer(it) }

--- a/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/xray/XrayVpnInterfaceFactory.kt
+++ b/kmp_module/app/src/androidMain/kotlin/com/dobby/feature/vpn_service/domain/xray/XrayVpnInterfaceFactory.kt
@@ -9,6 +9,8 @@ import android.util.Log
 import com.dobby.feature.logging.Logger
 import com.dobby.feature.vpn_service.DobbyVpnService
 import com.dobby.feature.vpn_service.VpnInterfaceFactory
+import com.dobby.feature.vpn_service.common.addIpv6BlockingRoute
+import com.dobby.feature.vpn_service.common.isIpv4Literal
 import com.dobby.feature.vpn_service.common.reservedBypassSubnets
 
 class XrayVpnInterfaceFactory(
@@ -22,11 +24,13 @@ class XrayVpnInterfaceFactory(
             .setMtu(1500) // Adjust if necessary
             .addAddress("10.233.233.1", 24) // Dummy local IP for the TUN
             .addDisallowedApplication(context.packageName)
+            .addIpv6BlockingRoute(logger, "Xray")
 
         builder.addDnsServer("1.1.1.1")
 
         val dnsServers = getDnsServers(context)
             .filter { it.isNotBlank() }
+            .filter { it.isIpv4Literal() }
             .distinct()
 
         if (dnsServers.isNotEmpty()) {

--- a/swift_module/tunnel/PacketTunnelProvider.swift
+++ b/swift_module/tunnel/PacketTunnelProvider.swift
@@ -274,6 +274,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let remoteAddress = "254.1.1.1"
         let localAddress = "198.18.0.1"
         let subnetMask = "255.255.0.0"
+        let ipv6Address = "fd00:dbb::1"
+        let ipv6PrefixLength = 128
         let dnsServers = ["1.1.1.1", "8.8.8.8"]
 
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
@@ -284,12 +286,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         )
         settings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
         settings.ipv4Settings?.excludedRoutes = excludedRoutes
-        settings.ipv6Settings = nil
+        settings.ipv6Settings = NEIPv6Settings(
+            addresses: [ipv6Address],
+            networkPrefixLengths: [NSNumber(value: ipv6PrefixLength)]
+        )
+        settings.ipv6Settings?.includedRoutes = [NEIPv6Route.default()]
         settings.dnsSettings = NEDNSSettings(servers: dnsServers)
         settings.dnsSettings?.matchDomains = [""]
 
         logs.writeLog(log: "Settings are ready:")
-        logs.writeLog(log: "[tunnel:\(tunnelId)] settings mtu=\(settings.mtu?.stringValue ?? "nil") ipv4=\(localAddress)/\(subnetMask) remote=\(remoteAddress) dns=\(dnsServers.joined(separator: ",")) excludedRoutes=\(excludedRoutes.count)")
+        logs.writeLog(log: "[tunnel:\(tunnelId)] settings mtu=\(settings.mtu?.stringValue ?? "nil") ipv4=\(localAddress)/\(subnetMask) ipv6=\(ipv6Address)/\(ipv6PrefixLength) ipv6DefaultRoute=true remote=\(remoteAddress) dns=\(dnsServers.joined(separator: ",")) excludedRoutes=\(excludedRoutes.count)")
         do {
             try await self.setTunnelNetworkSettings(settings)
         } catch {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-wide IPv6 blocking added across platforms (Windows, macOS, Linux, iOS, Android) to prevent IPv6 traffic.
  * VPN builders now add an IPv6-blocking route; tunnel layers reject pure-IPv6 dials.

* **Behavior Changes**
  * DNS selection now only accepts IPv4 literal addresses by default.

* **Reliability**
  * Improved startup/shutdown logging and error handling around route installation/removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->