### PR TITLE
Restore F-Droid v1.4.3 version compatibility

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -79,6 +79,18 @@ run and source commit, downloads its artifacts only to a GitHub-hosted runner,
 and creates `vX.Y.Z` plus the GitHub Release. That final tag is the sole signal
 for official F-Droid update processing.
 
+Android and F-Droid use a stable version code derived from the marketing
+version: `major * 1,000,000 + minor * 1,000 + maintenance`. For example,
+`1.4.3` is `1004003`. This is intentionally independent of the GitHub Actions
+run number, which remains Apple's monotonically increasing `CFBundleVersion`.
+The release workflow and APK scan both enforce this mapping.
+
+`repair_fdroid_release.yml` is a guarded recovery path for a release whose
+Android assets predate that enforcement. It rebuilds from the exact existing
+tag commit and replaces only the signed APK, unsigned APK, and `version.txt`
+after checking the protected `release` environment and an explicit
+`replace-vX.Y.Z` confirmation.
+
 The same operator command dispatches `submit_app_store.yml` for production
 App Review. Its secretless validation job binds the request to the exact
 successful `main` Release run, source version, iOS job, and build number.

--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -83,6 +83,28 @@ def main() -> int:
                 f"submit_app_store.yml: missing protected submission control: {expected}"
             )
 
