### PR TITLE
Fix F-Droid v1.4.3 legacy repair build

### DIFF
--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -96,6 +96,7 @@ def main() -> int:
         'test "$REPLACE_CONFIRMATION" = "replace-v$RELEASE_VERSION"',
         'test "$tag_sha" = "$RELEASE_SOURCE_SHA"',
         "source_sha: ${{ needs.preflight.outputs.source_sha }}",
+        "legacy_android_version_code: ${{ needs.preflight.outputs.android_version_code }}",
         "environment: release",
         "--clobber",
         "versionCode=$ANDROID_VERSION_CODE",

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -27,6 +27,11 @@ on:
       source_sha:
         type: string
         required: true
+      legacy_android_version_code:
+        description: Compatibility override for tagged sources that used APPLE_BUILD_NUMBER as Android versionCode
+        type: string
+        required: false
+        default: ''
 
 jobs:
   android_build:
@@ -36,7 +41,7 @@ jobs:
       APP_MAJOR_VERSION: ${{ inputs.app_major_version }}
       APP_MINOR_VERSION: ${{ inputs.app_minor_version }}
       APP_MAINTENANCE_VERSION: ${{ inputs.app_maintenance_version }}
-      APPLE_BUILD_NUMBER: ${{ github.run_number }}
+      APPLE_BUILD_NUMBER: ${{ inputs.legacy_android_version_code || github.run_number }}
       ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
       GITHUB_SHA: ${{ inputs.source_sha }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/repair_fdroid_release.yml
+++ b/.github/workflows/repair_fdroid_release.yml
@@ -98,6 +98,9 @@ jobs:
       app_maintenance_version: ${{ needs.preflight.outputs.maintenance }}
       android_version_code: ${{ needs.preflight.outputs.android_version_code }}
       source_sha: ${{ needs.preflight.outputs.source_sha }}
+      # v1.4.3's tagged Fastfile predates ANDROID_VERSION_CODE and reads this
+      # legacy variable for Gradle's Android versionCode.
+      legacy_android_version_code: ${{ needs.preflight.outputs.android_version_code }}
     secrets:
       KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
       KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}


### PR DESCRIPTION
## Summary
- pass the stable Android code through the legacy variable read by the already-tagged v1.4.3 Fastfile
- keep the override scoped to the guarded exact-tag repair workflow
- retain the normal GitHub run number for all ordinary builds

The first protected repair run stopped at metadata verification before replacing any release asset, proving the fail-closed guard worked. Local unit, workflow-policy, Ruby syntax, and diff checks pass.