### PR TITLE
Fix v1.4.8 Android release bootstrap path ordering

### DIFF
--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -17,6 +17,35 @@ WORKFLOWS = ROOT / "workflows"
 PR_TRIGGER = re.compile(r"^\s{2}pull_request\s*:", re.MULTILINE)
 SECRET = re.compile(r"\$\{\{\s*secrets\.([A-Za-z0-9_]+)\s*\}\}")
 FULL_SHA = r"[0-9a-f]{40}"
+STEP_NAME = re.compile(
+    r"^\s*-\s+name:\s*(?:"
+    r'"(?P<double>[^"]+)"|'
+    r"'(?P<single>[^']+)'|"
+    r"(?P<plain>[^#]+?))\s*$"
+)
+
+
+def _workflow_step_lines(source: str) -> dict[str, list[int]]:
+    steps: dict[str, list[int]] = {}
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        match = STEP_NAME.match(line)
+        if match is None:
+            continue
+        name = next(
+            value for value in match.groupdict().values() if value is not None
+        ).strip()
+        steps.setdefault(name, []).append(line_number)
+    return steps
+
+
+def _step_order_violation(source: str, before: str, after: str) -> str | None:
+    steps = _workflow_step_lines(source)
+    for name in (before, after):
+        if len(steps.get(name, ())) != 1:
+            return f"expected exactly one actual workflow step named {name!r}"
+    if steps[before][0] > steps[after][0]:
+        return f"workflow step {before!r} must run before {after!r}"
+    return None
 
 
 def main() -> int:
@@ -104,8 +133,6 @@ def main() -> int:
         "GOMOBILE: /home/vagrant/go/bin/gomobile",
         "GOFLAGS: -trimpath -buildvcs=false",
         "EXPECTED_ANDROID_SIGNER_SHA256: c3f0414a74012060d7c6aa3a3d9dac0aa13c1bd23b7512eefd860fb865e67933",
-        "Prepare F-Droid-compatible tool paths",
-        "Set up bootstrap Go",
         "ndk;27.3.13750724",
         'GO_SRC="$FDROID_COMPAT_GO_ROOT"',
         'ANDROID_GO_VERSION: ${{ steps.android_go.outputs.version }}',
@@ -152,16 +179,13 @@ def main() -> int:
             violations.append(
                 f"android_build.yml: {forbidden_cache} is forbidden for reproducible release inputs"
             )