+    fdroid_repair = (WORKFLOWS / "repair_fdroid_release.yml").read_text(encoding="utf-8")
+    if PR_TRIGGER.search(fdroid_repair):
+        violations.append(
+            "repair_fdroid_release.yml: protected repair must not run on pull_request"
+        )
+    for expected in (
+        "workflow_dispatch:",
+        "contents: write",
+        'test "$GITHUB_REF" = "refs/heads/main"',
+        'test "$GITHUB_SHA" = "$current_main"',
+        'test "$REPLACE_CONFIRMATION" = "replace-v$RELEASE_VERSION"',
+        'test "$tag_sha" = "$RELEASE_SOURCE_SHA"',
+        "source_sha: ${{ needs.preflight.outputs.source_sha }}",
+        "environment: release",
+        "--clobber",
+        "versionCode=$ANDROID_VERSION_CODE",
+    ):
+        if expected not in fdroid_repair:
+            violations.append(
+                f"repair_fdroid_release.yml: missing fail-closed repair control: {expected}"
+            )
+
     fastfile = (ROOT.parent / "fastlane" / "Fastfile").read_text(encoding="utf-8")
     for expected in (
         'lane :submit_app_store_review do',

--- a/.github/scripts/test_version_metadata.py
+++ b/.github/scripts/test_version_metadata.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from version_metadata import parse_version
+
+
+class VersionMetadataTests(unittest.TestCase):
+    def test_fdroid_version_code_scheme(self):
+        metadata = parse_version("1.4.3\n")
+        self.assertEqual(metadata.version_name, "1.4.3")
+        self.assertEqual(metadata.android_version_code, 1_004_003)
+
+    def test_previous_published_code_remains_compatible(self):
+        self.assertEqual(parse_version("1.3.9").android_version_code, 1_003_009)
+
+    def test_rejects_noncanonical_or_ambiguous_versions(self):
+        for value in ("1.4", "v1.4.3", "01.4.3", "1.1000.0", "1.4.1000"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    parse_version(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/version_metadata.py
+++ b/.github/scripts/version_metadata.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Parse VERSION and derive the stable Android/F-Droid version code."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+VERSION_RE = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+ANDROID_MAX_VERSION_CODE = 2_100_000_000
+
+
+@dataclass(frozen=True)
+class VersionMetadata:
+    major: int
+    minor: int
+    maintenance: int
+
+    @property
+    def version_name(self) -> str:
+        return f"{self.major}.{self.minor}.{self.maintenance}"
+
+    @property
+    def android_version_code(self) -> int:
+        return self.major * 1_000_000 + self.minor * 1_000 + self.maintenance
+
+    def outputs(self) -> dict[str, str]:
+        return {
+            "major": str(self.major),
+            "minor": str(self.minor),
+            "maintenance": str(self.maintenance),
+            "version_name": self.version_name,
+            "android_version_code": str(self.android_version_code),
+        }
+
+
+def parse_version(raw: str) -> VersionMetadata:
+    value = raw.strip()
+    match = VERSION_RE.fullmatch(value)
+    if not match:
+        raise ValueError("version must use canonical X.Y.Z numeric format")
+
+    metadata = VersionMetadata(*(int(part) for part in match.groups()))
+    if metadata.minor >= 1_000 or metadata.maintenance >= 1_000:
+        raise ValueError("minor and maintenance components must be below 1000")
+    if not 1 <= metadata.android_version_code <= ANDROID_MAX_VERSION_CODE:
+        raise ValueError("derived Android versionCode is outside the supported range")
+    return metadata
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--version")
+    source.add_argument("--version-file", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--field", choices=VersionMetadata(1, 2, 3).outputs())
+    args = parser.parse_args()
+
+    raw = args.version if args.version is not None else args.version_file.read_text()
+    metadata = parse_version(raw)
+    outputs = metadata.outputs()
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for key, value in outputs.items():
+                output.write(f"{key}={value}\n")
+    if args.field:
+        print(outputs[args.field])
+    elif not args.github_output:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -21,6 +21,12 @@ on:
       app_maintenance_version:
         type: string
         required: true
+      android_version_code:
+        type: string
+        required: true
+      source_sha:
+        type: string
+        required: true
 
 jobs:
   android_build:
@@ -31,13 +37,15 @@ jobs:
       APP_MINOR_VERSION: ${{ inputs.app_minor_version }}
       APP_MAINTENANCE_VERSION: ${{ inputs.app_maintenance_version }}
       APPLE_BUILD_NUMBER: ${{ github.run_number }}
-      GITHUB_SHA: ${{ github.sha }}
+      ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+      GITHUB_SHA: ${{ inputs.source_sha }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       FDROID_COMPAT_SOURCE_ROOT: /home/vagrant/build/com.dobby.vpn
 
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_sha }}
           submodules: true
 
       - name: Set up bootstrap Go

--- a/.github/workflows/fdroid_scan_apk.yml
+++ b/.github/workflows/fdroid_scan_apk.yml
@@ -2,6 +2,13 @@ name: F-Droid APK Scan
 
 on:
   workflow_call:
+    inputs:
+      version_name:
+        type: string
+        required: true
+      version_code:
+        type: string
+        required: true
 
 jobs:
   scan-apk:
@@ -59,6 +66,9 @@ jobs:
             echo "::error::Unsigned APK artifact was not found"
             exit 1
           fi
+
+          test "$(apkanalyzer manifest version-name "$APK")" = "${{ inputs.version_name }}"
+          test "$(apkanalyzer manifest version-code "$APK")" = "${{ inputs.version_code }}"
 
           PACKAGES=$(apkanalyzer dex packages "$APK" 2>/dev/null | awk '{print $NF}')
 

--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -75,6 +75,14 @@ jobs:
           )"
           source_version="$(printf '%s' "$encoded_version" | base64 --decode | tr -d '[:space:]')"
           test "$source_version" = "$RELEASE_VERSION"
+          android_version_code="$(
+            IFS=. read -r major minor maintenance <<< "$RELEASE_VERSION"
+            test "$minor" -lt 1000
+            test "$maintenance" -lt 1000
+            echo $((10#$major * 1000000 + 10#$minor * 1000 + 10#$maintenance))
+          )"
+          test "$android_version_code" -ge 1
+          test "$android_version_code" -le 2100000000
 
           tag="v$RELEASE_VERSION"
           run_number="$(jq -r .number <<<"$run_json")"
@@ -115,6 +123,7 @@ jobs:
           {
             echo "tag=$tag"
             echo "run_number=$run_number"
+            echo "android_version_code=$android_version_code"
             echo "release_state=$release_state"
           } >> "$GITHUB_OUTPUT"
           echo "Validated $tag from Release run $RELEASE_RUN_ID at $RELEASE_SOURCE_SHA"
@@ -207,7 +216,7 @@ jobs:
           set -euo pipefail
           {
             echo "versionName=$RELEASE_VERSION"
-            echo "versionCode=${{ steps.preflight.outputs.run_number }}"
+            echo "versionCode=${{ steps.preflight.outputs.android_version_code }}"
           } > release/version.txt
 
       - name: Create public GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       minor: ${{ steps.version.outputs.minor }}
       maintenance: ${{ steps.version.outputs.maintenance }}
       version_name: ${{ steps.version.outputs.version_name }}
+      android_version_code: ${{ steps.version.outputs.android_version_code }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,19 +32,20 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          raw="$(tr -d '[:space:]' < VERSION 2>/dev/null || echo '1.4.0')"
-          IFS=. read -r major minor patch <<< "${raw}"
-          major="${major:-1}"
-          minor="${minor:-0}"
-          patch="${patch:-0}"
-
-          {
-            echo "major=$major"
-            echo "minor=$minor"
-            echo "maintenance=$patch"
-            echo "version_name=${major}.${minor}.${patch}"
-          } >> "$GITHUB_OUTPUT"
-          echo "Marketing version ${major}.${minor}.${patch} (from VERSION file)"
+          python3 .github/scripts/version_metadata.py \
+            --version-file VERSION \
+            --github-output "$GITHUB_OUTPUT"
+          version_name="$(
+            python3 .github/scripts/version_metadata.py \
+              --version-file VERSION \
+              --field version_name
+          )"
+          android_version_code="$(
+            python3 .github/scripts/version_metadata.py \
+              --version-file VERSION \
+              --field android_version_code
+          )"
+          echo "Marketing version $version_name; Android/F-Droid versionCode $android_version_code"
 
   desktop_libs_build:
     needs: verification
@@ -57,6 +59,8 @@ jobs:
       app_major_version: ${{ needs.prepare_version.outputs.major }}
       app_minor_version: ${{ needs.prepare_version.outputs.minor }}
       app_maintenance_version: ${{ needs.prepare_version.outputs.maintenance }}
+      android_version_code: ${{ needs.prepare_version.outputs.android_version_code }}
+      source_sha: ${{ github.sha }}
 
   android_build:
     needs: [verification, prepare_version]
@@ -76,8 +80,11 @@ jobs:
     uses: ./.github/workflows/fdroid_check.yml
 
   fdroid_scan_apk:
-    needs: android_build
+    needs: [prepare_version, android_build]
     uses: ./.github/workflows/fdroid_scan_apk.yml
+    with:
+      version_name: ${{ needs.prepare_version.outputs.version_name }}
+      version_code: ${{ needs.prepare_version.outputs.android_version_code }}
 
   ios_build:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,6 @@ jobs:
       app_major_version: ${{ needs.prepare_version.outputs.major }}
       app_minor_version: ${{ needs.prepare_version.outputs.minor }}
       app_maintenance_version: ${{ needs.prepare_version.outputs.maintenance }}
-      android_version_code: ${{ needs.prepare_version.outputs.android_version_code }}
-      source_sha: ${{ github.sha }}
 
   android_build:
     needs: [verification, prepare_version]
@@ -69,6 +67,8 @@ jobs:
       app_major_version: ${{ needs.prepare_version.outputs.major }}
       app_minor_version: ${{ needs.prepare_version.outputs.minor }}
       app_maintenance_version: ${{ needs.prepare_version.outputs.maintenance }}
+      android_version_code: ${{ needs.prepare_version.outputs.android_version_code }}
+      source_sha: ${{ github.sha }}
     secrets:
       KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
       KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}

--- a/.github/workflows/repair_fdroid_release.yml
+++ b/.github/workflows/repair_fdroid_release.yml
@@ -1,0 +1,187 @@
+name: Repair F-Droid Release
+run-name: Repair F-Droid metadata for v${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing release version to repair (X.Y.Z)
+        required: true
+        type: string
+      source_sha:
+        description: Exact commit currently referenced by the release tag
+        required: true
+        type: string
+      confirm_replace:
+        description: Type replace-vX.Y.Z to authorize replacing only Android release assets
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: repair-fdroid-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      major: ${{ steps.validate.outputs.major }}
+      minor: ${{ steps.validate.outputs.minor }}
+      maintenance: ${{ steps.validate.outputs.maintenance }}
+      version_name: ${{ steps.validate.outputs.version_name }}
+      android_version_code: ${{ steps.validate.outputs.android_version_code }}
+      source_sha: ${{ steps.validate.outputs.source_sha }}
+      tag: ${{ steps.validate.outputs.tag }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+      REPLACE_CONFIRMATION: ${{ inputs.confirm_replace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate trusted workflow and existing release
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq .commit.sha)"
+          test "$GITHUB_SHA" = "$current_main"
+          test "$RELEASE_SOURCE_SHA" != "$GITHUB_SHA"
+          test "$REPLACE_CONFIRMATION" = "replace-v$RELEASE_VERSION"
+          [[ "$RELEASE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+          python3 .github/scripts/version_metadata.py \
+            --version "$RELEASE_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
+          tag="v$RELEASE_VERSION"
+          tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$tag" --jq .sha)"
+          test "$tag_sha" = "$RELEASE_SOURCE_SHA"
+
+          encoded_version="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/VERSION?ref=$RELEASE_SOURCE_SHA" \
+              --jq .content
+          )"
+          source_version="$(printf '%s' "$encoded_version" | base64 --decode | tr -d '[:space:]')"
+          test "$source_version" = "$RELEASE_VERSION"
+
+          release_json="$(
+            gh release view "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets,isDraft
+          )"
+          test "$(jq -r .isDraft <<<"$release_json")" = "false"
+          for asset in \
+            "DobbyVPN-v$RELEASE_VERSION-sign.apk" \
+            "DobbyVPN-v$RELEASE_VERSION-unsign.apk" \
+            "version.txt"; do
+            test "$(jq --arg asset "$asset" '[.assets[].name == $asset] | any' <<<"$release_json")" = "true"
+          done
+
+          {
+            echo "source_sha=$RELEASE_SOURCE_SHA"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+  build_android:
+    needs: preflight
+    uses: ./.github/workflows/android_build.yml
+    with:
+      app_major_version: ${{ needs.preflight.outputs.major }}
+      app_minor_version: ${{ needs.preflight.outputs.minor }}
+      app_maintenance_version: ${{ needs.preflight.outputs.maintenance }}
+      android_version_code: ${{ needs.preflight.outputs.android_version_code }}
+      source_sha: ${{ needs.preflight.outputs.source_sha }}
+    secrets:
+      KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+      KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+
+  replace_android_assets:
+    needs: [preflight, build_android]
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ needs.preflight.outputs.version_name }}
+      ANDROID_VERSION_CODE: ${{ needs.preflight.outputs.android_version_code }}
+      RELEASE_SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+      RELEASE_TAG: ${{ needs.preflight.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: android-actions/setup-android@v3
+        with:
+          packages: build-tools;36.0.0
+
+      - name: Download rebuilt signed APK
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyvpn-android-sign.apk
+          path: release
+
+      - name: Download rebuilt unsigned APK
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyvpn-android-unsign.apk
+          path: release
+
+      - name: Verify exact rebuilt APK metadata
+        id: apk
+        shell: bash
+        run: |
+          set -euo pipefail
+          signed="release/DobbyVPN-v$RELEASE_VERSION-sign.apk"
+          unsigned="release/DobbyVPN-v$RELEASE_VERSION-unsign.apk"
+          test -f "$signed"
+          test -f "$unsigned"
+          for apk in "$signed" "$unsigned"; do
+            test "$(apkanalyzer manifest application-id "$apk")" = "com.dobby.vpn"
+            test "$(apkanalyzer manifest version-name "$apk")" = "$RELEASE_VERSION"
+            test "$(apkanalyzer manifest version-code "$apk")" = "$ANDROID_VERSION_CODE"
+          done
+          {
+            echo "signed=$signed"
+            echo "unsigned=$unsigned"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "versionName=$RELEASE_VERSION"
+            echo "versionCode=$ANDROID_VERSION_CODE"
+          } > release/version.txt
+
+      - name: Replace only F-Droid-facing Android assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq .sha)" = "$RELEASE_SOURCE_SHA"
+          gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            "${{ steps.apk.outputs.signed }}" \
+            "${{ steps.apk.outputs.unsigned }}" \
+            release/version.txt
+
+      - name: Confirm repaired public metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG/version.txt"
+          test "$(
+            curl --fail --silent --show-error --location "$version_url"
+          )" = "$(printf 'versionName=%s\nversionCode=%s' "$RELEASE_VERSION" "$ANDROID_VERSION_CODE")"
+          gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json url \
+            --jq .url

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,9 +1,17 @@
 default_platform(:android)
 
 # CI sets APP_* from the manual VERSION file (prepare_version reads x.y.z, no auto-bump).
-# versionCode / CFBundleVersion use APPLE_BUILD_NUMBER (GitHub Actions run number).
+# Android/F-Droid versionCode is stable for the marketing version. Apple's
+# CFBundleVersion remains the GitHub Actions run number.
 FULL_VERSION    = "#{ENV['APP_MAJOR_VERSION']}.#{ENV['APP_MINOR_VERSION']}.#{ENV['APP_MAINTENANCE_VERSION']}"
-VERSION_CODE    = ENV['APPLE_BUILD_NUMBER'].to_i
+SEMANTIC_ANDROID_VERSION_CODE =
+  ENV['APP_MAJOR_VERSION'].to_i * 1_000_000 +
+  ENV['APP_MINOR_VERSION'].to_i * 1_000 +
+  ENV['APP_MAINTENANCE_VERSION'].to_i
+VERSION_CODE    = ENV.fetch('ANDROID_VERSION_CODE', SEMANTIC_ANDROID_VERSION_CODE.to_s).to_i
+if VERSION_CODE != SEMANTIC_ANDROID_VERSION_CODE
+  raise "ANDROID_VERSION_CODE must equal #{SEMANTIC_ANDROID_VERSION_CODE} for #{FULL_VERSION}"
+end
 COMMIT          = ENV["GITHUB_SHA"]
 SHORT_SHA       = COMMIT && !COMMIT.empty? ? COMMIT[0, 7] : "unknown"
 REPO            = ENV["GITHUB_REPOSITORY"]


### PR DESCRIPTION
## Summary
- derive Android/F-Droid versionCode from marketing version (1.4.3 -> 1004003)
- verify APK version metadata before release promotion
- add a protected, exact-tag repair workflow for the already-published v1.4.3 assets
- retain the GitHub run number exclusively for Apple's CFBundleVersion

## Validation
- Python workflow/unit tests pass
- workflow secret-isolation policy passes
- Fastfile Ruby syntax passes
- git diff --check passes

The repair workflow is manual and fail-closed: it requires trusted current main, the exact existing tag SHA, an explicit replace-vX.Y.Z confirmation, and the protected release environment. It replaces only the signed APK, unsigned APK, and version.txt.