### PR TITLE
v1.4.4: Stop waiting for TestFlight metadata processing

### DIFF
--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -46,11 +46,15 @@ def main() -> int:
         "workflow_dispatch:",
         "actions: read",
         "contents: write",
+        'test "$GITHUB_REF" = "refs/heads/main"',
+        'test "$GITHUB_SHA" = "$current_main"',
         'test "$(jq -r .conclusion <<<"$run_json")" = "success"',
         'test "$(jq -r .headSha <<<"$run_json")" = "$RELEASE_SOURCE_SHA"',
         'test "$source_version" = "$RELEASE_VERSION"',
         "run-id: ${{ inputs.run_id }}",
         '--target "$RELEASE_SOURCE_SHA"',
+        "dobbyvpn-android-provenance",
+        "Android provenance validation passed",
     ):
         if expected not in promotion:
             violations.append(

--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -120,6 +120,20 @@ def main() -> int:
             violations.append(
                 f"fastlane/Fastfile: missing exact production submission control: {expected}"
             )
+    upload_testflight_lane = fastfile.split("lane :upload_testflight do", 1)[-1].split("\n  end", 1)[0]
+    for expected in (
+        "skip_waiting_for_build_processing: true",
+        "distribute_external: false",
+        "notify_external_testers: false",
+    ):
+        if expected not in upload_testflight_lane:
+            violations.append(
+                f"fastlane/Fastfile: missing internal TestFlight upload control: {expected}"
+            )
+    if "changelog:" in upload_testflight_lane:
+        violations.append(
+            "fastlane/Fastfile: internal TestFlight upload must not wait to patch changelog metadata"
+        )
 
     torturer = (WORKFLOWS / "torturer.yml").read_text(encoding="utf-8")
     if "pull_request_target" in torturer:

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -159,6 +159,56 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
 
+      - name: Create Android source and digest provenance
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          VERSION_NAME: ${{ inputs.app_major_version }}.${{ inputs.app_minor_version }}.${{ inputs.app_maintenance_version }}
+          VERSION_CODE: ${{ inputs.android_version_code }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+
+          signed="$FDROID_COMPAT_SOURCE_ROOT/fastlane/DobbyVPN-v$VERSION_NAME-sign.apk"
+          unsigned="$FDROID_COMPAT_SOURCE_ROOT/fastlane/DobbyVPN-v$VERSION_NAME-unsign.apk"
+          manifest="$FDROID_COMPAT_SOURCE_ROOT/fastlane/DobbyVPN-v$VERSION_NAME-android-provenance.json"
+
+          for apk in "$signed" "$unsigned"; do
+            test "$(apkanalyzer manifest application-id "$apk")" = "com.dobby.vpn"
+            test "$(apkanalyzer manifest version-name "$apk")" = "$VERSION_NAME"
+            test "$(apkanalyzer manifest version-code "$apk")" = "$VERSION_CODE"
+          done
+
+          SIGNED_APK="$signed" UNSIGNED_APK="$unsigned" MANIFEST="$manifest" python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def artifact(kind: str, variable: str) -> dict[str, str]:
+              path = Path(os.environ[variable])
+              return {
+                  "kind": kind,
+                  "name": path.name,
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+              }
+
+          document = {
+              "schema": 1,
+              "source_sha": os.environ["SOURCE_SHA"],
+              "version_name": os.environ["VERSION_NAME"],
+              "version_code": int(os.environ["VERSION_CODE"]),
+              "application_id": "com.dobby.vpn",
+              "artifacts": [
+                  artifact("signed", "SIGNED_APK"),
+                  artifact("unsigned", "UNSIGNED_APK"),
+              ],
+          }
+          Path(os.environ["MANIFEST"]).write_text(
+              json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Upload signed APK
         uses: ./.github/actions/upload-artifact-retry
         with:
@@ -170,3 +220,9 @@ jobs:
         with:
           name: dobbyvpn-android-unsign.apk
           path: ${{ env.FDROID_COMPAT_SOURCE_ROOT }}/fastlane/DobbyVPN-v${{ inputs.app_major_version }}.${{ inputs.app_minor_version }}.${{ inputs.app_maintenance_version }}-unsign.apk
+
+      - name: Upload Android provenance
+        uses: ./.github/actions/upload-artifact-retry
+        with:
+          name: dobbyvpn-android-provenance
+          path: ${{ env.FDROID_COMPAT_SOURCE_ROOT }}/fastlane/DobbyVPN-v${{ inputs.app_major_version }}.${{ inputs.app_minor_version }}.${{ inputs.app_maintenance_version }}-android-provenance.json

--- a/.github/workflows/promote_release.yml
+++ b/.github/workflows/promote_release.yml
@@ -55,6 +55,9 @@ jobs:
             echo "commit_sha must be a full commit SHA" >&2
             exit 1
           fi
+          test "$GITHUB_REF" = "refs/heads/main"
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          test "$GITHUB_SHA" = "$current_main"
 
           run_json="$(
             gh run view "$RELEASE_RUN_ID" \
@@ -105,6 +108,7 @@ jobs:
                 printf '%s\n' \
                   "DobbyVPN-v$RELEASE_VERSION-sign.apk" \
                   "DobbyVPN-v$RELEASE_VERSION-unsign.apk" \
+                  "DobbyVPN-v$RELEASE_VERSION-android-provenance.json" \
                   "dobbyVPN-linux.deb" \
                   "dobbyVPN-macos-aarch64.pkg" \
                   "dobbyVPN-macos-amd64.pkg" \
@@ -208,6 +212,63 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ inputs.run_id }}
+
+      - name: Download Android provenance
+        if: steps.preflight.outputs.release_state != 'published'
+        uses: actions/download-artifact@v4
+        with:
+          name: dobbyvpn-android-provenance
+          path: release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Verify Android source and artifact provenance
+        if: steps.preflight.outputs.release_state != 'published'
+        env:
+          ANDROID_VERSION_CODE: ${{ steps.preflight.outputs.android_version_code }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          release = Path("release")
+          version = os.environ["RELEASE_VERSION"]
+          expected = {
+              "signed": release / f"DobbyVPN-v{version}-sign.apk",
+              "unsigned": release / f"DobbyVPN-v{version}-unsign.apk",
+          }
+          manifest_path = release / f"DobbyVPN-v{version}-android-provenance.json"
+          document = json.loads(manifest_path.read_text(encoding="utf-8"))
+          if document.get("schema") != 1:
+              raise SystemExit("Android provenance schema mismatch")
+          if document.get("source_sha") != os.environ["RELEASE_SOURCE_SHA"]:
+              raise SystemExit("Android provenance source mismatch")
+          if document.get("version_name") != version:
+              raise SystemExit("Android provenance version mismatch")
+          if document.get("version_code") != int(os.environ["ANDROID_VERSION_CODE"]):
+              raise SystemExit("Android provenance version code mismatch")
+          if document.get("application_id") != "com.dobby.vpn":
+              raise SystemExit("Android provenance application ID mismatch")
+
+          artifacts = document.get("artifacts")
+          if not isinstance(artifacts, list) or len(artifacts) != len(expected):
+              raise SystemExit("Android provenance artifact set mismatch")
+          by_kind = {item.get("kind"): item for item in artifacts if isinstance(item, dict)}
+          if set(by_kind) != set(expected):
+              raise SystemExit("Android provenance artifact kinds mismatch")
+          for kind, path in expected.items():
+              item = by_kind[kind]
+              if item.get("name") != path.name:
+                  raise SystemExit(f"Android provenance {kind} filename mismatch")
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              if item.get("sha256") != digest:
+                  raise SystemExit(f"Android provenance {kind} digest mismatch")
+          print("Android provenance validation passed")
+          PY
 
       - name: Create F-Droid version metadata
         if: steps.preflight.outputs.release_state != 'published'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -218,10 +218,11 @@ platform :ios do
     upload_to_testflight(
       ipa: "#{EXPORT_DIR}/#{IPA_NAME}",
       api_key: api_key,
-      skip_waiting_for_build_processing: false,
+      # A changelog makes Fastlane wait partially and patch beta metadata.
+      # CI only needs the immutable binary parked for later promotion.
+      skip_waiting_for_build_processing: true,
       distribute_external: false,
-      notify_external_testers: false,
-      changelog: "Build #{FULL_VERSION} (#{SHORT_SHA})"
+      notify_external_testers: false
     )
   end
 


### PR DESCRIPTION
## Summary
- park internal TestFlight builds without waiting for beta metadata
- avoid changelog patching during the CI upload lane
- emit and verify an Android source/digest provenance manifest before promotion
- bind promotion dispatch to current main and enforce all controls in workflow policy

## Verification
- python3 .github/scripts/check_workflow_policy.py
- Python workflow YAML parsing
- python3 -m py_compile .github/scripts/check_workflow_policy.py
- ruby -c fastlane/Fastfile
- git diff --check