### PR TITLE
Fix Windows launchers for v1.4.7

### DIFF
--- a/.github/workflows/desktop_build.yml
+++ b/.github/workflows/desktop_build.yml
@@ -163,7 +163,7 @@ jobs:
               if data[:2] != b"MZ" or len(data) < 0x40:
                   raise SystemExit(f"{path.name} is not a PE executable")
               offset = struct.unpack_from("<I", data, 0x3C)[0]
-              if data[offset:offset + 4] != b"PE\\0\\0":
+              if data[offset:offset + 4] != b"PE\0\0":
                   raise SystemExit(f"{path.name} has an invalid PE header")
               return struct.unpack_from("<H", data, offset + 4 + 20 + 68)[0]
 

--- a/.github/workflows/torturer.yml
+++ b/.github/workflows/torturer.yml
@@ -12,7 +12,7 @@ jobs:
     name: Public cross-platform contract
     permissions:
       contents: read
-    uses: DobbyVPN/Torturer/.github/workflows/verify.yml@6c421f77e524199413850bf8eecfbf46c2c283db
+    uses: DobbyVPN/Torturer/.github/workflows/verify.yml@c991b69b1a5a136180dae41cb1bde30401994d87
     with:
       source_repository: ${{ github.event.pull_request.head.repo.full_name }}
       commit_sha: ${{ github.event.pull_request.head.sha }}

--- a/kmp_module/conveyor.conf
+++ b/kmp_module/conveyor.conf
@@ -18,17 +18,17 @@ app.mac {
   }
 }
 
-app.windows {
-  // The desktop UI remains a GUI process. The supplementary dobby-cli
-  // launcher below is the console process used for machine-readable commands.
-  console = false
-}
-
 # One package, two deliberately different Windows entry points: the GUI must
 # not flash a console for ordinary users, while the CLI must preserve stdout
 # and stderr for status automation. Both run the same argument-aware MainKt.
-app.jvm.gui = MainKt
-app.jvm.cli.dobby-cli.main-class = MainKt
+app.jvm.gui {
+  main-class = MainKt
+  console = false
+}
+app.jvm.cli.dobby-cli {
+  main-class = MainKt
+  console = true
+}
 
 app.linux {
   inputs += "services/ubuntu_grpcvpnserver"


### PR DESCRIPTION
Correct the PE signature verifier to compare against the four-byte PE header and configure console mode per Conveyor launcher. The GUI remains subsystem 2; dobby-cli is subsystem 3.\n\nLocal verification: Conveyor 16 generated both launchers as valid PE32+ x86-64 executables with the intended distinct subsystems; workflow policy, 15 Python helper tests, YAML parsing, and diff checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build validation for PE headers.

* **New Features**
  * Added separate Windows GUI and command-line launch options.
  * GUI launches without a console window, while the CLI retains console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->