### PR TITLE
ci: protect v1.4.3 App Store submission

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -79,5 +79,16 @@ run and source commit, downloads its artifacts only to a GitHub-hosted runner,
 and creates `vX.Y.Z` plus the GitHub Release. That final tag is the sole signal
 for official F-Droid update processing.
 
+The same operator command dispatches `submit_app_store.yml` for production
+App Review. Its secretless validation job binds the request to the exact
+successful `main` Release run, source version, iOS job, and build number.
+Only then does a separate job enter the protected `release` environment and
+use its existing App Store Connect secrets. The selected build is submitted
+with automatic release after approval.
+
+Torturer remains the independent secretless gate for candidate code. Store
+credentials never enter Torturer or any pull-request job; production
+submission consumes the already-gated, successful Release result.
+
 A separate F-Droid candidate-testing repository is planned outside this
 public application repository; it is not part of the current workflow.

--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -57,6 +57,47 @@ def main() -> int:
                 f"promote_release.yml: missing fail-closed promotion control: {expected}"
             )
 
+    app_store = (WORKFLOWS / "submit_app_store.yml").read_text(encoding="utf-8")
+    if PR_TRIGGER.search(app_store):
+        violations.append(
+            "submit_app_store.yml: production submission must not run on pull_request"
+        )
+    for expected in (
+        "workflow_dispatch:",
+        "actions: read",
+        "contents: read",
+        'test "$GITHUB_REF" = "refs/heads/main"',
+        'test "$GITHUB_SHA" = "$current_main"',
+        'test "$(jq -r .conclusion <<<"$run_json")" = "success"',
+        'test "$(jq -r .headSha <<<"$run_json")" = "$RELEASE_SOURCE_SHA"',
+        'test "$(jq -r .number <<<"$run_json")" = "$RELEASE_BUILD_NUMBER"',
+        '"ios_build / ios_build"',
+        'test "$source_version" = "$RELEASE_VERSION"',
+        "environment: release",
+        "APP_STORE_API_KEY: ${{ secrets.APP_STORE_API_KEY }}",
+        "APP_STORE_KEY_ID: ${{ secrets.APP_STORE_KEY_ID }}",
+        "APP_STORE_ISSUER_ID: ${{ secrets.APP_STORE_ISSUER_ID }}",
+    ):
+        if expected not in app_store:
+            violations.append(
+                f"submit_app_store.yml: missing protected submission control: {expected}"
+            )
+
+    fastfile = (ROOT.parent / "fastlane" / "Fastfile").read_text(encoding="utf-8")
+    for expected in (
+        'lane :submit_app_store_review do',
+        'ENV.fetch("APP_STORE_VERSION")',
+        'ENV.fetch("APP_STORE_BUILD_NUMBER")',
+        "build_number: selected_build",
+        "skip_binary_upload: true",
+        "submit_for_review: true",
+        "automatic_release: true",
+    ):
+        if expected not in fastfile:
+            violations.append(
+                f"fastlane/Fastfile: missing exact production submission control: {expected}"
+            )
+
     torturer = (WORKFLOWS / "torturer.yml").read_text(encoding="utf-8")
     if "pull_request_target" in torturer:
         violations.append("torturer.yml: pull_request_target is forbidden for untrusted candidate execution")

