### PR TITLE
ci: automate v1.4.3 release promotion

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -66,3 +66,18 @@ workflow behavior; local service builds only run `go mod download` by default.
 
 Use `--skip-deps` to require dependencies to already exist and `--skip-build` to
 reuse existing build outputs where supported.
+
+## Release promotion
+
+Every `main` push produces candidate artifacts and uploads a successful iOS
+build to internal TestFlight. It does not create a final release tag.
+
+An operator promotes one qualified run with the private Harness
+`AppStore/publish_release.py` command. That command dispatches
+`promote_release.yml`, which revalidates the exact successful `main` Release
+run and source commit, downloads its artifacts only to a GitHub-hosted runner,
+and creates `vX.Y.Z` plus the GitHub Release. That final tag is the sole signal
+for official F-Droid update processing.
+
+A separate F-Droid candidate-testing repository is planned outside this
+public application repository; it is not part of the current workflow.

--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -35,6 +35,28 @@ def main() -> int:
     if PR_TRIGGER.search(release):
         violations.append("release.yml: protected release workflow must not run on pull_request")
 
+    promotion = (WORKFLOWS / "promote_release.yml").read_text(encoding="utf-8")
+    if PR_TRIGGER.search(promotion):
+        violations.append("promote_release.yml: public promotion must not run on pull_request")
+    if SECRET.search(promotion) or "environment:" in promotion:
+        violations.append(
+            "promote_release.yml: GitHub/F-Droid promotion must not consume release secrets"
+        )
+    for expected in (
+        "workflow_dispatch:",
+        "actions: read",
+        "contents: write",
+        'test "$(jq -r .conclusion <<<"$run_json")" = "success"',
+        'test "$(jq -r .headSha <<<"$run_json")" = "$RELEASE_SOURCE_SHA"',
+        'test "$source_version" = "$RELEASE_VERSION"',
+        "run-id: ${{ inputs.run_id }}",
+        '--target "$RELEASE_SOURCE_SHA"',
+    ):
+        if expected not in promotion:
+            violations.append(
+                f"promote_release.yml: missing fail-closed promotion control: {expected}"
+            )
+
     torturer = (WORKFLOWS / "torturer.yml").read_text(encoding="utf-8")
     if "pull_request_target" in torturer:
         violations.append("torturer.yml: pull_request_target is forbidden for untrusted candidate execution")

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -102,8 +102,9 @@ jobs:
           name: DobbyVPN.ipa
           path: swift_module/build/ipa/*.ipa
 
-      # Uploads IPA to TestFlight only (no external/public distribute).
-      # Public beta + F-Droid: local AppStore/publish_public.py after you trust the build.
+      # Every green main build is retained in internal TestFlight. Production
+      # App Review and GitHub/F-Droid promotion remain an explicit maintainer
+      # action through AppStore/publish_release.py.
       - name: Fastlane upload_testflight
         if: ${{ github.ref == 'refs/heads/main' }}
         env:

--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -1,0 +1,233 @@
+name: Promote Release
+run-name: Promote v${{ inputs.version }} from Release run ${{ inputs.run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version to publish (X.Y.Z)
+        required: true
+        type: string
+      run_id:
+        description: Successful Release workflow run containing the artifacts
+        required: true
+        type: string
+      commit_sha:
+        description: Exact main commit built by the selected run
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: promote-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.preflight.outputs.tag }}
+      release_state: ${{ steps.preflight.outputs.release_state }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_RUN_ID: ${{ inputs.run_id }}
+      RELEASE_SOURCE_SHA: ${{ inputs.commit_sha }}
+    steps:
+      - name: Validate selected release run
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must use X.Y.Z format" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "run_id must be numeric" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit_sha must be a full commit SHA" >&2
+            exit 1
+          fi
+
+          run_json="$(
+            gh run view "$RELEASE_RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json conclusion,event,headBranch,headSha,number,status,workflowName
+          )"
+          test "$(jq -r .status <<<"$run_json")" = "completed"
+          test "$(jq -r .conclusion <<<"$run_json")" = "success"
+          test "$(jq -r .workflowName <<<"$run_json")" = "Release"
+          test "$(jq -r .event <<<"$run_json")" = "push"
+          test "$(jq -r .headBranch <<<"$run_json")" = "main"
+          test "$(jq -r .headSha <<<"$run_json")" = "$RELEASE_SOURCE_SHA"
+
+          encoded_version="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/VERSION?ref=$RELEASE_SOURCE_SHA" \
+              --jq .content
+          )"
+          source_version="$(printf '%s' "$encoded_version" | base64 --decode | tr -d '[:space:]')"
+          test "$source_version" = "$RELEASE_VERSION"
+
+          tag="v$RELEASE_VERSION"
+          run_number="$(jq -r .number <<<"$run_json")"
+          release_state="new"
+          if release_json="$(
+            gh release view "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets,isDraft 2>/dev/null
+          )"; then
+            if [[ "$(jq -r .isDraft <<<"$release_json")" = "true" ]]; then
+              echo "$tag already exists as a draft; inspect it before retrying" >&2
+              exit 1
+            else
+              tag_sha="$(
+                gh api "repos/$GITHUB_REPOSITORY/commits/$tag" --jq .sha
+              )"
+              test "$tag_sha" = "$RELEASE_SOURCE_SHA"
+
+              expected_assets="$(
+                printf '%s\n' \
+                  "DobbyVPN-v$RELEASE_VERSION-sign.apk" \
+                  "DobbyVPN-v$RELEASE_VERSION-unsign.apk" \
+                  "dobbyVPN-linux.deb" \
+                  "dobbyVPN-macos-aarch64.pkg" \
+                  "dobbyVPN-macos-amd64.pkg" \
+                  "dobbyVPN-windows-amd64.msi" \
+                  "dobbyVPN-windows-arm64.msi" \
+                  "dobbyVPN-windows-x86.msi" \
+                  "version.txt" |
+                  sort
+              )"
+              actual_assets="$(jq -r '.assets[].name' <<<"$release_json" | sort)"
+              test "$actual_assets" = "$expected_assets"
+              release_state="published"
+            fi
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "run_number=$run_number"
+            echo "release_state=$release_state"
+          } >> "$GITHUB_OUTPUT"
+          echo "Validated $tag from Release run $RELEASE_RUN_ID at $RELEASE_SOURCE_SHA"
+          echo "Release state: $release_state"
+
+      - name: Download Linux package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-linux.deb
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download Windows x86 package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-windows-x86.msi
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download Windows amd64 package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-windows-amd64.msi
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download Windows arm64 package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-windows-arm64.msi
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download macOS amd64 package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-macos-amd64.pkg
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download macOS arm64 package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyVPN-macos-aarch64.pkg
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download signed Android package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyvpn-android-sign.apk
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Download unsigned Android package
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyvpn-android-unsign.apk
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Create F-Droid version metadata
+        if: steps.preflight.outputs.release_state != 'published'
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "versionName=$RELEASE_VERSION"
+            echo "versionCode=${{ steps.preflight.outputs.run_number }}"
+          } > release/version.txt
+
+      - name: Create public GitHub release
+        if: steps.preflight.outputs.release_state == 'new'
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "${{ steps.preflight.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$RELEASE_SOURCE_SHA" \
+            --title "${{ steps.preflight.outputs.tag }}" \
+            --notes "DobbyVPN $RELEASE_VERSION (build ${{ steps.preflight.outputs.run_number }})" \
+            --latest \
+            release/*
+
+      - name: Confirm publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release view "${{ steps.preflight.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,tagName,url \
+            --jq 'select(.isDraft == false) | {tagName,url}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,5 +119,7 @@ jobs:
       app_minor_version: ${{ needs.prepare_version.outputs.minor }}
       app_maintenance_version: ${{ needs.prepare_version.outputs.maintenance }}
 
-  # GitHub Release (and thus F-Droid AutoUpdate) is intentional/manual.
-  # After a known-good build, run local AppStore/publish_public.py.
+  # Public GitHub/F-Droid promotion is intentional/manual. A maintainer selects
+  # one successful run with AppStore/publish_release.py; promote_release.yml
+  # then transfers these retained artifacts to the public release entirely on
+  # GitHub-hosted infrastructure and creates the sole F-Droid-visible tag.


### PR DESCRIPTION
## Summary
- add an explicit GitHub-hosted promotion workflow for one qualified Release run
- require exact main commit, successful run, version, and release asset validation
- keep every green iOS main build in internal TestFlight while production promotion remains operator-controlled
- document the official F-Droid tag boundary and leave a separate candidate-testing repository for later

## Validation
- workflow secret-isolation policy passes
- Python release operator scripts compile
- live dry-run verifies Release run 30359321473 and existing v1.4.3 without downloading artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual release promotion workflow for publishing a verified build as a final public release.
  * Maintainers can select a successful release run, confirm its version and commit, and publish the associated platform artifacts.
  * Existing published releases are checked for matching commits and expected assets before completion.

* **Documentation**
  * Updated release and iOS build guidance to clarify artifact retention and the manual promotion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->