-    fdroid_paths_position = android_build.find("Prepare F-Droid-compatible tool paths")
-    setup_go_position = android_build.find("Set up bootstrap Go")
-    if (
-        fdroid_paths_position >= 0
-        and setup_go_position >= 0
-        and fdroid_paths_position > setup_go_position
-    ):
-        violations.append(
-            "android_build.yml: F-Droid-compatible GOPATH must exist before setup-go runs"
-        )
+    step_order_violation = _step_order_violation(
+        android_build,
+        "Prepare F-Droid-compatible tool paths",
+        "Set up bootstrap Go",
+    )
+    if step_order_violation is not None:
+        violations.append(f"android_build.yml: {step_order_violation}")
     if "GITHUB_SHA: ${{ inputs.source_sha }}" in android_build:
         violations.append(
             "android_build.yml: a job-level assignment cannot override GitHub's reserved GITHUB_SHA"

--- a/.github/scripts/check_workflow_policy.py
+++ b/.github/scripts/check_workflow_policy.py
@@ -104,6 +104,8 @@ def main() -> int:
         "GOMOBILE: /home/vagrant/go/bin/gomobile",
         "GOFLAGS: -trimpath -buildvcs=false",
         "EXPECTED_ANDROID_SIGNER_SHA256: c3f0414a74012060d7c6aa3a3d9dac0aa13c1bd23b7512eefd860fb865e67933",
+        "Prepare F-Droid-compatible tool paths",
+        "Set up bootstrap Go",
         "ndk;27.3.13750724",
         'GO_SRC="$FDROID_COMPAT_GO_ROOT"',
         'ANDROID_GO_VERSION: ${{ steps.android_go.outputs.version }}',
@@ -150,6 +152,16 @@ def main() -> int:
             violations.append(
                 f"android_build.yml: {forbidden_cache} is forbidden for reproducible release inputs"
             )
+    fdroid_paths_position = android_build.find("Prepare F-Droid-compatible tool paths")
+    setup_go_position = android_build.find("Set up bootstrap Go")
+    if (
+        fdroid_paths_position >= 0
+        and setup_go_position >= 0
+        and fdroid_paths_position > setup_go_position
+    ):
+        violations.append(
+            "android_build.yml: F-Droid-compatible GOPATH must exist before setup-go runs"
+        )
     if "GITHUB_SHA: ${{ inputs.source_sha }}" in android_build:
         violations.append(
             "android_build.yml: a job-level assignment cannot override GitHub's reserved GITHUB_SHA"

--- a/.github/scripts/test_check_workflow_policy.py
+++ b/.github/scripts/test_check_workflow_policy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check_workflow_policy.py")
+SPEC = importlib.util.spec_from_file_location("check_workflow_policy", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+policy = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(policy)
+
+
+PREPARE = "Prepare F-Droid-compatible tool paths"
+SETUP = "Set up bootstrap Go"
+
+
+class WorkflowStepOrderTests(unittest.TestCase):
+    def test_accepts_actual_steps_in_required_order(self) -> None:
+        source = f"""
+      - name: {PREPARE}
+        run: mkdir -p /tmp/example
+      - name: {SETUP}
+        uses: actions/setup-go@v6
+"""
+        self.assertIsNone(policy._step_order_violation(source, PREPARE, SETUP))
+
+    def test_rejects_actual_steps_in_reverse_order(self) -> None:
+        source = f"""
+      - name: {SETUP}
+        uses: actions/setup-go@v6
+      - name: {PREPARE}
+        run: mkdir -p /tmp/example
+"""
+        self.assertIn(
+            "must run before", policy._step_order_violation(source, PREPARE, SETUP)
+        )
+
+    def test_comment_cannot_substitute_for_prepare_step(self) -> None:
+        source = f"""
+      # - name: {PREPARE}
+      - name: {SETUP}
+        uses: actions/setup-go@v6
+"""
+        self.assertIn(
+            "exactly one actual workflow step",
+            policy._step_order_violation(source, PREPARE, SETUP),
+        )
+
+    def test_comment_cannot_substitute_for_setup_step(self) -> None:
+        source = f"""
+      - name: {PREPARE}
+        run: mkdir -p /tmp/example
+      # - name: {SETUP}
+"""
+        self.assertIn(
+            "exactly one actual workflow step",
+            policy._step_order_violation(source, PREPARE, SETUP),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -67,6 +67,16 @@ jobs:
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
 
+      # setup-go consults the job-level GOPATH. Create the F-Droid-compatible
+      # owner-controlled path before the action attempts to use it.
+      - name: Prepare F-Droid-compatible tool paths
+        run: |
+          sudo mkdir -p \
+            "$(dirname "$FDROID_COMPAT_SOURCE_ROOT")" \
+            "$(dirname "$FDROID_COMPAT_GO_ROOT")" \
+            "$GOPATH"
+          sudo chown -R "$USER:$USER" /home/vagrant
+
       - name: Set up bootstrap Go
         uses: actions/setup-go@v6
         with:
@@ -77,14 +87,6 @@ jobs:
       - name: Read Android Go version
         id: android_go
         run: echo "version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare F-Droid-compatible tool paths
-        run: |
-          sudo mkdir -p \
-            "$(dirname "$FDROID_COMPAT_SOURCE_ROOT")" \
-            "$(dirname "$FDROID_COMPAT_GO_ROOT")" \
-            "$GOPATH"
-          sudo chown -R "$USER:$USER" /home/vagrant
 
       - name: Build Go from source for Android
         env:


### PR DESCRIPTION
The exact-main v1.4.8 Release run failed before Android compilation because setup-go consulted the job-level F-Droid GOPATH before that path existed. This moves the existing owner-controlled path preparation ahead of setup-go and adds a workflow-policy ordering guard so the failure cannot recur silently. Local checks: workflow policy passed, YAML parsed, Python compiled, and diff check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build setup by preparing required source, Go, and GOPATH directories before Go is configured.
  * Added validation to ensure the setup steps occur in the correct order and are not omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->