### PR TITLE
v1.4.7: fix Windows package filename validation

### DIFF
--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -167,8 +167,8 @@ jobs:
                   raise SystemExit(f"{path.name} has an invalid PE header")
               return struct.unpack_from("<H", data, offset + 4 + 20 + 68)[0]
 
-          if subsystem(single("Dobby VPN.exe")) != 2:
-              raise SystemExit("Dobby VPN.exe must remain a GUI launcher")
+          if subsystem(single("Dobby Vpn.exe")) != 2:
+              raise SystemExit("Dobby Vpn.exe must remain a GUI launcher")
           if subsystem(single("dobby-cli.exe")) != 3:
               raise SystemExit("dobby-cli.exe must be a console launcher")
           PY


### PR DESCRIPTION
## Summary

- match the Windows GUI launcher validator to the canonical packaged name `Dobby Vpn.exe`
- preserve the existing exact-one-file and PE subsystem checks for both GUI and console launchers

## Failure addressed

Release run 30834609611 failed before desktop artifact upload because the Linux-hosted ZIP validator searched case-sensitively for `Dobby VPN.exe`, while Conveyor and the MSI contract use `Dobby Vpn.exe`. The validator therefore never reached either subsystem assertion.

## Local verification

- 7 desktop-build unit tests pass
- workflow secret-isolation policy passes
- workflow YAML parses successfully
- exact canonical-name consistency check passes
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows launcher verification to recognize the correct application filename.
  * Retained validation that the launcher uses the required graphical interface subsystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->