### PR TITLE
ci: fix v1.4.3 macOS helper checksum format

### DIFF
--- a/.github/workflows/desktop_libs_generate.yml
+++ b/.github/workflows/desktop_libs_generate.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           curl -#fL -o trusttunnel_client-v1.0.49-macos-universal.tar.gz "https://github.com/TrustTunnel/TrustTunnelClient/releases/download/v1.0.49/trusttunnel_client-v1.0.49-macos-universal.tar.gz"
-          echo "f2dab732d17a885dcc4c81831fa4b263db250f5bea8a151416b518e936979c64 trusttunnel_client-v1.0.49-macos-universal.tar.gz" | shasum -a 256 -c -
+          echo "f2dab732d17a885dcc4c81831fa4b263db250f5bea8a151416b518e936979c64  trusttunnel_client-v1.0.49-macos-universal.tar.gz" | shasum -a 256 -c -
           tar -xzf trusttunnel_client-v1.0.49-macos-universal.tar.gz --strip-components=1 trusttunnel_client-v1.0.49-macos-universal/trusttunnel_client
           chmod 755 trusttunnel_client
           codesign --verify --strict --verbose=2 trusttunnel_client


### PR DESCRIPTION
## Summary
- use the two-space checksum/file delimiter required by `shasum -c`
- unblock the macOS Intel desktop-library release job

## Verification
- reproduced the existing malformed-line failure locally
- downloaded the pinned TrustTunnel v1.0.49 macOS universal archive
- verified its SHA-256 is `f2dab732d17a885dcc4c81831fa4b263db250f5bea8a151416b518e936979c64`
- confirmed the corrected checksum record passes `shasum -a 256 -c -`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum verification for macOS TrustTunnel downloads to ensure the correct validation tool is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->