--- a/.github/workflows/submit_app_store.yml
+++ b/.github/workflows/submit_app_store.yml
@@ -1,0 +1,136 @@
+name: Submit App Store Release
+run-name: Submit v${{ inputs.version }} build ${{ inputs.build_number }} to App Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version to submit (X.Y.Z)
+        required: true
+        type: string
+      build_number:
+        description: Exact CI and App Store Connect build number
+        required: true
+        type: string
+      run_id:
+        description: Successful Release workflow run that uploaded the build
+        required: true
+        type: string
+      commit_sha:
+        description: Exact main commit built by the selected run
+        required: true
+        type: string
+      whats_new:
+        description: Optional en-US App Store release notes
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: submit-app-store-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      validated_build: ${{ steps.preflight.outputs.validated_build }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_BUILD_NUMBER: ${{ inputs.build_number }}
+      RELEASE_RUN_ID: ${{ inputs.run_id }}
+      RELEASE_SOURCE_SHA: ${{ inputs.commit_sha }}
+    steps:
+      - name: Validate trusted workflow and selected release run
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test "$GITHUB_REF" = "refs/heads/main"
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          test "$GITHUB_SHA" = "$current_main"
+
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must use X.Y.Z format" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "build_number must be numeric" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "run_id must be numeric" >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit_sha must be a full commit SHA" >&2
+            exit 1
+          fi
+
+          run_json="$(
+            gh run view "$RELEASE_RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json conclusion,event,headBranch,headSha,jobs,number,status,workflowName
+          )"
+          test "$(jq -r .status <<<"$run_json")" = "completed"
+          test "$(jq -r .conclusion <<<"$run_json")" = "success"
+          test "$(jq -r .workflowName <<<"$run_json")" = "Release"
+          test "$(jq -r .event <<<"$run_json")" = "push"
+          test "$(jq -r .headBranch <<<"$run_json")" = "main"
+          test "$(jq -r .headSha <<<"$run_json")" = "$RELEASE_SOURCE_SHA"
+          test "$(jq -r .number <<<"$run_json")" = "$RELEASE_BUILD_NUMBER"
+
+          ios_success="$(
+            jq -r \
+              '[.jobs[] | select(.name == "ios_build / ios_build" and .conclusion == "success")] | length' \
+              <<<"$run_json"
+          )"
+          test "$ios_success" = "1"
+
+          encoded_version="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/VERSION?ref=$RELEASE_SOURCE_SHA" \
+              --jq .content
+          )"
+          source_version="$(printf '%s' "$encoded_version" | base64 --decode | tr -d '[:space:]')"
+          test "$source_version" = "$RELEASE_VERSION"
+
+          echo "validated_build=$RELEASE_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Validated production submission for v$RELEASE_VERSION build $RELEASE_BUILD_NUMBER"
+
+  submit:
+    needs: validate
+    runs-on: macos-15
+    environment: release
+    timeout-minutes: 30
+    env:
+      APP_STORE_VERSION: ${{ inputs.version }}
+      APP_STORE_BUILD_NUMBER: ${{ needs.validate.outputs.validated_build }}
+      APP_STORE_RELEASE_NOTES: ${{ inputs.whats_new }}
+    steps:
+      - name: Check out trusted main submission tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify trusted checkout identity
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Submit exact build to production App Review
+        env:
+          APP_STORE_API_KEY: ${{ secrets.APP_STORE_API_KEY }}
+          APP_STORE_KEY_ID: ${{ secrets.APP_STORE_KEY_ID }}
+          APP_STORE_ISSUER_ID: ${{ secrets.APP_STORE_ISSUER_ID }}
+        run: bundle exec fastlane ios submit_app_store_review

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -216,4 +216,43 @@ platform :ios do
       changelog: "Build #{FULL_VERSION} (#{SHORT_SHA})"
     )
   end
+
+  desc "Submit an existing exact build to production App Review"
+  lane :submit_app_store_review do
+    version = ENV.fetch("APP_STORE_VERSION")
+    selected_build = ENV.fetch("APP_STORE_BUILD_NUMBER")
+    release_notes = ENV["APP_STORE_RELEASE_NOTES"].to_s.strip
+
+    unless version.match?(/\A\d+\.\d+\.\d+\z/)
+      UI.user_error!("APP_STORE_VERSION must use X.Y.Z format")
+    end
+    unless selected_build.match?(/\A\d+\z/)
+      UI.user_error!("APP_STORE_BUILD_NUMBER must be numeric")
+    end
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APP_STORE_KEY_ID"),
+      issuer_id: ENV.fetch("APP_STORE_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_API_KEY"),
+      duration: 1200
+    )
+
+    options = {
+      api_key: api_key,
+      app_identifier: BUNDLE_ID,
+      platform: "ios",
+      app_version: version,
+      build_number: selected_build,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      submit_for_review: true,
+      automatic_release: true,
+      force: true,
+      run_precheck_before_submit: true,
+      precheck_include_in_app_purchases: false
+    }
+    options[:release_notes] = { "en-US" => release_notes } unless release_notes.empty?
+
+    upload_to_app_store(**options)
+  end
 end


### PR DESCRIPTION
## Summary
- add a workflow-dispatch-only production App Store submission in the protected release environment
- revalidate the exact successful main Release run, source version, iOS job, and build number before secrets become available
- submit the existing TestFlight build through fastlane with automatic release after approval
- preserve Torturer as the independent secretless candidate gate

## Validation
- workflow secret-isolation policy passes
- Fastfile Ruby syntax passes and fastlane discovers the new lane
- Harness operator unit tests pass
- live 1.4.3 operator dry-run selects Release run 30359321473 / build 2134 without local Apple credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a controlled workflow for submitting verified iOS builds to App Store Review.
  - Supports manual entry of version, build number, source release, commit, and optional release notes.
  - Validates release details and build provenance before submission.
  - Enables automatic release settings and localized “What’s New” notes when provided.

- **Chores**
  - Added automated checks to enforce App Store submission safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->